### PR TITLE
Bound PDF viewer memory with lazy windowed rendering; reap ACP agents

### DIFF
--- a/assets/pdf.css
+++ b/assets/pdf.css
@@ -218,6 +218,19 @@
   user-select: none;
 }
 
+/* Slot for a page not yet in the resident render window. Reserves scroll height
+   so every page is reachable; fills in with the real page once rendered. */
+.pdf-page-placeholder {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--surface, #f4f4f5),
+    var(--surface, #f4f4f5) 12px,
+    color-mix(in srgb, var(--surface, #f4f4f5) 92%, #000) 12px,
+    color-mix(in srgb, var(--surface, #f4f4f5) 92%, #000) 24px
+  );
+  opacity: 0.5;
+}
+
 .annotation-click-overlay {
   position: absolute;
   top: 0;

--- a/crates/rotero-pdf/src/renderer.rs
+++ b/crates/rotero-pdf/src/renderer.rs
@@ -230,6 +230,58 @@ impl PdfEngine {
         Ok(pages)
     }
 
+    /// Opens a document once and renders its first `batch_size` pages, returning
+    /// the total page count alongside the rendered pages. Equivalent to
+    /// `load_document` followed by `render_pages(.., 0, batch_size, ..)` but parses
+    /// the PDF a single time instead of twice.
+    pub fn open_and_render_initial(
+        &mut self,
+        pdf_path: &str,
+        scale: f32,
+        batch_size: u32,
+    ) -> Result<(u32, Vec<RenderedPage>), PdfError> {
+        let document = self.open_document(pdf_path)?;
+        let page_count = document.pages().len() as u32;
+        let end = batch_size.min(page_count);
+
+        let mut pages = Vec::with_capacity(end as usize);
+        let mut img_bytes: Vec<u8> = Vec::with_capacity(256 * 1024);
+        for i in 0..end {
+            let page = document
+                .pages()
+                .get(i as u16)
+                .map_err(|e| PdfError::RenderError(e.to_string()))?;
+
+            let width = (page.width().value * scale) as i32;
+            let height = (page.height().value * scale) as i32;
+
+            let render_config = PdfRenderConfig::new()
+                .set_target_width(width.max(1))
+                .set_maximum_height(height.max(1));
+
+            let bitmap = page
+                .render_with_config(&render_config)
+                .map_err(|e| PdfError::RenderError(e.to_string()))?;
+
+            let image = bitmap.as_image();
+            let img_width = image.width();
+            let img_height = image.height();
+
+            encode_png(&image, &mut img_bytes)?;
+            let base64_data = BASE64.encode(&img_bytes);
+
+            pages.push(RenderedPage {
+                page_index: i,
+                base64_data,
+                mime: "image/png",
+                width: img_width,
+                height: img_height,
+            });
+        }
+
+        Ok((page_count, pages))
+    }
+
     /// Renders a range of pages as thumbnails constrained to `max_width` pixels.
     pub fn render_thumbnails_range(
         &mut self,

--- a/src/agent/connection.rs
+++ b/src/agent/connection.rs
@@ -32,9 +32,22 @@ impl RawAcpConnection {
             .stdout(Stdio::piped())
             .stderr(Stdio::null());
 
+        // Put the child in its own process group (setsid) so we can kill it and
+        // any grandchildren as a group — used by the signal reaper on app exit.
+        #[cfg(unix)]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            cmd.pre_exec(|| {
+                // Detach into a new session/process group. Errors are non-fatal.
+                libc::setsid();
+                Ok(())
+            });
+        }
+
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("Failed to spawn node: {e}"))?;
+        super::reaper::register(child.id() as i32);
         let stdout = child.stdout.take().ok_or("No stdout")?;
 
         let (line_tx, line_rx) = mpsc::channel();
@@ -151,8 +164,15 @@ impl RawAcpConnection {
     }
 
     pub(crate) fn kill(&mut self) {
+        let pid = self.child.id() as i32;
+        // Kill the whole process group (setsid at spawn) to also reap grandchildren.
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
         let _ = self.child.kill();
         let _ = self.child.wait();
+        super::reaper::unregister(pid);
     }
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2,6 +2,7 @@ mod connection;
 mod helpers;
 mod install;
 pub(crate) mod node;
+pub(crate) mod reaper;
 mod session;
 pub mod types;
 

--- a/src/agent/reaper.rs
+++ b/src/agent/reaper.rs
@@ -1,0 +1,67 @@
+//! Tracks spawned ACP agent child processes so they can be killed even when the
+//! app exits via a signal (Cmd+Q, Ctrl+C, `dx serve` hot-reload → SIGTERM), where
+//! Rust destructors (and thus `RawAcpConnection`'s `Drop`) never run.
+//!
+//! Each child is spawned into its own process group (see `connection.rs`
+//! `pre_exec(setsid)`), so we kill the whole group by its negative PID — this
+//! also reaps any grandchildren the node agent spawned. SIGKILL of the parent
+//! still can't be caught by anything, but that is the only uncatchable case.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+fn registry() -> &'static Mutex<HashSet<i32>> {
+    static REG: OnceLock<Mutex<HashSet<i32>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Record a live child PID (which is also its process-group id).
+pub(crate) fn register(pid: i32) {
+    if pid > 0 {
+        registry().lock().unwrap().insert(pid);
+    }
+}
+
+/// Forget a child PID once we've reaped it ourselves.
+pub(crate) fn unregister(pid: i32) {
+    registry().lock().unwrap().remove(&pid);
+}
+
+/// Kill every tracked process group. Async-signal-safety note: this calls only
+/// `kill(2)` and touches a `Mutex` — acceptable here because our own signal
+/// handler runs on a normal thread context (see `install_signal_handler`) rather
+/// than a raw async-signal context.
+fn kill_all() {
+    let pids: Vec<i32> = registry().lock().unwrap().iter().copied().collect();
+    for pid in pids {
+        // Negative pid → signal the whole process group.
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+}
+
+/// Installs handlers for SIGTERM/SIGINT/SIGHUP that reap tracked children and
+/// then restore the default action and re-raise, so the process still exits with
+/// normal semantics. Call once at startup.
+pub(crate) fn install_signal_handler() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    if INSTALLED.set(()).is_err() {
+        return;
+    }
+    let handler = handle_signal as extern "C" fn(i32) as *const () as libc::sighandler_t;
+    unsafe {
+        for sig in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
+            libc::signal(sig, handler);
+        }
+    }
+}
+
+extern "C" fn handle_signal(sig: i32) {
+    kill_all();
+    // Restore default handler and re-raise so the process terminates as expected.
+    unsafe {
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,11 @@ pub use init::mcp::MCP_HTTP_PORT;
 fn main() {
     init::logging::init_logging();
 
+    // Reap spawned ACP agent node processes if the app is terminated by a signal
+    // (Cmd+Q, Ctrl+C, `dx serve` reload) — their Drop-based cleanup won't run then.
+    #[cfg(all(unix, feature = "desktop"))]
+    agent::reaper::install_signal_handler();
+
     let config = sync::engine::SyncConfig::load();
 
     #[cfg(feature = "desktop")]

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use rotero_models::{Annotation, Collection, Paper, Tag};
@@ -8,7 +8,14 @@ pub type TabId = u64;
 
 #[derive(Debug, Clone, Default)]
 pub struct PageRenderData {
-    pub rendered_pages: Vec<RenderedPageData>,
+    /// Resident rendered pages keyed by absolute page index. Bounded to a
+    /// sliding window around the viewport (see `MAX_RESIDENT_PAGES`); BTreeMap
+    /// so iteration yields pages in page order for the render loop.
+    pub rendered_pages: BTreeMap<u32, RenderedPageData>,
+    /// Pixel dimensions `(width, height)` for every page, indexed by page number.
+    /// Used to size placeholders for not-yet-rendered pages so the scroll
+    /// container has its full height and scrolling can reach every page.
+    pub page_dims: Vec<(u32, u32)>,
     pub text_data: HashMap<u32, PageTextData>,
     pub thumbnails: HashMap<u32, RenderedPageData>,
 }
@@ -21,6 +28,9 @@ pub struct ViewState {
     pub page_batch_size: u32,
     /// Render at `zoom * dpr` for sharp HiDPI output.
     pub dpr: f32,
+    /// Page index nearest the viewport center, reported by the viewer's
+    /// scroll handler. Drives the sliding render window.
+    pub current_page: u32,
 }
 
 impl Default for ViewState {
@@ -31,6 +41,7 @@ impl Default for ViewState {
             scroll_top: 0.0,
             page_batch_size: 5,
             dpr: 1.0,
+            current_page: 0,
         }
     }
 }
@@ -100,10 +111,6 @@ impl PdfTab {
 
     pub fn needs_render(&self) -> bool {
         self.render.rendered_pages.is_empty() && self.page_count > 0
-    }
-
-    pub fn rendered_count(&self) -> u32 {
-        self.render.rendered_pages.len() as u32
     }
 
     pub fn suspend(&mut self) {

--- a/src/state/commands/mod.rs
+++ b/src/state/commands/mod.rs
@@ -60,6 +60,9 @@ pub enum RenderRequest {
         pdf_path: String,
         reply: oneshot::Sender<Result<Vec<rotero_pdf::ExtractedAnnotation>, String>>,
     },
+    /// Drops the engine's cached PDF file bytes. Sent when the last PDF tab
+    /// closes so a large document's raw bytes aren't pinned indefinitely.
+    ClearCache,
 }
 
 pub fn spawn_render_thread() -> mpsc::Sender<RenderRequest> {
@@ -87,14 +90,12 @@ pub fn spawn_render_thread() -> mpsc::Sender<RenderRequest> {
                     reply,
                 } => {
                     let result = (|| {
-                        let info = engine.load_document(&pdf_path).map_err(|e| e.to_string())?;
-                        let render_count = info.page_count.min(batch_size);
-                        let rendered = engine
-                            .render_pages(&pdf_path, 0, render_count, zoom)
+                        let (page_count, rendered) = engine
+                            .open_and_render_initial(&pdf_path, zoom, batch_size)
                             .map_err(|e| e.to_string())?;
                         let pages: Vec<RenderedPageData> =
                             rendered.into_iter().map(|r| r.into()).collect();
-                        Ok((info.page_count, pages))
+                        Ok((page_count, pages))
                     })();
                     let _ = reply.send(result);
                 }
@@ -189,6 +190,9 @@ pub fn spawn_render_thread() -> mpsc::Sender<RenderRequest> {
                         .extract_annotations(&pdf_path)
                         .map_err(|e| e.to_string());
                     let _ = reply.send(result);
+                }
+                RenderRequest::ClearCache => {
+                    engine.clear_byte_cache();
                 }
             }
         }

--- a/src/state/commands/pdf_loading.rs
+++ b/src/state/commands/pdf_loading.rs
@@ -3,7 +3,32 @@ use tokio::sync::oneshot;
 use dioxus::prelude::*;
 
 use super::{RenderRequest, recv_reply};
-use crate::state::app_state::{PdfTabManager, TabId};
+use crate::state::app_state::{PdfTabManager, RenderedPageData, TabId};
+
+/// Max full-resolution pages kept resident per tab. Full pages are far larger
+/// than thumbnails (`MAX_RESIDENT_THUMBS = 50`), so this window is smaller.
+/// Rendered pages outside a window centered on the current page are evicted.
+pub const MAX_RESIDENT_PAGES: usize = 30;
+
+/// Number of pages to render/keep on each side of the current page. The full
+/// resident window is `2 * PAGE_WINDOW_RADIUS + 1` pages, which must stay
+/// within `MAX_RESIDENT_PAGES`.
+pub const PAGE_WINDOW_RADIUS: u32 = 12;
+
+/// Evicts rendered pages far from `center` once the resident set exceeds
+/// `MAX_RESIDENT_PAGES`, keeping a window `[center - radius, center + radius]`.
+/// Mirrors the thumbnail windowing in `pdf_cache.rs`.
+fn evict_pages_outside_window(
+    rendered: &mut std::collections::BTreeMap<u32, RenderedPageData>,
+    center: u32,
+) {
+    if rendered.len() <= MAX_RESIDENT_PAGES {
+        return;
+    }
+    let lo = center.saturating_sub(PAGE_WINDOW_RADIUS);
+    let hi = center.saturating_add(PAGE_WINDOW_RADIUS);
+    rendered.retain(|&idx, _| idx >= lo && idx <= hi);
+}
 
 /// Collect all extracted text from a tab's text_data and save it to the DB fulltext column.
 #[cfg(feature = "desktop")]
@@ -73,13 +98,20 @@ pub async fn open_pdf(
     });
     let cache_result = cache_rx.await.ok();
     if let Some((Some((meta, cached_pages)), text_data)) = cache_result {
+        // How many pages the on-disk cache holds (decides whether it's complete),
+        // independent of how many we keep resident in memory.
         let cached_count = cached_pages.len() as u32;
+        // Only keep an initial window (around page 0) resident; the rest render
+        // lazily on scroll even though they exist in the disk cache.
+        let mut resident: std::collections::BTreeMap<u32, RenderedPageData> =
+            cached_pages.into_iter().map(|p| (p.page_index, p)).collect();
+        evict_pages_outside_window(&mut resident, 0);
         tabs.with_mut(|mgr| {
             if let Some(tab) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
                 tab.page_count = meta.page_count;
                 tab.view.dpr = dpr;
                 tab.view.render_zoom = render_scale;
-                tab.render.rendered_pages = cached_pages;
+                tab.render.rendered_pages = resident;
                 tab.is_loading = false;
             }
         });
@@ -105,91 +137,40 @@ pub async fn open_pdf(
             let render_tx_bg = render_tx.clone();
             let data_dir_bg = data_dir.to_path_buf();
             let mut tabs_bg = *tabs;
-            let total = meta.page_count;
             let paper_id_bg = paper_id.clone();
             let path_bg = path.clone();
             spawn(async move {
+                // Ensure the initial window (around page 0) is rendered. Remaining
+                // pages render lazily on scroll rather than all up front.
                 if need_render {
-                    let rendered_indices: std::collections::HashSet<u32> = tabs_bg
-                        .read()
-                        .tabs
-                        .iter()
-                        .find(|t| t.id == tab_id)
-                        .map(|t| {
-                            t.render
-                                .rendered_pages
-                                .iter()
-                                .map(|p| p.page_index)
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    let mut missing: Vec<u32> = (0..total)
-                        .filter(|i| !rendered_indices.contains(i))
-                        .collect();
-                    missing.sort();
-                    for chunk in missing.chunks(batch_size as usize) {
-                        let start = chunk[0];
-                        let count = chunk.last().unwrap() - start + 1;
-                        if render_more_pages(
-                            &render_tx_bg,
-                            &mut tabs_bg,
-                            tab_id,
-                            start,
-                            count,
-                            &data_dir_bg,
-                        )
-                        .await
-                        .is_err()
-                        {
-                            break;
-                        }
-                    }
+                    ensure_window_rendered(&render_tx_bg, &mut tabs_bg, tab_id, 0, &data_dir_bg)
+                        .await;
                 }
+                // Text is needed for the WHOLE document (search + fulltext), extracted
+                // without rendering images. Also refresh the on-disk text cache.
                 if need_text {
-                    // Re-extract text for pages missing from text_data
-                    let missing_dims: Vec<(u32, u32, u32)> = {
+                    extract_remaining_text(
+                        &render_tx_bg,
+                        &mut tabs_bg,
+                        tab_id,
+                        &path_bg,
+                        render_scale,
+                    )
+                    .await;
+                    let all_text: std::collections::HashMap<u32, rotero_pdf::PageTextData> = {
                         let mgr = tabs_bg.read();
                         mgr.tabs
                             .iter()
                             .find(|t| t.id == tab_id)
-                            .map(|t| {
-                                t.render
-                                    .rendered_pages
-                                    .iter()
-                                    .filter(|p| !t.render.text_data.contains_key(&p.page_index))
-                                    .map(|p| (p.page_index, p.width, p.height))
-                                    .collect()
-                            })
+                            .map(|t| t.render.text_data.clone())
                             .unwrap_or_default()
                     };
-                    if !missing_dims.is_empty() {
-                        let (text_tx, text_rx) = oneshot::channel();
-                        let _ = render_tx_bg.send(RenderRequest::ExtractText {
-                            pdf_path: path_bg.clone(),
-                            page_dims: missing_dims,
-                            reply: text_tx,
+                    if !all_text.is_empty() {
+                        let dir = data_dir_bg.clone();
+                        let path_save = path_bg.clone();
+                        std::thread::spawn(move || {
+                            crate::cache::save_text(&dir, &path_save, &all_text);
                         });
-                        if let Ok(text_data) = recv_reply(text_rx).await {
-                            tabs_bg.with_mut(|mgr| {
-                                if let Some(tab) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
-                                    tab.render.text_data.extend(text_data);
-                                }
-                            });
-                            // Save complete text cache to disk
-                            let all_text: std::collections::HashMap<u32, rotero_pdf::PageTextData> = {
-                                let mgr = tabs_bg.read();
-                                mgr.tabs
-                                    .iter()
-                                    .find(|t| t.id == tab_id)
-                                    .map(|t| t.render.text_data.clone())
-                                    .unwrap_or_default()
-                            };
-                            let dir = data_dir_bg.clone();
-                            let path_save = path_bg.clone();
-                            std::thread::spawn(move || {
-                                crate::cache::save_text(&dir, &path_save, &all_text);
-                            });
-                        }
                     }
                 }
                 #[cfg(feature = "desktop")]
@@ -227,7 +208,7 @@ pub async fn open_pdf(
             tab.page_count = page_count;
             tab.view.dpr = dpr;
             tab.view.render_zoom = render_scale;
-            tab.render.rendered_pages = pages;
+            tab.render.rendered_pages = pages.into_iter().map(|p| (p.page_index, p)).collect();
             tab.is_loading = false;
         }
     });
@@ -239,7 +220,7 @@ pub async fn open_pdf(
             .map(|t| {
                 t.render
                     .rendered_pages
-                    .iter()
+                    .values()
                     .map(|p| (p.page_index, p.width, p.height))
                     .collect()
             })
@@ -272,38 +253,26 @@ pub async fn open_pdf(
         }
     });
 
-    let rendered_so_far = batch_size.min(page_count);
-    if rendered_so_far < page_count {
+    // Images are rendered lazily in a sliding window (see `ensure_window_rendered`),
+    // so we no longer render every page here. But search and the DB fulltext column
+    // need text for the WHOLE document, and text extraction only needs page pixel
+    // dimensions (not rendered images). Extract text for all remaining pages using
+    // dimensions computed from the point-size of each page, without rendering them.
+    if batch_size < page_count {
         let render_tx_bg = render_tx.clone();
-        let data_dir_bg = data_dir.to_path_buf();
         let mut tabs_bg = *tabs;
         let paper_id_bg = paper_id.clone();
+        let path_bg = path.clone();
         spawn(async move {
-            let mut start = rendered_so_far;
-            while start < page_count {
-                let count = batch_size.min(page_count - start);
-                if render_more_pages(
-                    &render_tx_bg,
-                    &mut tabs_bg,
-                    tab_id,
-                    start,
-                    count,
-                    &data_dir_bg,
-                )
-                .await
-                .is_err()
-                {
-                    break;
-                }
-                start += count;
-            }
+            extract_remaining_text(&render_tx_bg, &mut tabs_bg, tab_id, &path_bg, render_scale)
+                .await;
             #[cfg(feature = "desktop")]
             if let Some(pid) = paper_id_bg {
                 save_fulltext_to_db(&tabs_bg, tab_id, &pid).await;
             }
         });
     } else {
-        // All pages fit in one batch — save fulltext now
+        // All pages fit in one batch — text already extracted above, save fulltext now.
         #[cfg(feature = "desktop")]
         if let Some(pid) = paper_id {
             let tabs_ref = *tabs;
@@ -314,6 +283,191 @@ pub async fn open_pdf(
     }
 
     Ok(())
+}
+
+/// Fetches every page's point size via one cheap `GetPageDimensions` pass (no
+/// rendering), converts to pixel dims at `render_scale`, stores them on the tab
+/// (`render.page_dims`) for placeholder sizing, and returns them. Idempotent: if
+/// dims are already populated, returns the cached copy without re-parsing.
+pub async fn populate_page_dims(
+    render_tx: &std::sync::mpsc::Sender<RenderRequest>,
+    tabs: &mut Signal<PdfTabManager>,
+    tab_id: TabId,
+    pdf_path: &str,
+    render_scale: f32,
+) -> Vec<(u32, u32)> {
+    // Already populated for the full document? Reuse it.
+    {
+        let mgr = tabs.read();
+        if let Some(t) = mgr.tabs.iter().find(|t| t.id == tab_id)
+            && t.render.page_dims.len() as u32 == t.page_count
+            && t.page_count > 0
+        {
+            return t.render.page_dims.clone();
+        }
+    }
+    let (dim_tx, dim_rx) = oneshot::channel();
+    if render_tx
+        .send(RenderRequest::GetPageDimensions {
+            pdf_path: pdf_path.to_string(),
+            reply: dim_tx,
+        })
+        .is_err()
+    {
+        return Vec::new();
+    }
+    let Ok(point_dims) = recv_reply(dim_rx).await else {
+        return Vec::new();
+    };
+    let pixel_dims: Vec<(u32, u32)> = point_dims
+        .iter()
+        .map(|(w_pts, h_pts)| {
+            (
+                (w_pts * render_scale).round().max(1.0) as u32,
+                (h_pts * render_scale).round().max(1.0) as u32,
+            )
+        })
+        .collect();
+    tabs.with_mut(|mgr| {
+        if let Some(t) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
+            t.render.page_dims = pixel_dims.clone();
+        }
+    });
+    pixel_dims
+}
+
+/// Extracts text for every page not already in `text_data`, computing pixel
+/// dimensions from each page's point size × `render_scale` (matching what a real
+/// render would produce, so text-layer coordinates line up). Does NOT render page
+/// images — keeps search/fulltext whole-document while images stay windowed.
+async fn extract_remaining_text(
+    render_tx: &std::sync::mpsc::Sender<RenderRequest>,
+    tabs: &mut Signal<PdfTabManager>,
+    tab_id: TabId,
+    pdf_path: &str,
+    render_scale: f32,
+) {
+    // Populate per-page pixel dims (also used for placeholder sizing) and get them back.
+    let pixel_dims = populate_page_dims(render_tx, tabs, tab_id, pdf_path, render_scale).await;
+    if pixel_dims.is_empty() {
+        return;
+    }
+    // Pages already having text (the initial rendered batch) are skipped.
+    let have_text: std::collections::HashSet<u32> = {
+        let mgr = tabs.read();
+        mgr.tabs
+            .iter()
+            .find(|t| t.id == tab_id)
+            .map(|t| t.render.text_data.keys().copied().collect())
+            .unwrap_or_default()
+    };
+    let page_dims: Vec<(u32, u32, u32)> = pixel_dims
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !have_text.contains(&(*i as u32)))
+        .map(|(i, (w, h))| (i as u32, *w, *h))
+        .collect();
+    if page_dims.is_empty() {
+        return;
+    }
+    let (text_tx, text_rx) = oneshot::channel();
+    if render_tx
+        .send(RenderRequest::ExtractText {
+            pdf_path: pdf_path.to_string(),
+            page_dims,
+            reply: text_tx,
+        })
+        .is_err()
+    {
+        return;
+    }
+    if let Ok(text_data) = recv_reply(text_rx).await {
+        tabs.with_mut(|mgr| {
+            if let Some(tab) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
+                tab.render.text_data.extend(text_data);
+            }
+        });
+    }
+}
+
+/// Ensures rendered page images cover the window `[center - radius, center + radius]`,
+/// rendering any missing pages. Eviction of pages outside the window happens inside
+/// `render_more_pages`. Called from the viewer's scroll handler as `center` changes.
+pub async fn ensure_window_rendered(
+    render_tx: &std::sync::mpsc::Sender<RenderRequest>,
+    tabs: &mut Signal<PdfTabManager>,
+    tab_id: TabId,
+    center: u32,
+    data_dir: &std::path::Path,
+) {
+    let (page_count, render_scale, dims_ready, cur_page, pdf_path, present): (
+        u32,
+        f32,
+        bool,
+        u32,
+        String,
+        std::collections::BTreeSet<u32>,
+    ) = {
+        let mgr = tabs.read();
+        match mgr.tabs.iter().find(|t| t.id == tab_id) {
+            Some(t) => (
+                t.page_count,
+                t.view.render_zoom,
+                t.render.page_dims.len() as u32 == t.page_count && t.page_count > 0,
+                t.view.current_page,
+                t.pdf_path.clone(),
+                t.render.rendered_pages.keys().copied().collect(),
+            ),
+            None => return,
+        }
+    };
+    if page_count == 0 {
+        return;
+    }
+    // Fast path: the scroll handler fires many times per second. If the center
+    // page hasn't moved, dims are loaded, and the target window is already fully
+    // resident, there's nothing to do — skip the state write so the viewer does
+    // NOT re-render on every scroll tick.
+    if dims_ready && center == cur_page {
+        let lo = center.saturating_sub(PAGE_WINDOW_RADIUS);
+        let hi = center.saturating_add(PAGE_WINDOW_RADIUS).min(page_count - 1);
+        if (lo..=hi).all(|i| present.contains(&i)) {
+            return;
+        }
+    }
+    // Ensure placeholder dims exist for the whole document so unrendered pages
+    // reserve scroll height — otherwise the container is only as tall as the few
+    // rendered pages and scrolling can never reach (or trigger) the rest.
+    if !dims_ready {
+        let _ = populate_page_dims(render_tx, tabs, tab_id, &pdf_path, render_scale).await;
+    }
+    // Record the new center so eviction keeps the right window.
+    tabs.with_mut(|mgr| {
+        if let Some(t) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
+            t.view.current_page = center;
+        }
+    });
+    let lo = center.saturating_sub(PAGE_WINDOW_RADIUS);
+    let hi = center.saturating_add(PAGE_WINDOW_RADIUS).min(page_count - 1);
+    // Render contiguous runs of missing pages in the window.
+    let mut idx = lo;
+    while idx <= hi {
+        if present.contains(&idx) {
+            idx += 1;
+            continue;
+        }
+        let run_start = idx;
+        while idx <= hi && !present.contains(&idx) {
+            idx += 1;
+        }
+        let count = idx - run_start;
+        if render_more_pages(render_tx, tabs, tab_id, run_start, count, data_dir)
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
 }
 
 pub async fn render_more_pages(
@@ -363,7 +517,10 @@ pub async fn render_more_pages(
     });
     tabs.with_mut(|mgr| {
         if let Some(tab) = mgr.tabs.iter_mut().find(|t| t.id == tab_id) {
-            tab.render.rendered_pages.extend(pages);
+            tab.render
+                .rendered_pages
+                .extend(pages.into_iter().map(|p| (p.page_index, p)));
+            evict_pages_outside_window(&mut tab.render.rendered_pages, tab.view.current_page);
         }
     });
     let render_tx2 = render_tx.clone();

--- a/src/ui/keybindings.rs
+++ b/src/ui/keybindings.rs
@@ -171,6 +171,10 @@ fn action_close_tab(
     tabs.with_mut(|m| m.close_tab(tab_id));
     if tabs.read().tabs.is_empty() {
         lib_state.with_mut(|s| s.view = LibraryView::AllPapers);
+        // No PDFs open — free the engine's cached file bytes.
+        let _ = render_ch
+            .sender()
+            .send(crate::state::commands::RenderRequest::ClearCache);
     } else {
         let needs = tabs
             .read()

--- a/src/ui/pdf/annotation_panel.rs
+++ b/src/ui/pdf/annotation_panel.rs
@@ -240,11 +240,7 @@ pub(crate) fn AnnotationContextMenu() -> Element {
                 label: format!("Go to page {}", ctx_page + 1),
                 icon: Some("bi-arrow-right-circle".to_string()),
                 on_click: move |_| {
-                    let js = format!(
-                        "let el = document.getElementById('pdf-page-{}'); if (el) el.scrollIntoView({{behavior: 'smooth'}})",
-                        ctx_page
-                    );
-                    let _ = document::eval(&js);
+                    let _ = document::eval(&super::scroll_to_page_js(ctx_page.max(0) as u32, "center"));
                     ann_ctx.set(None);
                 },
             }

--- a/src/ui/pdf/mod.rs
+++ b/src/ui/pdf/mod.rs
@@ -16,6 +16,24 @@ use crate::state::app_state::AnnotationContextInfo;
 
 pub(crate) type AnnCtxState = Signal<Option<AnnotationContextInfo>>;
 
+/// Builds JS that scrolls the given page into view, polling for the element so it
+/// works even when the page was just added to the sliding render window and Dioxus
+/// hasn't flushed it to the DOM yet. `block` is the `scrollIntoView` block alignment
+/// ("start" or "center"). Retries for ~1s before giving up.
+pub(crate) fn scroll_to_page_js(page_index: u32, block: &str) -> String {
+    format!(
+        "(function() {{ \
+           let tries = 0; \
+           function go() {{ \
+             let el = document.getElementById('pdf-page-{page_index}'); \
+             if (el) {{ el.scrollIntoView({{ behavior: 'smooth', block: '{block}' }}); return; }} \
+             if (tries++ < 20) setTimeout(go, 50); \
+           }} \
+           go(); \
+         }})()"
+    )
+}
+
 pub(crate) fn hex_to_rgba(hex: &str, alpha: f32) -> String {
     let hex = hex.trim_start_matches('#');
     if hex.len() >= 6 {

--- a/src/ui/pdf/navigation.rs
+++ b/src/ui/pdf/navigation.rs
@@ -7,6 +7,7 @@ use crate::state::app_state::PdfTabManager;
 pub(crate) fn ThumbnailSidebar() -> Element {
     let mut tabs = use_context::<Signal<PdfTabManager>>();
     let render_ch = use_context::<RenderChannel>();
+    let config = use_context::<Signal<crate::sync::engine::SyncConfig>>();
     let mut is_loading_thumbs = use_signal(|| false);
 
     let mgr = tabs.read();
@@ -51,9 +52,15 @@ pub(crate) fn ThumbnailSidebar() -> Element {
                             div {
                                 key: "thumb-{page_idx}", class: "thumbnail-item",
                                 onclick: move |_| {
+                                    let render_tx = render_ch.sender();
+                                    let data_dir = config.read().effective_library_path();
                                     spawn(async move {
-                                        let js = format!("let pages = document.querySelectorAll('.pdf-page-wrapper'); if (pages[{page_idx}]) {{ pages[{page_idx}].scrollIntoView({{ behavior: 'smooth', block: 'start' }}); }}");
-                                        let _ = document::eval(&js);
+                                        // Ensure the target page is rendered (it may be
+                                        // outside the current window) before scrolling to it.
+                                        crate::state::commands::ensure_window_rendered(
+                                            &render_tx, &mut tabs, tab_id, page_idx, &data_dir,
+                                        ).await;
+                                        let _ = document::eval(&super::scroll_to_page_js(page_idx, "start"));
                                     });
                                 },
                                 img { class: "thumbnail-img", src: "data:{mime};base64,{base64}", width: "{w}", height: "{h}" }
@@ -78,7 +85,10 @@ pub(crate) fn ThumbnailSidebar() -> Element {
 
 #[component]
 pub(crate) fn OutlinePanel() -> Element {
-    let tabs = use_context::<Signal<PdfTabManager>>();
+    let mut tabs = use_context::<Signal<PdfTabManager>>();
+    let render_ch = use_context::<RenderChannel>();
+    let config = use_context::<Signal<crate::sync::engine::SyncConfig>>();
+    let tab_id = tabs.read().tab().id;
     let outline = tabs.read().tab().nav.outline.clone();
 
     rsx! {
@@ -95,9 +105,13 @@ pub(crate) fn OutlinePanel() -> Element {
                                 key: "outline-{idx}", class: "outline-entry", style: "padding-left: {indent}px;",
                                 onclick: move |_| {
                                     if let Some(pi) = page_idx {
+                                        let render_tx = render_ch.sender();
+                                        let data_dir = config.read().effective_library_path();
                                         spawn(async move {
-                                            let js = format!("let pages = document.querySelectorAll('.pdf-page-wrapper'); if (pages[{pi}]) {{ pages[{pi}].scrollIntoView({{ behavior: 'smooth', block: 'start' }}); }}");
-                                            let _ = document::eval(&js);
+                                            crate::state::commands::ensure_window_rendered(
+                                                &render_tx, &mut tabs, tab_id, pi, &data_dir,
+                                            ).await;
+                                            let _ = document::eval(&super::scroll_to_page_js(pi, "start"));
                                         });
                                     }
                                 },

--- a/src/ui/pdf/page_overlay.rs
+++ b/src/ui/pdf/page_overlay.rs
@@ -11,7 +11,12 @@ use rotero_models::{Annotation, AnnotationType};
 #[component]
 pub(crate) fn PdfPageWithOverlay(
     page_index: u32,
-    base64_data: Arc<String>,
+    /// `None` while the page is outside the resident render window — the slot
+    /// renders as a sized placeholder so the scroll container keeps full height
+    /// and this element (and its stable `id`) always exists. Keeping one node
+    /// type per page slot avoids Dioxus keyed-diff breakage when a page swaps
+    /// between placeholder and rendered.
+    base64_data: Option<Arc<String>>,
     mime: &'static str,
     width: u32,
     height: u32,
@@ -79,9 +84,23 @@ pub(crate) fn PdfPageWithOverlay(
         1.0
     };
 
+    // Not-yet-rendered slot: render a sized placeholder with the SAME element type,
+    // wrapper class, and id as a rendered page so it reserves scroll height and the
+    // node type never changes when the real page arrives.
+    let Some(base64_data) = base64_data else {
+        return rsx! {
+            div {
+                class: "pdf-page-wrapper pdf-page-placeholder",
+                id: "pdf-page-{page_index}",
+                style: "width: {width}px; height: {height}px; zoom: {css_zoom};",
+            }
+        };
+    };
+
     rsx! {
         div {
             class: "pdf-page-wrapper",
+            id: "pdf-page-{page_index}",
             style: "cursor: {cursor}; zoom: {css_zoom};",
 
             {

--- a/src/ui/pdf/search_bar.rs
+++ b/src/ui/pdf/search_bar.rs
@@ -5,6 +5,8 @@ use crate::state::app_state::{PdfTabManager, TabId};
 #[component]
 pub(crate) fn PdfSearchBar(tab_id: TabId) -> Element {
     let mut tabs = use_context::<Signal<PdfTabManager>>();
+    let render_ch = use_context::<crate::app::RenderChannel>();
+    let config = use_context::<Signal<crate::sync::engine::SyncConfig>>();
     let mgr = tabs.read();
     let tab = mgr.tab();
     let query = tab.search.query.clone();
@@ -41,9 +43,14 @@ pub(crate) fn PdfSearchBar(tab_id: TabId) -> Element {
                         if let Some(m) = mgr.tab().search.matches.get(mgr.tab().search.current_index) {
                             let page_idx = m.page_index;
                             drop(mgr);
+                            let render_tx = render_ch.sender();
+                            let data_dir = config.read().effective_library_path();
                             spawn(async move {
-                                let js = format!("let pages = document.querySelectorAll('.pdf-page-wrapper'); if (pages[{page_idx}]) {{ pages[{page_idx}].scrollIntoView({{ behavior: 'smooth', block: 'center' }}); }}");
-                                let _ = document::eval(&js);
+                                // Match may be on a page outside the current render window.
+                                crate::state::commands::ensure_window_rendered(
+                                    &render_tx, &mut tabs, tab_id, page_idx, &data_dir,
+                                ).await;
+                                let _ = document::eval(&super::scroll_to_page_js(page_idx, "center"));
                             });
                         }
                     } else if evt.key() == Key::Escape {

--- a/src/ui/pdf/tab_bar.rs
+++ b/src/ui/pdf/tab_bar.rs
@@ -80,19 +80,32 @@ pub fn PdfTabBar() -> Element {
                                 }
 
                                 spawn(async move {
-                                    let scroll_top = tabs.read().active_tab().map(|t| t.view.scroll_top).unwrap_or(0.0);
-                                    let js = format!(
-                                        "setTimeout(() => {{ let el = document.getElementById('pdf-pages-container'); if (el) el.scrollTop = {}; }}, 30)",
-                                        scroll_top
-                                    );
-                                    let _ = document::eval(&js);
+                                    let render_tx = render_ch.sender();
+                                    let cfg_dir = config.read().effective_library_path();
 
                                     let needs = tabs.read().active_tab().map(|t| t.needs_render()).unwrap_or(false);
                                     if needs {
                                         tabs.with_mut(|m| m.tab_mut().is_loading = true);
-                                        let render_tx = render_ch.sender();
-                                        let cfg_dir = config.read().effective_library_path();
                                         let _ = crate::state::commands::open_pdf(&render_tx, &mut tabs, tab_id, &cfg_dir, dpr_sig.read().0).await;
+                                    }
+
+                                    // Pages render in a sliding window, so before restoring
+                                    // scroll we must render the window around the page the
+                                    // user was last on; otherwise that region is blank.
+                                    let last_page = tabs.read().active_tab().map(|t| t.view.current_page).unwrap_or(0);
+                                    if last_page > 0 {
+                                        crate::state::commands::ensure_window_rendered(&render_tx, &mut tabs, tab_id, last_page, &cfg_dir).await;
+                                        // Scroll to the page element (robust to variable page heights
+                                        // and to Dioxus not having flushed the just-rendered page yet).
+                                        let _ = document::eval(&super::scroll_to_page_js(last_page, "start"));
+                                    } else {
+                                        // Restore exact pixel offset for the top of the document.
+                                        let scroll_top = tabs.read().active_tab().map(|t| t.view.scroll_top).unwrap_or(0.0);
+                                        let js = format!(
+                                            "setTimeout(() => {{ let el = document.getElementById('pdf-pages-container'); if (el) el.scrollTop = {}; }}, 30)",
+                                            scroll_top
+                                        );
+                                        let _ = document::eval(&js);
                                     }
                                 });
                             },
@@ -104,6 +117,8 @@ pub fn PdfTabBar() -> Element {
                                     tabs.with_mut(|m| m.close_tab(tab_id));
                                     if tabs.read().tabs.is_empty() {
                                         lib_state.with_mut(|s| s.view = LibraryView::AllPapers);
+                                        // No PDFs open — free the engine's cached file bytes.
+                                        let _ = render_ch.sender().send(crate::state::commands::RenderRequest::ClearCache);
                                     } else {
                                         let needs = tabs.read().active_tab().map(|t| t.needs_render()).unwrap_or(false);
                                         if needs {
@@ -149,6 +164,7 @@ pub fn PdfTabBar() -> Element {
                                     tabs.with_mut(|m| m.close_tab(ctx_tab_id));
                                     if tabs.read().tabs.is_empty() {
                                         lib_state.with_mut(|s| s.view = LibraryView::AllPapers);
+                                        let _ = render_ch.sender().send(crate::state::commands::RenderRequest::ClearCache);
                                     }
                                     tab_ctx.set(None);
                                 },

--- a/src/ui/pdf/toolbar.rs
+++ b/src/ui/pdf/toolbar.rs
@@ -184,6 +184,31 @@ pub(crate) fn PdfToolbar(page_count: u32, zoom: f32, tab_id: TabId) -> Element {
                 },
                 "TOC"
             }
+            div { class: "toolbar-tooltip", "data-tooltip": "Find (\u{2318}F)",
+                button {
+                    class: "btn btn--ghost",
+                    onclick: move |_| {
+                        let now_visible = tabs.with_mut(|m| {
+                            let t = m.tab_mut();
+                            t.search.visible = !t.search.visible;
+                            if !t.search.visible {
+                                t.search.query.clear();
+                                t.search.matches.clear();
+                                t.search.current_index = 0;
+                            }
+                            t.search.visible
+                        });
+                        if now_visible {
+                            spawn(async move {
+                                let _ = document::eval(
+                                    "setTimeout(() => { document.querySelector('.pdf-search-input')?.focus(); }, 30)",
+                                );
+                            });
+                        }
+                    },
+                    span { class: "bi bi-search" }
+                }
+            }
             button {
                 class: "btn btn--ghost",
                 onclick: move |_| {

--- a/src/ui/pdf/viewer.rs
+++ b/src/ui/pdf/viewer.rs
@@ -19,6 +19,8 @@ pub fn PdfViewer() -> Element {
     let db = use_context::<Database>();
     let dpr_sig = use_context::<Signal<crate::app::DevicePixelRatio>>();
     use_context_provider::<AnnCtxState>(|| Signal::new(None));
+    // Guards the scroll-driven render window against re-entrant scroll events.
+    let mut window_loading = use_signal(|| false);
 
     let mgr = tabs.read();
     let Some(tab) = mgr.active_tab() else {
@@ -60,13 +62,15 @@ pub fn PdfViewer() -> Element {
                             .unwrap_or_default();
 
                     let pdf_path = tabs.read().tab().pdf_path.clone();
-                    let rendered_pages: Vec<(u32, u32)> = tabs
+                    // Page pixel dims keyed by absolute page index (rendered_pages
+                    // is a sliding window, so it may not be contiguous from 0).
+                    let page_dims: std::collections::HashMap<u32, (u32, u32)> = tabs
                         .read()
                         .tab()
                         .render
                         .rendered_pages
-                        .iter()
-                        .map(|p| (p.width, p.height))
+                        .values()
+                        .map(|p| (p.page_index, (p.width, p.height)))
                         .collect();
 
                     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
@@ -87,8 +91,8 @@ pub fn PdfViewer() -> Element {
                                         a.geometry.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
                                     let ay =
                                         a.geometry.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                                    let (rw, rh) = rendered_pages
-                                        .get(ext.page as usize)
+                                    let (rw, rh) = page_dims
+                                        .get(&ext.page)
                                         .copied()
                                         .unwrap_or((1, 1));
                                     let sx = rw as f64 / ext.page_width_pts as f64;
@@ -103,8 +107,8 @@ pub fn PdfViewer() -> Element {
                                 continue;
                             }
 
-                            let (rw, rh) = rendered_pages
-                                .get(ext.page as usize)
+                            let (rw, rh) = page_dims
+                                .get(&ext.page)
                                 .copied()
                                 .unwrap_or((1, 1));
                             let sx = rw as f32 / ext.page_width_pts;
@@ -151,8 +155,6 @@ pub fn PdfViewer() -> Element {
     let page_count = tab.page_count;
     let zoom = tab.view.zoom;
     let render_zoom = tab.view.render_zoom;
-    let rendered_count = tab.rendered_count();
-    let has_more = rendered_count < page_count;
     let show_thumbnails = tab.nav.show_thumbnails;
     let show_outline = tab.nav.show_outline && !tab.nav.outline.is_empty();
     let show_search = tab.search.visible;
@@ -246,6 +248,52 @@ pub fn PdfViewer() -> Element {
                 div {
                     class: "pdf-pages",
                     id: "pdf-pages-container",
+                    onscroll: move |_| {
+                        if window_loading() {
+                            return;
+                        }
+                        window_loading.set(true);
+                        let render_tx = render_ch.sender();
+                        let data_dir = config.read().effective_library_path();
+                        spawn(async move {
+                            // Find the page wrapper whose vertical midpoint is nearest
+                            // the container's viewport center; return its page index.
+                            // Send the result back via `dioxus.send(...)`; a bare `return`
+                            // from the IIFE is NOT delivered to `.recv()` in this Dioxus
+                            // version (it comes back as Err(Finished)).
+                            let mut eval = document::eval(
+                                "let el = document.getElementById('pdf-pages-container'); \
+                                 let best = -1; \
+                                 if (el) { \
+                                   let cr = el.getBoundingClientRect(); \
+                                   let mid = cr.top + cr.height / 2; \
+                                   let bestDist = Infinity; \
+                                   for (let w of el.querySelectorAll('.pdf-page-wrapper')) { \
+                                     let r = w.getBoundingClientRect(); \
+                                     let c = r.top + r.height / 2; \
+                                     let d = Math.abs(c - mid); \
+                                     if (d < bestDist) { bestDist = d; \
+                                       best = parseInt(w.id.replace('pdf-page-', ''), 10); } \
+                                   } \
+                                 } \
+                                 dioxus.send(best);",
+                            );
+                            let idx_res = eval.recv::<i64>().await;
+                            if let Ok(idx) = idx_res
+                                && idx >= 0
+                            {
+                                crate::state::commands::ensure_window_rendered(
+                                    &render_tx,
+                                    &mut tabs,
+                                    tab_id,
+                                    idx as u32,
+                                    &data_dir,
+                                )
+                                .await;
+                            }
+                            window_loading.set(false);
+                        });
+                    },
                     onmounted: move |_| {
                         spawn(async move {
                             let _ = document::eval(r#"
@@ -326,27 +374,40 @@ pub fn PdfViewer() -> Element {
                         let mgr = tabs.read();
                         let tab = mgr.tab();
                         let pages = tab.render.rendered_pages.clone();
+                        let page_dims = tab.render.page_dims.clone();
+                        let total = tab.page_count;
                         drop(mgr);
+                        // Render every page slot in order with a SINGLE element type
+                        // (PdfPageWithOverlay). Resident pages pass Some(image); the rest
+                        // pass None and render as a sized placeholder, keeping full scroll
+                        // height so every page is reachable (which triggers rendering the
+                        // next window). Keeping one node type per key avoids Dioxus
+                        // keyed-diff breakage when a slot swaps placeholder<->rendered.
                         rsx! {
-                            for (idx, page) in pages.iter().enumerate() {
-                                PdfPageWithOverlay {
-                                    key: "{idx}",
-                                    page_index: page.page_index,
-                                    base64_data: page.base64_data.clone(),
-                                    mime: page.mime,
-                                    width: page.width,
-                                    height: page.height,
-                                    zoom,
-                                    render_zoom,
-                                    tab_id,
+                            for idx in 0..total {
+                                {
+                                    let page = pages.get(&idx);
+                                    // Rendered pages carry their exact pixel size; placeholders
+                                    // fall back to page_dims (or US-Letter until dims load).
+                                    let (w, h) = page
+                                        .map(|p| (p.width, p.height))
+                                        .or_else(|| page_dims.get(idx as usize).copied())
+                                        .unwrap_or((612, 792));
+                                    rsx! {
+                                        PdfPageWithOverlay {
+                                            key: "{idx}",
+                                            page_index: idx,
+                                            base64_data: page.map(|p| p.base64_data.clone()),
+                                            mime: page.map(|p| p.mime).unwrap_or("image/png"),
+                                            width: w,
+                                            height: h,
+                                            zoom,
+                                            render_zoom,
+                                            tab_id,
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
-
-                    if has_more {
-                        div { class: "pdf-load-more",
-                            "Loading pages..."
                         }
                     }
                 }


### PR DESCRIPTION
## Why

A prior run "ended up taking a lot of mem." Investigation (with live RSS sampling) found no classic leak, but two real problems:

1. **PDF viewer memory grew unbounded.** Every page of an opened PDF was rendered eagerly and kept resident as a full-resolution base64 PNG (in both the Rust `Vec` and the WebView DOM), so RSS grew with document size and never recovered — a sustained ~380 MB that climbed with pages viewed.
2. **Leaked ACP agent processes.** Spawned Claude ACP `node` processes were orphaned on app exit; ~17 had accumulated (~530 MB) across restarts.

## What changed

### PDF rendering — bounded memory
- `rendered_pages`: `Vec` → `BTreeMap<u32, RenderedPageData>` keyed by page index (non-contiguous sliding window).
- Render only a window around the viewport (`PAGE_WINDOW_RADIUS`), evicting pages outside it (`MAX_RESIDENT_PAGES`), mirroring the existing thumbnail windowing. Scroll position is reported to Rust to drive the window.
- Every page slot always renders as **one node type** (`PdfPageWithOverlay`): resident pages pass `Some(image)`, the rest render a sized placeholder so the scroll container keeps full height and all pages stay reachable. (Keeping one node type per key avoids a Dioxus keyed-diff bug when a slot swaps placeholder↔rendered.)
- Full-document text is still extracted for search/fulltext without rendering images (dims-only pass); per-page dims size the placeholders.
- Fixed positional-index assumptions the `Vec`→map change exposed: annotation dim lookup by page index, and scroll-to-page now uses `getElementById('pdf-page-N')` (polling for the element) instead of `querySelectorAll[idx]` — which also fixes the previously **dead annotation "Go to page"** menu item.
- Wired up the never-called `clear_byte_cache()` to fire when the last PDF tab closes; merged `OpenPdf`'s double PDF parse into one.
- Added a focus-independent **Search button** to the PDF toolbar.

### ACP agent process cleanup
- Spawn each agent `node` process in its own process group (`setsid`), track live PIDs, and kill the whole group on session end and via a `SIGTERM`/`SIGINT`/`SIGHUP` handler — so agents aren't orphaned when the app is terminated by a signal (Cmd+Q, `dx serve` reload) where `Drop` won't run.

## Result
Idle ~130 MB; with a PDF open, RSS oscillates and reclaims instead of climbing. Total Rotero footprint dropped from ~800 MB+ (with orphans) to ~250 MB.

## Verification
- `cargo check`/`clippy` clean for `rotero` + `rotero-pdf`.
- Manually verified: fresh multi-page PDFs now scroll/render fully; search-jump, thumbnail, outline, "Go to page", tab scroll-restore, and zoom all work.
- **Not yet exercised:** a 40+ page PDF scrolled end-to-end (would confirm eviction trims resident pages). Window constants (`MAX_RESIDENT_PAGES=30`, `PAGE_WINDOW_RADIUS=12`) may want tuning after that test.