### PR TITLE
Add rebindable keybindings settings page

### DIFF
--- a/assets/dialogs.css
+++ b/assets/dialogs.css
@@ -201,6 +201,132 @@
   flex-shrink: 0;
 }
 
+/* --- Keybindings settings --- */
+.settings-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+
+.settings-keybind-notice {
+  font-size: var(--text-sm);
+  color: var(--warning, #b45309);
+  background: var(--bg-muted);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-3);
+}
+
+.settings-keybind-group {
+  margin-bottom: var(--space-4);
+}
+
+.settings-keybind-scope {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin: var(--space-3) 0 var(--space-1);
+}
+
+.settings-keybind-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  min-height: 34px;
+}
+
+.settings-keybind-label {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.settings-keybind-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.settings-keybind-chip {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  min-width: 3rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: center;
+  user-select: none;
+  outline: none;
+}
+
+.settings-keybind-chip:hover {
+  border-color: var(--border-strong, var(--text-secondary));
+}
+
+.settings-keybind-chip:focus-visible {
+  border-color: var(--accent, #2563eb);
+}
+
+.settings-keybind-chip--capturing,
+.settings-keybind-chip--capturing:focus-visible {
+  border-color: var(--accent, #2563eb);
+  color: var(--accent, #2563eb);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, #2563eb) 25%, transparent);
+}
+
+.settings-keybind-reset {
+  font-size: var(--text-sm);
+  line-height: 1;
+}
+
+.settings-overlay--nested {
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.settings-confirm {
+  background: var(--bg-elevated, var(--bg-primary, #fff));
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg, var(--radius-md));
+  padding: var(--space-5);
+  max-width: 24rem;
+  box-shadow: var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.2));
+}
+
+.settings-confirm-title {
+  font-size: var(--text-base, var(--text-sm));
+  font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+.settings-confirm-body {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-normal);
+  margin-bottom: var(--space-2);
+}
+
+.settings-confirm-body .settings-keybind-chip {
+  display: inline-block;
+  cursor: default;
+  vertical-align: baseline;
+}
+
+.settings-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
 .settings-select {
   min-width: 100px;
   width: auto;

--- a/assets/keybindings.js
+++ b/assets/keybindings.js
@@ -1,0 +1,39 @@
+// Stop unmodified library shortcut keys (Enter, Backspace, Delete, ArrowUp,
+// ArrowDown) from bubbling to the global onkeydown handler when focus is in an
+// editable element. Dioxus' SerializedKeyboardData carries no DOM target, so
+// the Rust handler can't tell whether the user is typing into a textbox vs.
+// pressing a library shortcut — we gate it here in capture phase instead.
+//
+// Cmd/Ctrl-modified keys are left alone so shortcuts like Cmd+F still work
+// while typing.
+(function () {
+  if (window.__rotero_keybindings) return;
+  window.__rotero_keybindings = true;
+
+  const SWALLOW = new Set([
+    "Enter",
+    "Backspace",
+    "Delete",
+    "ArrowUp",
+    "ArrowDown",
+  ]);
+
+  function isEditable(el) {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+    if (el.isContentEditable) return true;
+    return false;
+  }
+
+  document.addEventListener(
+    "keydown",
+    function (e) {
+      if (e.metaKey || e.ctrlKey) return;
+      if (!SWALLOW.has(e.key)) return;
+      if (!isEditable(e.target)) return;
+      e.stopPropagation();
+    },
+    true,
+  );
+})();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -41,6 +41,7 @@ const DIALOGS_CSS: &str = include_str!("../../assets/dialogs.css");
 const THEME_CSS: &str = include_str!("../../assets/theme.css");
 const GRAPH_CSS: &str = include_str!("../../assets/graph.css");
 const GRAPH_JS: &str = include_str!("../../assets/graph.js");
+const KEYBINDINGS_JS: &str = include_str!("../../assets/keybindings.js");
 const CHAT_CSS: &str = include_str!("../../assets/chat.css");
 #[cfg(feature = "mobile")]
 const LONGPRESS_JS: &str = include_str!("../../assets/longpress.js");
@@ -179,6 +180,7 @@ pub fn App() -> Element {
                 document::Style { {GRAPH_CSS} }
                 document::Style { {CHAT_CSS} }
                 document::Script { {GRAPH_JS} }
+                document::Script { {KEYBINDINGS_JS} }
                 {longpress_script()}
                 LoadLibraryData {}
                 SyncLoop {}

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -155,6 +155,11 @@ pub struct SyncConfig {
     /// Cached device pixel ratio from the last run. Avoids async DPR race on startup.
     #[serde(default = "default_dpr")]
     pub cached_dpr: f32,
+
+    /// User keybinding overrides: command id → key spec. Empty means "use the
+    /// built-in defaults". See `crate::ui::keybindings`.
+    #[serde(default)]
+    pub keybindings: crate::ui::keybindings::Overrides,
 }
 
 fn default_max_resident_tabs() -> u32 {
@@ -211,6 +216,7 @@ impl Default for SyncConfig {
             auto_fetch_metadata: default_true(),
             max_resident_tabs: default_max_resident_tabs(),
             cached_dpr: default_dpr(),
+            keybindings: crate::ui::keybindings::Overrides::default(),
         }
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -158,6 +158,11 @@ pub struct SyncConfig {
 
     /// User keybinding overrides: command id → key spec. Empty means "use the
     /// built-in defaults". See `crate::ui::keybindings`.
+    ///
+    /// Desktop-only: the keybinding module (native menus, muda) doesn't build on
+    /// mobile. `#[serde(default)]` means the field simply round-trips absent
+    /// there, so a config written on desktop still loads on mobile.
+    #[cfg(feature = "desktop")]
     #[serde(default)]
     pub keybindings: crate::ui::keybindings::Overrides,
 }
@@ -216,6 +221,7 @@ impl Default for SyncConfig {
             auto_fetch_metadata: default_true(),
             max_resident_tabs: default_max_resident_tabs(),
             cached_dpr: default_dpr(),
+            #[cfg(feature = "desktop")]
             keybindings: crate::ui::keybindings::Overrides::default(),
         }
     }

--- a/src/ui/keybindings.rs
+++ b/src/ui/keybindings.rs
@@ -25,7 +25,7 @@ use rotero_db::Database;
 // input claimed.
 
 /// A semantic action, decoupled from the key that triggers it. This is the unit
-/// a future rebinding UI would let users remap.
+/// a rebinding UI lets users remap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Command {
     OpenSettings,
@@ -52,6 +52,73 @@ pub enum Command {
     Escape,
 }
 
+impl Command {
+    /// Stable string id used as the config key for a user override. Changing one
+    /// of these orphans existing overrides, so treat them as a wire format.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::OpenSettings => "open_settings",
+            Self::OpenPdf => "open_pdf",
+            Self::ImportBibtex => "import_bibtex",
+            Self::ExportBibtex => "export_bibtex",
+            Self::Find => "find",
+            Self::FocusLibrarySearch => "focus_library_search",
+            Self::CloseTab => "close_tab",
+            Self::NewCollection => "new_collection",
+            Self::ShowLibrary => "show_library",
+            Self::PrevTab => "prev_tab",
+            Self::NextTab => "next_tab",
+            Self::Undo => "undo",
+            Self::Redo => "redo",
+            Self::SelectAll => "select_all",
+            Self::ToggleFavorite => "toggle_favorite",
+            Self::ToggleRead => "toggle_read",
+            Self::CheckUpdates => "check_updates",
+            Self::SelectNext => "select_next",
+            Self::SelectPrev => "select_prev",
+            Self::OpenSelected => "open_selected",
+            Self::DeleteSelected => "delete_selected",
+            Self::Escape => "escape",
+        }
+    }
+
+    /// Human-readable name shown in the keybindings settings page.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::OpenSettings => "Open settings",
+            Self::OpenPdf => "Open PDF\u{2026}",
+            Self::ImportBibtex => "Import BibTeX\u{2026}",
+            Self::ExportBibtex => "Export BibTeX\u{2026}",
+            Self::Find => "Find in page / library",
+            Self::FocusLibrarySearch => "Focus library search",
+            Self::CloseTab => "Close tab",
+            Self::NewCollection => "New collection",
+            Self::ShowLibrary => "Show library",
+            Self::PrevTab => "Previous tab",
+            Self::NextTab => "Next tab",
+            Self::Undo => "Undo",
+            Self::Redo => "Redo",
+            Self::SelectAll => "Select all papers",
+            Self::ToggleFavorite => "Toggle favorite",
+            Self::ToggleRead => "Toggle read",
+            Self::CheckUpdates => "Check for updates",
+            Self::SelectNext => "Select next paper",
+            Self::SelectPrev => "Select previous paper",
+            Self::OpenSelected => "Open selected paper",
+            Self::DeleteSelected => "Delete selected papers",
+            Self::Escape => "Cancel / dismiss",
+        }
+    }
+
+    /// Whether the settings page lets the user rebind this command.
+    ///
+    /// `Escape` is a hard-wired cancel key and `CheckUpdates` has no keyboard
+    /// shortcut (menu-only), so neither is user-rebindable.
+    pub fn is_rebindable(self) -> bool {
+        !matches!(self, Self::Escape | Self::CheckUpdates)
+    }
+}
+
 /// Where a binding is active. `Global` fires regardless of view; the others only
 /// fire when the current view matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,8 +128,9 @@ pub enum Scope {
     Viewer,
 }
 
-/// A key combination, normalized so the DOM handler, the menu accelerator, and a
-/// future config file all agree on the same representation.
+/// A key combination, normalized so the DOM handler, the menu accelerator, and
+/// the config file all agree on the same representation. Serialized as a compact
+/// string like `"cmd+shift+z"` or `"arrowdown"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeySpec {
     pub cmd: bool,
@@ -82,27 +150,59 @@ pub enum Trigger {
     Escape,
 }
 
+impl Trigger {
+    /// Lowercase token used in the serialized form.
+    fn token(self) -> String {
+        match self {
+            Trigger::Char(c) => c.to_ascii_lowercase().to_string(),
+            Trigger::ArrowUp => "arrowup".to_string(),
+            Trigger::ArrowDown => "arrowdown".to_string(),
+            Trigger::Enter => "enter".to_string(),
+            Trigger::Backspace => "backspace".to_string(),
+            Trigger::Escape => "escape".to_string(),
+        }
+    }
+
+    fn from_token(tok: &str) -> Option<Self> {
+        Some(match tok {
+            "arrowup" => Trigger::ArrowUp,
+            "arrowdown" => Trigger::ArrowDown,
+            "enter" => Trigger::Enter,
+            "backspace" => Trigger::Backspace,
+            "escape" => Trigger::Escape,
+            _ => {
+                let mut chars = tok.chars();
+                let c = chars.next()?;
+                if chars.next().is_some() {
+                    return None; // multi-char token that isn't a known name
+                }
+                Trigger::Char(c)
+            }
+        })
+    }
+
+    /// Symbol shown in the UI (e.g. the up-arrow glyph).
+    fn glyph(self) -> String {
+        match self {
+            Trigger::Char(c) => c.to_ascii_uppercase().to_string(),
+            Trigger::ArrowUp => "\u{2191}".to_string(),
+            Trigger::ArrowDown => "\u{2193}".to_string(),
+            Trigger::Enter => "\u{21a9}".to_string(),
+            Trigger::Backspace => "\u{232b}".to_string(),
+            Trigger::Escape => "esc".to_string(),
+        }
+    }
+}
+
 impl KeySpec {
     const fn cmd(c: char) -> Self {
-        Self {
-            cmd: true,
-            shift: false,
-            trigger: Trigger::Char(c),
-        }
+        Self { cmd: true, shift: false, trigger: Trigger::Char(c) }
     }
     const fn cmd_shift(c: char) -> Self {
-        Self {
-            cmd: true,
-            shift: true,
-            trigger: Trigger::Char(c),
-        }
+        Self { cmd: true, shift: true, trigger: Trigger::Char(c) }
     }
     const fn bare(trigger: Trigger) -> Self {
-        Self {
-            cmd: false,
-            shift: false,
-            trigger,
-        }
+        Self { cmd: false, shift: false, trigger }
     }
 
     /// Does this spec match a live keyboard event's modifiers + key?
@@ -123,6 +223,82 @@ impl KeySpec {
             Trigger::Escape => *key == Key::Escape,
         }
     }
+
+    /// Compact serialized form, e.g. `"cmd+shift+z"`, `"arrowdown"`.
+    fn to_token_string(self) -> String {
+        let mut parts = Vec::new();
+        if self.cmd {
+            parts.push("cmd".to_string());
+        }
+        if self.shift {
+            parts.push("shift".to_string());
+        }
+        parts.push(self.trigger.token());
+        parts.join("+")
+    }
+
+    fn from_token_string(s: &str) -> Option<Self> {
+        let mut cmd = false;
+        let mut shift = false;
+        let mut trigger = None;
+        for part in s.split('+') {
+            match part {
+                "cmd" => cmd = true,
+                "shift" => shift = true,
+                other => trigger = Some(Trigger::from_token(other)?),
+            }
+        }
+        Some(Self { cmd, shift, trigger: trigger? })
+    }
+
+    /// Human-facing label for the settings chip, e.g. `⌘⇧Z` or `↓`.
+    pub fn display(self) -> String {
+        let mut s = String::new();
+        if self.cmd {
+            s.push('\u{2318}'); // ⌘
+        }
+        if self.shift {
+            s.push('\u{21e7}'); // ⇧
+        }
+        s.push_str(&self.trigger.glyph());
+        s
+    }
+
+    /// Build a spec from a captured keyboard event, or `None` if the key can't be
+    /// bound (e.g. a lone modifier press, or a non-printable key we don't model).
+    pub fn from_event(cmd: bool, shift: bool, key: &Key) -> Option<Self> {
+        let trigger = match key {
+            Key::Character(c) => {
+                let ch = c.chars().next()?;
+                // Reject whitespace/control chars as bindings.
+                if ch.is_control() {
+                    return None;
+                }
+                Trigger::Char(ch)
+            }
+            Key::ArrowUp => Trigger::ArrowUp,
+            Key::ArrowDown => Trigger::ArrowDown,
+            Key::Enter => Trigger::Enter,
+            Key::Backspace | Key::Delete => Trigger::Backspace,
+            // Escape is reserved as cancel; don't let it be captured as a binding.
+            _ => return None,
+        };
+        Some(Self { cmd, shift, trigger })
+    }
+}
+
+impl serde::Serialize for KeySpec {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_token_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for KeySpec {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Self::from_token_string(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid keyspec: {s:?}")))
+    }
 }
 
 /// One row of the shortcut table: key + scope → command, plus an optional native
@@ -140,140 +316,126 @@ pub struct Binding {
 /// wins, so put more specific scopes before `Global` if they ever share a key.
 pub const BINDINGS: &[Binding] = &[
     // Global — fire in any view.
-    Binding {
-        key: KeySpec::cmd(','),
-        command: Command::OpenSettings,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd('o'),
-        command: Command::OpenPdf,
-        scope: Scope::Global,
-        menu_id: Some("open-pdf"),
-    },
-    Binding {
-        key: KeySpec::cmd('i'),
-        command: Command::ImportBibtex,
-        scope: Scope::Global,
-        menu_id: Some("import-bibtex"),
-    },
-    Binding {
-        key: KeySpec::cmd('e'),
-        command: Command::ExportBibtex,
-        scope: Scope::Global,
-        menu_id: Some("export-bibtex"),
-    },
-    Binding {
-        key: KeySpec::cmd('f'),
-        command: Command::Find,
-        scope: Scope::Global,
-        menu_id: Some("find"),
-    },
-    Binding {
-        key: KeySpec::cmd('l'),
-        command: Command::FocusLibrarySearch,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd('w'),
-        command: Command::CloseTab,
-        scope: Scope::Global,
-        menu_id: Some("close-tab"),
-    },
-    Binding {
-        key: KeySpec::cmd('n'),
-        command: Command::NewCollection,
-        scope: Scope::Global,
-        menu_id: Some("new-collection"),
-    },
-    Binding {
-        key: KeySpec::cmd('1'),
-        command: Command::ShowLibrary,
-        scope: Scope::Global,
-        menu_id: Some("show-library"),
-    },
-    Binding {
-        key: KeySpec::cmd('['),
-        command: Command::PrevTab,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd(']'),
-        command: Command::NextTab,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd('z'),
-        command: Command::Undo,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd_shift('z'),
-        command: Command::Redo,
-        scope: Scope::Global,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::bare(Trigger::Escape),
-        command: Command::Escape,
-        scope: Scope::Global,
-        menu_id: None,
-    },
+    Binding { key: KeySpec::cmd(','), command: Command::OpenSettings, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::cmd('o'), command: Command::OpenPdf, scope: Scope::Global, menu_id: Some("open-pdf") },
+    Binding { key: KeySpec::cmd('i'), command: Command::ImportBibtex, scope: Scope::Global, menu_id: Some("import-bibtex") },
+    Binding { key: KeySpec::cmd('e'), command: Command::ExportBibtex, scope: Scope::Global, menu_id: Some("export-bibtex") },
+    Binding { key: KeySpec::cmd('f'), command: Command::Find, scope: Scope::Global, menu_id: Some("find") },
+    Binding { key: KeySpec::cmd('l'), command: Command::FocusLibrarySearch, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::cmd('w'), command: Command::CloseTab, scope: Scope::Global, menu_id: Some("close-tab") },
+    Binding { key: KeySpec::cmd('n'), command: Command::NewCollection, scope: Scope::Global, menu_id: Some("new-collection") },
+    Binding { key: KeySpec::cmd('1'), command: Command::ShowLibrary, scope: Scope::Global, menu_id: Some("show-library") },
+    Binding { key: KeySpec::cmd('['), command: Command::PrevTab, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::cmd(']'), command: Command::NextTab, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::cmd('z'), command: Command::Undo, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::cmd_shift('z'), command: Command::Redo, scope: Scope::Global, menu_id: None },
+    Binding { key: KeySpec::bare(Trigger::Escape), command: Command::Escape, scope: Scope::Global, menu_id: None },
     // Library — only when a paper list is showing.
-    Binding {
-        key: KeySpec::cmd('a'),
-        command: Command::SelectAll,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd_shift('f'),
-        command: Command::ToggleFavorite,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::cmd_shift('u'),
-        command: Command::ToggleRead,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::bare(Trigger::ArrowDown),
-        command: Command::SelectNext,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::bare(Trigger::ArrowUp),
-        command: Command::SelectPrev,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::bare(Trigger::Enter),
-        command: Command::OpenSelected,
-        scope: Scope::Library,
-        menu_id: None,
-    },
-    Binding {
-        key: KeySpec::bare(Trigger::Backspace),
-        command: Command::DeleteSelected,
-        scope: Scope::Library,
-        menu_id: None,
-    },
+    Binding { key: KeySpec::cmd('a'), command: Command::SelectAll, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::cmd_shift('f'), command: Command::ToggleFavorite, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::cmd_shift('u'), command: Command::ToggleRead, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::bare(Trigger::ArrowDown), command: Command::SelectNext, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::bare(Trigger::ArrowUp), command: Command::SelectPrev, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::bare(Trigger::Enter), command: Command::OpenSelected, scope: Scope::Library, menu_id: None },
+    Binding { key: KeySpec::bare(Trigger::Backspace), command: Command::DeleteSelected, scope: Scope::Library, menu_id: None },
 ];
 
-/// Resolve a live key event within a scope to a command, if any binding matches.
-fn resolve(cmd: bool, shift: bool, key: &Key, scope: Scope) -> Option<Command> {
+/// The default (built-in) key for a command, if it has one.
+pub fn default_key(command: Command) -> Option<KeySpec> {
     BINDINGS
         .iter()
-        .find(|b| (b.scope == scope || b.scope == Scope::Global) && b.key.matches(cmd, shift, key))
+        .find(|b| b.command == command)
+        .map(|b| b.key)
+}
+
+/// The scope a command belongs to (from its `BINDINGS` row).
+pub fn command_scope(command: Command) -> Scope {
+    BINDINGS
+        .iter()
+        .find(|b| b.command == command)
+        .map(|b| b.scope)
+        .unwrap_or(Scope::Global)
+}
+
+/// User overrides: command id → binding.
+///
+/// - key **absent**  → use the built-in default
+/// - `Some(key)`     → rebound to `key`
+/// - `None`          → explicitly unbound (default suppressed, no shortcut)
+pub type Overrides = std::collections::HashMap<String, Option<KeySpec>>;
+
+/// The effective key for a command, honoring a user override if present. Returns
+/// `None` when the command has no default and no override, or when the user has
+/// explicitly unbound it.
+pub fn effective_key(command: Command, overrides: &Overrides) -> Option<KeySpec> {
+    match overrides.get(command.id()) {
+        // An entry exists (rebound or explicitly unbound) — it wins over the default.
+        Some(binding) => *binding,
+        // No entry — fall back to the built-in default.
+        None => default_key(command),
+    }
+}
+
+impl Scope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Scope::Global => "Global",
+            Scope::Library => "Library",
+            Scope::Viewer => "PDF Viewer",
+        }
+    }
+}
+
+/// Every user-rebindable command, in table order. Used by the settings page.
+pub fn rebindable_commands() -> impl Iterator<Item = Command> {
+    BINDINGS
+        .iter()
+        .filter(|b| b.command.is_rebindable())
+        .map(|b| b.command)
+}
+
+/// Would assigning `key` to `command` collide with another command that could
+/// fire in the same scope? Returns the conflicting command if so.
+///
+/// Two commands conflict when their scopes overlap (either is `Global`, or they
+/// share a scope) and their effective keys match the same event.
+pub fn conflict_for(
+    command: Command,
+    key: KeySpec,
+    overrides: &Overrides,
+) -> Option<Command> {
+    let target_scope = command_scope(command);
+    for b in BINDINGS {
+        if b.command == command {
+            continue;
+        }
+        let other_scope = command_scope(b.command);
+        let scopes_overlap = target_scope == Scope::Global
+            || other_scope == Scope::Global
+            || target_scope == other_scope;
+        if !scopes_overlap {
+            continue;
+        }
+        if effective_key(b.command, overrides) == Some(key) {
+            return Some(b.command);
+        }
+    }
+    None
+}
+
+/// Resolve a live key event within a scope to a command, honoring user overrides.
+///
+/// A command matches if its *effective* key (override or default) matches the
+/// event and its scope is active. The default table order is preserved so that,
+/// absent overrides, resolution is identical to the built-in behavior.
+fn resolve(cmd: bool, shift: bool, key: &Key, scope: Scope, overrides: &Overrides) -> Option<Command> {
+    BINDINGS
+        .iter()
+        .filter(|b| b.scope == scope || b.scope == Scope::Global)
+        .find(|b| {
+            effective_key(b.command, overrides)
+                .is_some_and(|k| k.matches(cmd, shift, key))
+        })
         .map(|b| b.command)
 }
 
@@ -841,7 +1003,9 @@ fn dispatch(cmd: Command, ctx: &KeyCtx, db: &Database) {
         Command::CheckUpdates => action_check_updates(update_state),
         Command::SelectNext => action_select_next(lib_state),
         Command::SelectPrev => action_select_prev(lib_state),
-        Command::OpenSelected => action_open_selected_pdf(lib_state, tabs, db, &config, &dpr_sig),
+        Command::OpenSelected => {
+            action_open_selected_pdf(lib_state, tabs, db, &config, &dpr_sig)
+        }
         Command::DeleteSelected => action_delete_selected(lib_state),
         Command::Escape => action_escape(show_settings, tabs, tools, lib_state),
     }
@@ -873,7 +1037,8 @@ pub fn handle_keydown(event: Event<KeyboardData>, ctx: KeyCtx, db: Database) {
     let cmd = modifiers.meta() || modifiers.ctrl();
     let shift = modifiers.shift();
 
-    if let Some(command) = resolve(cmd, shift, &key, ctx.scope()) {
+    let overrides = ctx.config.read().keybindings.clone();
+    if let Some(command) = resolve(cmd, shift, &key, ctx.scope(), &overrides) {
         // Escape is intentionally not prevent_default'd — matches prior behavior.
         if command != Command::Escape {
             event.prevent_default();

--- a/src/ui/keybindings.rs
+++ b/src/ui/keybindings.rs
@@ -196,13 +196,25 @@ impl Trigger {
 
 impl KeySpec {
     const fn cmd(c: char) -> Self {
-        Self { cmd: true, shift: false, trigger: Trigger::Char(c) }
+        Self {
+            cmd: true,
+            shift: false,
+            trigger: Trigger::Char(c),
+        }
     }
     const fn cmd_shift(c: char) -> Self {
-        Self { cmd: true, shift: true, trigger: Trigger::Char(c) }
+        Self {
+            cmd: true,
+            shift: true,
+            trigger: Trigger::Char(c),
+        }
     }
     const fn bare(trigger: Trigger) -> Self {
-        Self { cmd: false, shift: false, trigger }
+        Self {
+            cmd: false,
+            shift: false,
+            trigger,
+        }
     }
 
     /// Does this spec match a live keyboard event's modifiers + key?
@@ -248,7 +260,11 @@ impl KeySpec {
                 other => trigger = Some(Trigger::from_token(other)?),
             }
         }
-        Some(Self { cmd, shift, trigger: trigger? })
+        Some(Self {
+            cmd,
+            shift,
+            trigger: trigger?,
+        })
     }
 
     /// Human-facing label for the settings chip, e.g. `⌘⇧Z` or `↓`.
@@ -283,7 +299,11 @@ impl KeySpec {
             // Escape is reserved as cancel; don't let it be captured as a binding.
             _ => return None,
         };
-        Some(Self { cmd, shift, trigger })
+        Some(Self {
+            cmd,
+            shift,
+            trigger,
+        })
     }
 }
 
@@ -316,28 +336,133 @@ pub struct Binding {
 /// wins, so put more specific scopes before `Global` if they ever share a key.
 pub const BINDINGS: &[Binding] = &[
     // Global — fire in any view.
-    Binding { key: KeySpec::cmd(','), command: Command::OpenSettings, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::cmd('o'), command: Command::OpenPdf, scope: Scope::Global, menu_id: Some("open-pdf") },
-    Binding { key: KeySpec::cmd('i'), command: Command::ImportBibtex, scope: Scope::Global, menu_id: Some("import-bibtex") },
-    Binding { key: KeySpec::cmd('e'), command: Command::ExportBibtex, scope: Scope::Global, menu_id: Some("export-bibtex") },
-    Binding { key: KeySpec::cmd('f'), command: Command::Find, scope: Scope::Global, menu_id: Some("find") },
-    Binding { key: KeySpec::cmd('l'), command: Command::FocusLibrarySearch, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::cmd('w'), command: Command::CloseTab, scope: Scope::Global, menu_id: Some("close-tab") },
-    Binding { key: KeySpec::cmd('n'), command: Command::NewCollection, scope: Scope::Global, menu_id: Some("new-collection") },
-    Binding { key: KeySpec::cmd('1'), command: Command::ShowLibrary, scope: Scope::Global, menu_id: Some("show-library") },
-    Binding { key: KeySpec::cmd('['), command: Command::PrevTab, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::cmd(']'), command: Command::NextTab, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::cmd('z'), command: Command::Undo, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::cmd_shift('z'), command: Command::Redo, scope: Scope::Global, menu_id: None },
-    Binding { key: KeySpec::bare(Trigger::Escape), command: Command::Escape, scope: Scope::Global, menu_id: None },
+    Binding {
+        key: KeySpec::cmd(','),
+        command: Command::OpenSettings,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd('o'),
+        command: Command::OpenPdf,
+        scope: Scope::Global,
+        menu_id: Some("open-pdf"),
+    },
+    Binding {
+        key: KeySpec::cmd('i'),
+        command: Command::ImportBibtex,
+        scope: Scope::Global,
+        menu_id: Some("import-bibtex"),
+    },
+    Binding {
+        key: KeySpec::cmd('e'),
+        command: Command::ExportBibtex,
+        scope: Scope::Global,
+        menu_id: Some("export-bibtex"),
+    },
+    Binding {
+        key: KeySpec::cmd('f'),
+        command: Command::Find,
+        scope: Scope::Global,
+        menu_id: Some("find"),
+    },
+    Binding {
+        key: KeySpec::cmd('l'),
+        command: Command::FocusLibrarySearch,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd('w'),
+        command: Command::CloseTab,
+        scope: Scope::Global,
+        menu_id: Some("close-tab"),
+    },
+    Binding {
+        key: KeySpec::cmd('n'),
+        command: Command::NewCollection,
+        scope: Scope::Global,
+        menu_id: Some("new-collection"),
+    },
+    Binding {
+        key: KeySpec::cmd('1'),
+        command: Command::ShowLibrary,
+        scope: Scope::Global,
+        menu_id: Some("show-library"),
+    },
+    Binding {
+        key: KeySpec::cmd('['),
+        command: Command::PrevTab,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd(']'),
+        command: Command::NextTab,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd('z'),
+        command: Command::Undo,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd_shift('z'),
+        command: Command::Redo,
+        scope: Scope::Global,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::bare(Trigger::Escape),
+        command: Command::Escape,
+        scope: Scope::Global,
+        menu_id: None,
+    },
     // Library — only when a paper list is showing.
-    Binding { key: KeySpec::cmd('a'), command: Command::SelectAll, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::cmd_shift('f'), command: Command::ToggleFavorite, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::cmd_shift('u'), command: Command::ToggleRead, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::bare(Trigger::ArrowDown), command: Command::SelectNext, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::bare(Trigger::ArrowUp), command: Command::SelectPrev, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::bare(Trigger::Enter), command: Command::OpenSelected, scope: Scope::Library, menu_id: None },
-    Binding { key: KeySpec::bare(Trigger::Backspace), command: Command::DeleteSelected, scope: Scope::Library, menu_id: None },
+    Binding {
+        key: KeySpec::cmd('a'),
+        command: Command::SelectAll,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd_shift('f'),
+        command: Command::ToggleFavorite,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::cmd_shift('u'),
+        command: Command::ToggleRead,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::bare(Trigger::ArrowDown),
+        command: Command::SelectNext,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::bare(Trigger::ArrowUp),
+        command: Command::SelectPrev,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::bare(Trigger::Enter),
+        command: Command::OpenSelected,
+        scope: Scope::Library,
+        menu_id: None,
+    },
+    Binding {
+        key: KeySpec::bare(Trigger::Backspace),
+        command: Command::DeleteSelected,
+        scope: Scope::Library,
+        menu_id: None,
+    },
 ];
 
 /// The default (built-in) key for a command, if it has one.
@@ -399,11 +524,7 @@ pub fn rebindable_commands() -> impl Iterator<Item = Command> {
 ///
 /// Two commands conflict when their scopes overlap (either is `Global`, or they
 /// share a scope) and their effective keys match the same event.
-pub fn conflict_for(
-    command: Command,
-    key: KeySpec,
-    overrides: &Overrides,
-) -> Option<Command> {
+pub fn conflict_for(command: Command, key: KeySpec, overrides: &Overrides) -> Option<Command> {
     let target_scope = command_scope(command);
     for b in BINDINGS {
         if b.command == command {
@@ -428,14 +549,17 @@ pub fn conflict_for(
 /// A command matches if its *effective* key (override or default) matches the
 /// event and its scope is active. The default table order is preserved so that,
 /// absent overrides, resolution is identical to the built-in behavior.
-fn resolve(cmd: bool, shift: bool, key: &Key, scope: Scope, overrides: &Overrides) -> Option<Command> {
+fn resolve(
+    cmd: bool,
+    shift: bool,
+    key: &Key,
+    scope: Scope,
+    overrides: &Overrides,
+) -> Option<Command> {
     BINDINGS
         .iter()
         .filter(|b| b.scope == scope || b.scope == Scope::Global)
-        .find(|b| {
-            effective_key(b.command, overrides)
-                .is_some_and(|k| k.matches(cmd, shift, key))
-        })
+        .find(|b| effective_key(b.command, overrides).is_some_and(|k| k.matches(cmd, shift, key)))
         .map(|b| b.command)
 }
 
@@ -1003,9 +1127,7 @@ fn dispatch(cmd: Command, ctx: &KeyCtx, db: &Database) {
         Command::CheckUpdates => action_check_updates(update_state),
         Command::SelectNext => action_select_next(lib_state),
         Command::SelectPrev => action_select_prev(lib_state),
-        Command::OpenSelected => {
-            action_open_selected_pdf(lib_state, tabs, db, &config, &dpr_sig)
-        }
+        Command::OpenSelected => action_open_selected_pdf(lib_state, tabs, db, &config, &dpr_sig),
         Command::DeleteSelected => action_delete_selected(lib_state),
         Command::Escape => action_escape(show_settings, tabs, tools, lib_state),
     }

--- a/src/ui/settings/keybindings.rs
+++ b/src/ui/settings/keybindings.rs
@@ -1,0 +1,289 @@
+use dioxus::prelude::*;
+
+use crate::sync::engine::SyncConfig;
+use crate::ui::helpers::save_config;
+use crate::ui::keybindings::{
+    Command, KeySpec, Scope, command_scope, conflict_for, default_key, effective_key,
+    rebindable_commands,
+};
+
+/// A rebind that collided with an existing binding, awaiting user confirmation
+/// to swap. `key` would move from `existing_owner` to `command`.
+#[derive(Clone, Copy, PartialEq)]
+struct PendingSwap {
+    command: Command,
+    key: KeySpec,
+    existing_owner: Command,
+}
+
+/// The keybindings settings page: one row per rebindable command, each with a
+/// clickable chip that captures a new combo, plus per-row and global reset.
+#[component]
+pub fn KeybindingsSection() -> Element {
+    let mut config = use_context::<Signal<SyncConfig>>();
+
+    // Which command (if any) is currently capturing a keypress. `None` = idle.
+    let mut capturing = use_signal(|| None::<Command>);
+    // Transient message shown after a capture (e.g. "that key can't be bound").
+    let mut notice = use_signal(String::new);
+    // A conflicting rebind awaiting the user's confirm-to-swap decision.
+    let mut pending_swap = use_signal(|| None::<PendingSwap>);
+
+    let overrides = config.read().keybindings.clone();
+    let any_override = !overrides.is_empty();
+
+    // Group commands by their scope for a tidy layout.
+    let scopes = [Scope::Global, Scope::Library, Scope::Viewer];
+
+    rsx! {
+        div { class: "settings-section",
+            div { class: "settings-section-header",
+                h4 { class: "settings-section-title", "Keybindings" }
+                if any_override {
+                    button {
+                        class: "btn btn--sm",
+                        onclick: move |_| {
+                            capturing.set(None);
+                            notice.set(String::new());
+                            save_config(&mut config, |c| c.keybindings.clear());
+                        },
+                        "Reset all"
+                    }
+                }
+            }
+
+            p { class: "settings-description",
+                if capturing.read().is_some() {
+                    "Press a key combination\u{2026} (Esc to cancel)"
+                } else {
+                    "Click a shortcut to change it."
+                }
+            }
+
+            if !notice.read().is_empty() {
+                p { class: "settings-keybind-notice", "{notice}" }
+            }
+
+            for scope in scopes {
+                {
+                    let overrides = overrides.clone();
+                    let rows: Vec<Command> = rebindable_commands()
+                        .filter(|c| command_scope(*c) == scope)
+                        .collect();
+                    if rows.is_empty() {
+                        rsx! {}
+                    } else {
+                        rsx! {
+                            div { class: "settings-keybind-group",
+                                span { class: "settings-keybind-scope", "{scope.label()}" }
+                                for command in rows {
+                                    KeybindRow {
+                                        command,
+                                        overrides: overrides.clone(),
+                                        capturing,
+                                        notice,
+                                        pending_swap,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(swap) = *pending_swap.read() {
+                SwapConfirm {
+                    swap,
+                    on_cancel: move |_| pending_swap.set(None),
+                    on_confirm: move |_| {
+                        // Assign the key to the new command and unbind the old
+                        // owner. `None` marks it explicitly unbound so its default
+                        // no longer resolves (see keybindings::effective_key).
+                        let new_is_default = default_key(swap.command) == Some(swap.key);
+                        save_config(&mut config, |c| {
+                            if new_is_default {
+                                c.keybindings.remove(swap.command.id());
+                            } else {
+                                c.keybindings.insert(swap.command.id().to_string(), Some(swap.key));
+                            }
+                            c.keybindings.insert(swap.existing_owner.id().to_string(), None);
+                        });
+                        notice.set(String::new());
+                        pending_swap.set(None);
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Modal warning shown when a rebind would take a key from another command.
+#[component]
+fn SwapConfirm(
+    swap: PendingSwap,
+    on_cancel: EventHandler<()>,
+    on_confirm: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div { class: "settings-overlay settings-overlay--nested",
+            onclick: move |_| on_cancel.call(()),
+            div { class: "settings-confirm",
+                onclick: move |evt| evt.stop_propagation(),
+                h4 { class: "settings-confirm-title", "Reassign shortcut?" }
+                p { class: "settings-confirm-body",
+                    span { class: "settings-keybind-chip", "{swap.key.display()}" }
+                    " is already used by \u{201c}{swap.existing_owner.label()}\u{201d}."
+                }
+                p { class: "settings-confirm-body",
+                    "Reassign it to \u{201c}{swap.command.label()}\u{201d}? "
+                    "\u{201c}{swap.existing_owner.label()}\u{201d} will have no shortcut."
+                }
+                div { class: "settings-confirm-actions",
+                    button {
+                        class: "btn btn--sm",
+                        onclick: move |_| on_cancel.call(()),
+                        "Cancel"
+                    }
+                    button {
+                        class: "btn btn--sm btn--primary",
+                        onclick: move |_| on_confirm.call(()),
+                        "Reassign"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn KeybindRow(
+    command: Command,
+    overrides: crate::ui::keybindings::Overrides,
+    capturing: Signal<Option<Command>>,
+    notice: Signal<String>,
+    pending_swap: Signal<Option<PendingSwap>>,
+) -> Element {
+    let mut config = use_context::<Signal<SyncConfig>>();
+    let mut capturing = capturing;
+    let mut notice = notice;
+    let mut pending_swap = pending_swap;
+
+    let is_capturing = *capturing.read() == Some(command);
+    let current = effective_key(command, &overrides);
+    let is_overridden = overrides.contains_key(command.id());
+
+    let chip_label = if is_capturing {
+        "Press keys\u{2026}".to_string()
+    } else {
+        current.map(KeySpec::display).unwrap_or_else(|| "\u{2014}".to_string())
+    };
+
+    let chip_class = if is_capturing {
+        "settings-keybind-chip settings-keybind-chip--capturing"
+    } else {
+        "settings-keybind-chip"
+    };
+
+    rsx! {
+        div { class: "settings-keybind-row",
+            span { class: "settings-keybind-label", "{command.label()}" }
+            div { class: "settings-keybind-controls",
+                // A focusable div (not a <button>) so it receives raw keydowns
+                // for every key — a native button would hijack Enter/Space as an
+                // activation and never deliver them as a keydown to capture.
+                div {
+                    id: "keybind-chip-{command.id()}",
+                    class: "{chip_class}",
+                    tabindex: "0",
+                    role: "button",
+                    // Capturing rows listen for the next keydown here. The div is
+                    // focused (see onclick) so the event lands on it and is
+                    // stopped from bubbling to the global keydown handler.
+                    onkeydown: move |evt| {
+                        if *capturing.read() != Some(command) {
+                            return;
+                        }
+                        evt.stop_propagation();
+                        evt.prevent_default();
+                        let m = evt.modifiers();
+                        let cmd = m.meta() || m.ctrl();
+                        let shift = m.shift();
+                        let key = evt.key();
+
+                        // Escape cancels capture without binding.
+                        if key == Key::Escape {
+                            capturing.set(None);
+                            return;
+                        }
+                        // Ignore lone modifier presses; wait for a real key.
+                        if matches!(key, Key::Control | Key::Meta | Key::Shift | Key::Alt) {
+                            return;
+                        }
+                        match KeySpec::from_event(cmd, shift, &key) {
+                            Some(spec) => {
+                                let overrides = config.read().keybindings.clone();
+                                if let Some(other) = conflict_for(command, spec, &overrides) {
+                                    // Don't overwrite silently — ask the user to
+                                    // confirm swapping the key away from its owner.
+                                    notice.set(String::new());
+                                    pending_swap.set(Some(PendingSwap {
+                                        command,
+                                        key: spec,
+                                        existing_owner: other,
+                                    }));
+                                } else {
+                                    notice.set(String::new());
+                                    // Store as override unless it equals the default,
+                                    // in which case drop the override to keep config tidy.
+                                    let is_default = default_key(command) == Some(spec);
+                                    save_config(&mut config, |c| {
+                                        if is_default {
+                                            c.keybindings.remove(command.id());
+                                        } else {
+                                            c.keybindings.insert(command.id().to_string(), Some(spec));
+                                        }
+                                    });
+                                }
+                                capturing.set(None);
+                            }
+                            None => {
+                                notice.set("That key can\u{2019}t be bound.".to_string());
+                            }
+                        }
+                    },
+                    onclick: move |_| {
+                        notice.set(String::new());
+                        if *capturing.read() == Some(command) {
+                            capturing.set(None);
+                        } else {
+                            capturing.set(Some(command));
+                            // Ensure the chip holds focus so the next keydown is
+                            // captured here rather than by the global handler.
+                            let id = command.id();
+                            spawn(async move {
+                                let _ = document::eval(&format!(
+                                    "document.getElementById('keybind-chip-{id}')?.focus();"
+                                ));
+                            });
+                        }
+                    },
+                    "{chip_label}"
+                }
+                if is_overridden {
+                    button {
+                        class: "btn--icon settings-keybind-reset",
+                        title: "Reset to default",
+                        onclick: move |_| {
+                            notice.set(String::new());
+                            capturing.set(None);
+                            save_config(&mut config, |c| {
+                                c.keybindings.remove(command.id());
+                            });
+                        },
+                        "\u{27f2}"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/settings/keybindings.rs
+++ b/src/ui/settings/keybindings.rs
@@ -175,7 +175,9 @@ fn KeybindRow(
     let chip_label = if is_capturing {
         "Press keys\u{2026}".to_string()
     } else {
-        current.map(KeySpec::display).unwrap_or_else(|| "\u{2014}".to_string())
+        current
+            .map(KeySpec::display)
+            .unwrap_or_else(|| "\u{2014}".to_string())
     };
 
     let chip_class = if is_capturing {

--- a/src/ui/settings/mod.rs
+++ b/src/ui/settings/mod.rs
@@ -2,6 +2,7 @@ mod appearance;
 mod claude;
 mod connector;
 mod import;
+mod keybindings;
 mod pdf_viewer;
 mod sync;
 #[cfg(feature = "desktop")]
@@ -14,6 +15,7 @@ use dioxus::prelude::*;
 enum SettingsTab {
     General,
     PdfViewer,
+    Keybindings,
     AiAgent,
     Advanced,
 }
@@ -23,15 +25,17 @@ impl SettingsTab {
         match self {
             Self::General => "General",
             Self::PdfViewer => "PDF Viewer",
+            Self::Keybindings => "Keybindings",
             Self::AiAgent => "AI Agent",
             Self::Advanced => "Advanced",
         }
     }
 }
 
-const TABS: [SettingsTab; 4] = [
+const TABS: [SettingsTab; 5] = [
     SettingsTab::General,
     SettingsTab::PdfViewer,
+    SettingsTab::Keybindings,
     SettingsTab::AiAgent,
     SettingsTab::Advanced,
 ];
@@ -96,6 +100,9 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                         },
                         SettingsTab::PdfViewer => rsx! {
                             pdf_viewer::PdfViewerSection {}
+                        },
+                        SettingsTab::Keybindings => rsx! {
+                            keybindings::KeybindingsSection {}
                         },
                         SettingsTab::AiAgent => rsx! {
                             claude::AgentSection {}

--- a/src/ui/settings/mod.rs
+++ b/src/ui/settings/mod.rs
@@ -2,6 +2,8 @@ mod appearance;
 mod claude;
 mod connector;
 mod import;
+// Keybindings settings depend on `ui::keybindings`, which is desktop-only.
+#[cfg(feature = "desktop")]
 mod keybindings;
 mod pdf_viewer;
 mod sync;
@@ -15,6 +17,7 @@ use dioxus::prelude::*;
 enum SettingsTab {
     General,
     PdfViewer,
+    #[cfg(feature = "desktop")]
     Keybindings,
     AiAgent,
     Advanced,
@@ -25,6 +28,7 @@ impl SettingsTab {
         match self {
             Self::General => "General",
             Self::PdfViewer => "PDF Viewer",
+            #[cfg(feature = "desktop")]
             Self::Keybindings => "Keybindings",
             Self::AiAgent => "AI Agent",
             Self::Advanced => "Advanced",
@@ -32,9 +36,10 @@ impl SettingsTab {
     }
 }
 
-const TABS: [SettingsTab; 5] = [
+const TABS: &[SettingsTab] = &[
     SettingsTab::General,
     SettingsTab::PdfViewer,
+    #[cfg(feature = "desktop")]
     SettingsTab::Keybindings,
     SettingsTab::AiAgent,
     SettingsTab::Advanced,
@@ -80,7 +85,7 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                 }
 
                 div { class: "settings-tabs",
-                    for tab in TABS {
+                    for tab in TABS.iter().copied() {
                         button {
                             class: if *active_tab.read() == tab { "settings-tab settings-tab--active" } else { "settings-tab" },
                             onclick: move |_| active_tab.set(tab),
@@ -101,6 +106,7 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                         SettingsTab::PdfViewer => rsx! {
                             pdf_viewer::PdfViewerSection {}
                         },
+                        #[cfg(feature = "desktop")]
                         SettingsTab::Keybindings => rsx! {
                             keybindings::KeybindingsSection {}
                         },


### PR DESCRIPTION
## Summary

Adds a **Keybindings** tab to Settings where every rebindable command is listed by scope (Global / Library / PDF Viewer) with a clickable chip showing its current shortcut. Clicking a chip captures the next key combination and saves it; per-row ⟲ and **Reset all** restore defaults.

Builds on the existing `Command`/`BINDINGS` table (already on `master`) — the same table now drives the UI, the config keys, and resolution.

## What's included

- **`KeySpec` serde** — compact `"cmd+shift+z"` form; `display()` for chips (`⌘⇧Z`, `↓`); `from_event()` to capture a live keystroke (rejects lone modifiers, Escape, control chars).
- **`Command` metadata** — `id()` / `label()` / `is_rebindable()`. `Escape` (hard-wired cancel) and `CheckUpdates` (menu-only) are not user-rebindable.
- **Config storage** — `SyncConfig.keybindings`: `HashMap<command-id, Option<KeySpec>>`, `#[serde(default)]`. `Some(key)` = rebound, `None` = **explicitly unbound** (suppresses the built-in default so a swapped-away command truly loses its shortcut), absent = use default. `resolve()` consults overrides first, so with no overrides behavior is byte-for-byte the built-ins.
- **Conflict handling** — rebinding to a key already used by another command in an overlapping scope pops a confirm dialog (*"⌘F is used by 'Find'. Reassign it to 'Undo'? 'Find' will have no shortcut."*). Confirm → reassign + unbind the old owner; Cancel → no change.
- **Capture UX fix** — the chip is a focusable `div` (not a `<button>`, which hijacks Enter/Space) and stops propagation, so keystrokes are captured rather than eaten by the global keydown handler.

## Verification

- ✅ Builds clean on `origin/master` + these 7 files only (no dependency on unmerged work).
- ✅ A config mixing the **old bare-string format** (`"undo": "cmd+shift+p"`) and the **new null-unbind format** (`"find": null`) round-trips through load/save without loss or panic — backward compatible.