### PR TITLE
Nested collections in the browser extension with aggregate parent view

### DIFF
--- a/crates/rotero-connector/src/handlers.rs
+++ b/crates/rotero-connector/src/handlers.rs
@@ -45,6 +45,8 @@ pub struct StatusResponse {
 pub struct CollectionInfo {
     pub id: String,
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
 }
 
 /// JSON response for `GET /api/collections`.
@@ -79,7 +81,7 @@ pub async fn status() -> Json<StatusResponse> {
 /// Handler for `GET /api/collections`. Returns the user's collection list.
 pub async fn collections(State(state): State<Arc<ConnectorState>>) -> Json<CollectionsResponse> {
     let collections = if let Some(ref callback) = state.on_get_collections {
-        callback()
+        callback().await
     } else {
         Vec::new()
     };
@@ -89,7 +91,7 @@ pub async fn collections(State(state): State<Arc<ConnectorState>>) -> Json<Colle
 /// Handler for `GET /api/tags`. Returns the user's tag list.
 pub async fn tags(State(state): State<Arc<ConnectorState>>) -> Json<TagsResponse> {
     let tags = if let Some(ref callback) = state.on_get_tags {
-        callback()
+        callback().await
     } else {
         Vec::new()
     };
@@ -316,7 +318,7 @@ pub async fn cite_search(
     Query(query): Query<CiteSearchQuery>,
 ) -> Json<CiteSearchResponse> {
     let papers = if let Some(ref callback) = state.on_search_papers {
-        callback(&query.q)
+        callback(query.q).await
     } else {
         Vec::new()
     };
@@ -354,7 +356,7 @@ pub async fn cite_format(
     };
 
     let papers = if let Some(ref callback) = state.on_get_papers_by_ids {
-        callback(&req.paper_ids)
+        callback(req.paper_ids.clone()).await
     } else {
         Vec::new()
     };
@@ -404,7 +406,7 @@ pub async fn cite_bibliography(
     };
 
     let papers = if let Some(ref callback) = state.on_get_papers_by_ids {
-        callback(&req.paper_ids)
+        callback(req.paper_ids.clone()).await
     } else {
         Vec::new()
     };
@@ -467,7 +469,8 @@ pub async fn save_paper(
             req.collection_id,
             req.tag_ids.unwrap_or_default(),
             req.pdf_url,
-        );
+        )
+        .await;
     }
 
     Json(SavePaperResponse {

--- a/crates/rotero-connector/src/lib.rs
+++ b/crates/rotero-connector/src/lib.rs
@@ -24,10 +24,9 @@ use rotero_models::Paper;
 /// Boxed future returned by async callbacks.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-type OnPaperSavedFn =
-    dyn Fn(Paper, Option<String>, Vec<String>, Option<String>) -> BoxFuture<'static, ()>
-        + Send
-        + Sync;
+type OnPaperSavedFn = dyn Fn(Paper, Option<String>, Vec<String>, Option<String>) -> BoxFuture<'static, ()>
+    + Send
+    + Sync;
 type GetCollectionsFn = dyn Fn() -> BoxFuture<'static, Vec<CollectionInfo>> + Send + Sync;
 type GetTagsFn = dyn Fn() -> BoxFuture<'static, Vec<TagInfo>> + Send + Sync;
 type SearchPapersFn = dyn Fn(String) -> BoxFuture<'static, Vec<Paper>> + Send + Sync;

--- a/crates/rotero-connector/src/lib.rs
+++ b/crates/rotero-connector/src/lib.rs
@@ -9,6 +9,8 @@ pub mod handlers;
 /// HTML meta-tag and JSON-LD scraper for extracting paper metadata from web pages.
 pub mod scrape;
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use axum::http::{Method, header};
@@ -19,18 +21,26 @@ use tower_http::cors::{Any, CorsLayer};
 use handlers::{CollectionInfo, TagInfo};
 use rotero_models::Paper;
 
-type OnPaperSavedFn = dyn Fn(Paper, Option<String>, Vec<String>, Option<String>) + Send + Sync;
-type SearchPapersFn = dyn Fn(&str) -> Vec<Paper> + Send + Sync;
-type GetPapersByIdsFn = dyn Fn(&[String]) -> Vec<Paper> + Send + Sync;
+/// Boxed future returned by async callbacks.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+type OnPaperSavedFn =
+    dyn Fn(Paper, Option<String>, Vec<String>, Option<String>) -> BoxFuture<'static, ()>
+        + Send
+        + Sync;
+type GetCollectionsFn = dyn Fn() -> BoxFuture<'static, Vec<CollectionInfo>> + Send + Sync;
+type GetTagsFn = dyn Fn() -> BoxFuture<'static, Vec<TagInfo>> + Send + Sync;
+type SearchPapersFn = dyn Fn(String) -> BoxFuture<'static, Vec<Paper>> + Send + Sync;
+type GetPapersByIdsFn = dyn Fn(Vec<String>) -> BoxFuture<'static, Vec<Paper>> + Send + Sync;
 
 /// Shared state for the connector server, holding callbacks into the main app.
 pub struct ConnectorState {
     /// Arguments: paper, collection_id, tag_ids, pdf_url
     pub on_paper_saved: Option<Box<OnPaperSavedFn>>,
     /// Callback to retrieve the user's collections for the save dialog.
-    pub on_get_collections: Option<Box<dyn Fn() -> Vec<CollectionInfo> + Send + Sync>>,
+    pub on_get_collections: Option<Box<GetCollectionsFn>>,
     /// Callback to retrieve the user's tags for the save dialog.
-    pub on_get_tags: Option<Box<dyn Fn() -> Vec<TagInfo> + Send + Sync>>,
+    pub on_get_tags: Option<Box<GetTagsFn>>,
     /// Callback to search papers by query string.
     pub on_search_papers: Option<Box<SearchPapersFn>>,
     /// Callback to fetch papers by their IDs.

--- a/crates/rotero-connector/tests/cite_api_test.rs
+++ b/crates/rotero-connector/tests/cite_api_test.rs
@@ -10,32 +10,36 @@ fn test_state() -> Arc<ConnectorState> {
         on_paper_saved: None,
         on_get_collections: None,
         on_get_tags: None,
-        on_search_papers: Some(Box::new(|query: &str| {
-            if query.contains("attention") {
-                let mut p = Paper::new("Attention Is All You Need".to_string());
-                p.id = Some("paper-001".to_string());
-                p.authors = vec!["Vaswani".to_string()];
-                p.year = Some(2017);
-                vec![p]
-            } else {
-                Vec::new()
-            }
+        on_search_papers: Some(Box::new(|query: String| {
+            Box::pin(async move {
+                if query.contains("attention") {
+                    let mut p = Paper::new("Attention Is All You Need".to_string());
+                    p.id = Some("paper-001".to_string());
+                    p.authors = vec!["Vaswani".to_string()];
+                    p.year = Some(2017);
+                    vec![p]
+                } else {
+                    Vec::new()
+                }
+            })
         })),
-        on_get_papers_by_ids: Some(Box::new(|ids: &[String]| {
-            ids.iter()
-                .filter_map(|id| {
-                    if id == "paper-001" {
-                        let mut p = Paper::new("Attention Is All You Need".to_string());
-                        p.id = Some("paper-001".to_string());
-                        p.authors = vec!["Vaswani".to_string()];
-                        p.year = Some(2017);
-                        p.publication.journal = Some("NeurIPS".to_string());
-                        Some(p)
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+        on_get_papers_by_ids: Some(Box::new(|ids: Vec<String>| {
+            Box::pin(async move {
+                ids.iter()
+                    .filter_map(|id| {
+                        if id == "paper-001" {
+                            let mut p = Paper::new("Attention Is All You Need".to_string());
+                            p.id = Some("paper-001".to_string());
+                            p.authors = vec!["Vaswani".to_string()];
+                            p.year = Some(2017);
+                            p.publication.journal = Some("NeurIPS".to_string());
+                            Some(p)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            })
         })),
         translation_server: tokio::sync::RwLock::new(None),
     })

--- a/crates/rotero-db/src/collections.rs
+++ b/crates/rotero-db/src/collections.rs
@@ -118,6 +118,89 @@ pub async fn list_paper_ids_in_collection(
     Ok(ids)
 }
 
+/// Return all paper IDs in a collection *and all of its descendant collections*,
+/// deduplicated. Viewing a parent collection aggregates its whole subtree.
+///
+/// turso does not yet support `WITH RECURSIVE` (see COMPAT.md / tursodatabase
+/// issue #6205), so the descendant walk is done in Rust via [`descendant_ids`].
+/// When recursive CTEs land, delete `descendant_ids` and replace this body with
+/// a single query:
+///
+/// ```sql
+/// WITH RECURSIVE subtree(id) AS (
+///     SELECT id FROM collections WHERE id = ?1
+///     UNION
+///     SELECT c.id FROM collections c JOIN subtree s ON c.parent_id = s.id
+/// )
+/// SELECT DISTINCT pc.paper_id
+/// FROM paper_collections pc JOIN subtree ON pc.collection_id = subtree.id
+/// ```
+pub async fn list_paper_ids_in_subtree(
+    conn: &Connection,
+    collection_id: &str,
+) -> Result<Vec<String>, turso::Error> {
+    let subtree = descendant_ids(conn, collection_id).await?;
+    if subtree.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // SELECT DISTINCT paper_id FROM paper_collections WHERE collection_id IN (?, ?, ...)
+    let placeholders = std::iter::repeat("?")
+        .take(subtree.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT DISTINCT paper_id FROM paper_collections WHERE collection_id IN ({placeholders})"
+    );
+    let params: Vec<Value> = subtree.into_iter().map(Value::Text).collect();
+
+    let mut rows = conn
+        .query(&sql, turso::params::Params::Positional(params))
+        .await?;
+    let mut ids = Vec::new();
+    while let Some(row) = rows.next().await? {
+        if let Some(id) = row.get_value(0).ok().and_then(|v| v.as_text().cloned()) {
+            ids.push(id);
+        }
+    }
+    Ok(ids)
+}
+
+/// Collect `collection_id` and every collection transitively parented under it.
+///
+/// Workaround for turso's missing `WITH RECURSIVE`: loads the flat collection
+/// list once and walks the `parent_id` tree in memory. A `visited` set guards
+/// against parent-pointer cycles so malformed data can't loop forever.
+async fn descendant_ids(
+    conn: &Connection,
+    root: &str,
+) -> Result<Vec<String>, turso::Error> {
+    let all = list_collections(conn).await?;
+
+    // Build parent -> children adjacency.
+    let mut children: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for coll in &all {
+        if let (Some(id), Some(parent)) = (coll.id.as_ref(), coll.parent_id.as_ref()) {
+            children.entry(parent.clone()).or_default().push(id.clone());
+        }
+    }
+
+    let mut visited = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_string()];
+    while let Some(id) = stack.pop() {
+        if !visited.insert(id.clone()) {
+            continue; // already seen — skip to break any cycle
+        }
+        if let Some(kids) = children.get(&id) {
+            stack.extend(kids.iter().cloned());
+        }
+        out.push(id);
+    }
+    Ok(out)
+}
+
 /// Add a paper to a collection (idempotent via INSERT OR IGNORE).
 pub async fn add_paper_to_collection(
     conn: &Connection,

--- a/crates/rotero-db/src/collections.rs
+++ b/crates/rotero-db/src/collections.rs
@@ -145,8 +145,7 @@ pub async fn list_paper_ids_in_subtree(
     }
 
     // SELECT DISTINCT paper_id FROM paper_collections WHERE collection_id IN (?, ?, ...)
-    let placeholders = std::iter::repeat("?")
-        .take(subtree.len())
+    let placeholders = std::iter::repeat_n("?", subtree.len())
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
@@ -171,10 +170,7 @@ pub async fn list_paper_ids_in_subtree(
 /// Workaround for turso's missing `WITH RECURSIVE`: loads the flat collection
 /// list once and walks the `parent_id` tree in memory. A `visited` set guards
 /// against parent-pointer cycles so malformed data can't loop forever.
-async fn descendant_ids(
-    conn: &Connection,
-    root: &str,
-) -> Result<Vec<String>, turso::Error> {
+async fn descendant_ids(conn: &Connection, root: &str) -> Result<Vec<String>, turso::Error> {
     let all = list_collections(conn).await?;
 
     // Build parent -> children adjacency.

--- a/crates/rotero-db/tests/collection_subtree_test.rs
+++ b/crates/rotero-db/tests/collection_subtree_test.rs
@@ -1,0 +1,101 @@
+//! Verifies `list_paper_ids_in_subtree` aggregates papers across a collection
+//! and all of its descendants (the Zotero-style parent-view model), and that
+//! the recursive CTE executes correctly on turso.
+
+use rotero_db::{collections, papers, schema};
+use rotero_models::{Collection, Paper};
+
+async fn open_test_db(dir: &std::path::Path) -> rotero_db::turso::Connection {
+    std::fs::create_dir_all(dir).unwrap();
+    let db_path = dir.join("test.db");
+    let db = rotero_db::turso::Builder::new_local(&db_path.to_string_lossy())
+        .experimental_index_method(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = db.connect().unwrap();
+    schema::initialize_db(&conn).await.unwrap();
+    conn
+}
+
+async fn new_collection(
+    conn: &rotero_db::turso::Connection,
+    name: &str,
+    parent: Option<&str>,
+) -> String {
+    let mut coll = Collection::new(name.to_string());
+    coll.parent_id = parent.map(|s| s.to_string());
+    collections::insert_collection(conn, &coll).await.unwrap()
+}
+
+async fn new_paper(conn: &rotero_db::turso::Connection, title: &str) -> String {
+    papers::insert_paper(conn, &Paper::new(title.to_string()))
+        .await
+        .unwrap()
+}
+
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+#[tokio::test]
+async fn subtree_aggregates_descendants_and_dedupes() {
+    let dir = tempfile::tempdir().unwrap();
+    let conn = open_test_db(dir.path()).await;
+
+    // Tree:  ML
+    //         ├── NLP
+    //         │    └── LLM
+    //         └── Vision
+    //        Unrelated (separate root)
+    let ml = new_collection(&conn, "ML", None).await;
+    let nlp = new_collection(&conn, "NLP", Some(&ml)).await;
+    let llm = new_collection(&conn, "LLM", Some(&nlp)).await;
+    let vision = new_collection(&conn, "Vision", Some(&ml)).await;
+    let other = new_collection(&conn, "Unrelated", None).await;
+
+    let p_ml = new_paper(&conn, "directly in ML").await;
+    let p_nlp = new_paper(&conn, "in NLP").await;
+    let p_llm = new_paper(&conn, "deep in LLM").await;
+    let p_vision = new_paper(&conn, "in Vision").await;
+    let p_shared = new_paper(&conn, "in both NLP and Vision").await;
+    let p_other = new_paper(&conn, "unrelated").await;
+
+    collections::add_paper_to_collection(&conn, &p_ml, &ml).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_nlp, &nlp).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_llm, &llm).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_vision, &vision).await.unwrap();
+    // Shared paper lives in two subtree collections -> must be deduped
+    collections::add_paper_to_collection(&conn, &p_shared, &nlp).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_shared, &vision).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_other, &other).await.unwrap();
+
+    // ML: own paper + every descendant, deduped, excluding the unrelated root.
+    let got = sorted(collections::list_paper_ids_in_subtree(&conn, &ml).await.unwrap());
+    let want = sorted(vec![
+        p_ml.clone(),
+        p_nlp.clone(),
+        p_llm.clone(),
+        p_vision.clone(),
+        p_shared.clone(),
+    ]);
+    assert_eq!(got, want, "ML subtree = own + all descendant papers, deduped");
+    assert!(!got.contains(&p_other), "unrelated root's paper must be excluded");
+
+    // NLP: its own paper, the shared one, plus its LLM child — but not Vision's.
+    let nlp_got = sorted(collections::list_paper_ids_in_subtree(&conn, &nlp).await.unwrap());
+    let nlp_want = sorted(vec![p_nlp.clone(), p_llm.clone(), p_shared.clone()]);
+    assert_eq!(nlp_got, nlp_want, "NLP subtree includes LLM child but not Vision");
+    assert!(!nlp_got.contains(&p_vision), "Vision's paper must not appear under NLP");
+
+    // Vision leaf: only its two direct papers.
+    let vision_got = sorted(collections::list_paper_ids_in_subtree(&conn, &vision).await.unwrap());
+    assert_eq!(vision_got, sorted(vec![p_vision, p_shared]));
+
+    // A collection id that doesn't exist yields nothing (no panic on empty CTE seed).
+    let none = collections::list_paper_ids_in_subtree(&conn, "does-not-exist")
+        .await
+        .unwrap();
+    assert!(none.is_empty());
+}

--- a/crates/rotero-db/tests/collection_subtree_test.rs
+++ b/crates/rotero-db/tests/collection_subtree_test.rs
@@ -62,17 +62,35 @@ async fn subtree_aggregates_descendants_and_dedupes() {
     let p_shared = new_paper(&conn, "in both NLP and Vision").await;
     let p_other = new_paper(&conn, "unrelated").await;
 
-    collections::add_paper_to_collection(&conn, &p_ml, &ml).await.unwrap();
-    collections::add_paper_to_collection(&conn, &p_nlp, &nlp).await.unwrap();
-    collections::add_paper_to_collection(&conn, &p_llm, &llm).await.unwrap();
-    collections::add_paper_to_collection(&conn, &p_vision, &vision).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_ml, &ml)
+        .await
+        .unwrap();
+    collections::add_paper_to_collection(&conn, &p_nlp, &nlp)
+        .await
+        .unwrap();
+    collections::add_paper_to_collection(&conn, &p_llm, &llm)
+        .await
+        .unwrap();
+    collections::add_paper_to_collection(&conn, &p_vision, &vision)
+        .await
+        .unwrap();
     // Shared paper lives in two subtree collections -> must be deduped
-    collections::add_paper_to_collection(&conn, &p_shared, &nlp).await.unwrap();
-    collections::add_paper_to_collection(&conn, &p_shared, &vision).await.unwrap();
-    collections::add_paper_to_collection(&conn, &p_other, &other).await.unwrap();
+    collections::add_paper_to_collection(&conn, &p_shared, &nlp)
+        .await
+        .unwrap();
+    collections::add_paper_to_collection(&conn, &p_shared, &vision)
+        .await
+        .unwrap();
+    collections::add_paper_to_collection(&conn, &p_other, &other)
+        .await
+        .unwrap();
 
     // ML: own paper + every descendant, deduped, excluding the unrelated root.
-    let got = sorted(collections::list_paper_ids_in_subtree(&conn, &ml).await.unwrap());
+    let got = sorted(
+        collections::list_paper_ids_in_subtree(&conn, &ml)
+            .await
+            .unwrap(),
+    );
     let want = sorted(vec![
         p_ml.clone(),
         p_nlp.clone(),
@@ -80,17 +98,37 @@ async fn subtree_aggregates_descendants_and_dedupes() {
         p_vision.clone(),
         p_shared.clone(),
     ]);
-    assert_eq!(got, want, "ML subtree = own + all descendant papers, deduped");
-    assert!(!got.contains(&p_other), "unrelated root's paper must be excluded");
+    assert_eq!(
+        got, want,
+        "ML subtree = own + all descendant papers, deduped"
+    );
+    assert!(
+        !got.contains(&p_other),
+        "unrelated root's paper must be excluded"
+    );
 
     // NLP: its own paper, the shared one, plus its LLM child — but not Vision's.
-    let nlp_got = sorted(collections::list_paper_ids_in_subtree(&conn, &nlp).await.unwrap());
+    let nlp_got = sorted(
+        collections::list_paper_ids_in_subtree(&conn, &nlp)
+            .await
+            .unwrap(),
+    );
     let nlp_want = sorted(vec![p_nlp.clone(), p_llm.clone(), p_shared.clone()]);
-    assert_eq!(nlp_got, nlp_want, "NLP subtree includes LLM child but not Vision");
-    assert!(!nlp_got.contains(&p_vision), "Vision's paper must not appear under NLP");
+    assert_eq!(
+        nlp_got, nlp_want,
+        "NLP subtree includes LLM child but not Vision"
+    );
+    assert!(
+        !nlp_got.contains(&p_vision),
+        "Vision's paper must not appear under NLP"
+    );
 
     // Vision leaf: only its two direct papers.
-    let vision_got = sorted(collections::list_paper_ids_in_subtree(&conn, &vision).await.unwrap());
+    let vision_got = sorted(
+        collections::list_paper_ids_in_subtree(&conn, &vision)
+            .await
+            .unwrap(),
+    );
     assert_eq!(vision_got, sorted(vec![p_vision, p_shared]));
 
     // A collection id that doesn't exist yields nothing (no panic on empty CTE seed).

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -96,7 +96,7 @@ pub const COLLECTION_REPARENT: &str = "UPDATE collections SET parent_id = ?1 WHE
 /// Delete a collection by ID.
 pub const COLLECTION_DELETE: &str = "DELETE FROM collections WHERE id = ?1";
 
-/// List paper IDs belonging to a collection.
+/// List paper IDs belonging directly to a single collection.
 pub const COLLECTION_PAPER_IDS: &str =
     "SELECT paper_id FROM paper_collections WHERE collection_id = ?1";
 /// Add a paper to a collection (idempotent).

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Save papers to Rotero from your browser",
   "permissions": ["activeTab", "scripting"],
+  "host_permissions": ["http://127.0.0.1:21984/*"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -19,8 +19,16 @@
     .paper-doi { font-size: 11px; color: #999; }
 
     .field-section { margin-bottom: 12px; }
-    .field-label { font-size: 12px; font-weight: 500; color: #666; margin-bottom: 4px; }
-    .field-select { width: 100%; padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 13px; background: white; color: #1a1a1a; }
+    .field-label { font-size: 12px; font-weight: 500; color: #64748b; margin-bottom: 6px; }
+
+    /* Collection list — matches the main app's sidebar collection rows */
+    .coll-list { max-height: 180px; overflow-y: auto; display: flex; flex-direction: column; gap: 1px; }
+    .coll-item { height: 32px; padding: 0 12px; display: flex; align-items: center; gap: 8px; cursor: pointer; border-radius: 6px; font-size: 14px; color: #334155; transition: background 0.15s, color 0.15s; user-select: none; }
+    .coll-item:hover { background: #f1f5f9; color: #0f172a; }
+    .coll-item.selected { background: #e2e8f0; color: #0f172a; font-weight: 500; }
+    .coll-item .coll-icon { flex-shrink: 0; color: #64748b; }
+    .coll-item.selected .coll-icon { color: #0d9488; }
+    .coll-item .coll-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
     .tag-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 28px; }
     .tag-chip { display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 12px; font-size: 12px; cursor: pointer; border: 1.5px solid #d1d5db; background: white; color: #555; transition: all 0.15s; user-select: none; }
@@ -59,9 +67,7 @@
 
     <div class="field-section">
       <div class="field-label">Collection</div>
-      <select id="folderSelect" class="field-select">
-        <option value="">Library (no collection)</option>
-      </select>
+      <div id="collList" class="coll-list"></div>
     </div>
 
     <div class="field-section" id="tagsSection" style="display:none;">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -6,7 +6,7 @@ const main = document.getElementById('main');
 const paperTitle = document.getElementById('paperTitle');
 const paperAuthors = document.getElementById('paperAuthors');
 const paperDoi = document.getElementById('paperDoi');
-const folderSelect = document.getElementById('folderSelect');
+const collList = document.getElementById('collList');
 const tagsSection = document.getElementById('tagsSection');
 const tagChips = document.getElementById('tagChips');
 const addBtn = document.getElementById('addBtn');
@@ -14,6 +14,14 @@ const result = document.getElementById('result');
 
 let pageMetadata = null;
 let selectedTagIds = new Set();
+let selectedCollectionId = null; // null = Library (no collection)
+let selectedCollectionName = 'Library';
+
+// Bootstrap-icon-style folder glyphs as inline SVG (extension has no icon font)
+const ICON_FOLDER = '<svg class="coll-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zM2.19 4a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 14.81 4z"/></svg>';
+const ICON_FOLDER_FILL = '<svg class="coll-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31L.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3m-8.322.12q.322-.119.684-.12h5.396l-.707-.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981z"/></svg>';
+const ICON_FOLDER_OPEN = '<svg class="coll-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.828 4a3 3 0 0 1-2.12-.879l-.83-.828A1 1 0 0 0 6.173 2H2.5a1 1 0 0 0-1 .981L1.546 4zm-8.322.12C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981zM0 5c0-.552.446-1 .996-1h14.008A1 1 0 0 1 16 5.19l-.637 7A1.5 1.5 0 0 1 13.87 13.5H2.13A1.5 1.5 0 0 1 .637 12.19z"/></svg>';
+const ICON_LIBRARY = '<svg class="coll-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6zm1.5.5A.5.5 0 0 1 1 13V6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5z"/></svg>';
 
 // Check connection and load collections + tags
 async function init() {
@@ -33,18 +41,92 @@ async function init() {
   disconnected.style.display = 'block';
 }
 
-// Fetch collections from Rotero
+// Fetch collections from Rotero and render as a nested folder tree
 async function loadCollections() {
+  let collections = [];
   try {
     const resp = await fetch(`${API}/api/collections`);
     const data = await resp.json();
-    for (const coll of data.collections) {
-      const opt = document.createElement('option');
-      opt.value = coll.id;
-      opt.textContent = coll.name;
-      folderSelect.appendChild(opt);
+    collections = data.collections || [];
+  } catch {
+    return;
+  }
+
+  // Group by parent for tree traversal
+  const childrenOf = new Map();
+  for (const c of collections) {
+    const key = c.parent_id || null;
+    if (!childrenOf.has(key)) childrenOf.set(key, []);
+    childrenOf.get(key).push(c);
+  }
+
+  collList.innerHTML = '';
+
+  // "Library (no collection)" root row
+  collList.appendChild(makeCollRow(null, 'Library (no collection)', 0, false));
+
+  const seen = new Set();
+  const renderLevel = (parentId, depth) => {
+    const kids = childrenOf.get(parentId) || [];
+    for (const c of kids) {
+      if (seen.has(c.id)) continue; // guard against cycles
+      seen.add(c.id);
+      const hasChildren = (childrenOf.get(c.id) || []).length > 0;
+      collList.appendChild(makeCollRow(c.id, c.name, depth, hasChildren));
+      renderLevel(c.id, depth + 1);
     }
-  } catch {}
+  };
+  renderLevel(null, 0);
+
+  // Select the Library row by default
+  selectCollection(null, 'Library');
+}
+
+function makeCollRow(id, name, depth, hasChildren) {
+  const key = id === null ? '' : id;
+  const row = document.createElement('div');
+  row.className = 'coll-item';
+  row.dataset.collId = key;
+  row.dataset.hasChildren = hasChildren ? '1' : '';
+  row.style.paddingLeft = `${12 + depth * 16}px`;
+
+  const iconSvg = id === null
+    ? ICON_LIBRARY
+    : (hasChildren ? ICON_FOLDER_FILL : ICON_FOLDER);
+  row.innerHTML = iconSvg + `<span class="coll-name">${escapeHtml(name)}</span>`;
+
+  row.addEventListener('click', () => selectCollection(id, name));
+  return row;
+}
+
+function selectCollection(id, name) {
+  selectedCollectionId = id;
+  selectedCollectionName = id === null ? 'Library' : name;
+
+  const key = id === null ? '' : id;
+  for (const row of collList.querySelectorAll('.coll-item')) {
+    const isSel = row.dataset.collId === key;
+    row.classList.toggle('selected', isSel);
+    // Active collections with children show the "open folder" glyph
+    if (row.dataset.hasChildren) {
+      const svg = row.querySelector('.coll-icon');
+      if (svg) svg.outerHTML = isSel ? ICON_FOLDER_OPEN : ICON_FOLDER_FILL;
+    }
+  }
+
+  updateAddBtnLabel();
+}
+
+function updateAddBtnLabel() {
+  addBtn.textContent = selectedCollectionId
+    ? `Add to "${selectedCollectionName}"`
+    : 'Add to Library';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
 }
 
 // Fetch tags from Rotero
@@ -71,7 +153,7 @@ async function loadTags() {
       chip.appendChild(label);
 
       chip.addEventListener('click', () => {
-        const id = parseInt(chip.dataset.tagId);
+        const id = chip.dataset.tagId;
         if (selectedTagIds.has(id)) {
           selectedTagIds.delete(id);
           chip.classList.remove('selected');
@@ -342,14 +424,6 @@ function extractMetadata() {
   return meta;
 }
 
-// Update button text based on folder selection
-folderSelect.addEventListener('change', () => {
-  const selected = folderSelect.options[folderSelect.selectedIndex];
-  addBtn.textContent = folderSelect.value
-    ? `Add to "${selected.textContent}"`
-    : 'Add to Library';
-});
-
 // Save paper
 addBtn.addEventListener('click', async () => {
   if (!pageMetadata) return;
@@ -358,10 +432,8 @@ addBtn.addEventListener('click', async () => {
   addBtn.textContent = 'Adding...';
   result.style.display = 'none';
 
-  const collectionId = folderSelect.value ? parseInt(folderSelect.value) : null;
-  const selectedName = folderSelect.value
-    ? folderSelect.options[folderSelect.selectedIndex].textContent
-    : 'Library';
+  const collectionId = selectedCollectionId;
+  const selectedName = selectedCollectionName;
 
   try {
     const resp = await fetch(`${API}/api/save`, {
@@ -391,10 +463,7 @@ addBtn.addEventListener('click', async () => {
   }
 
   addBtn.disabled = false;
-  const selected = folderSelect.options[folderSelect.selectedIndex];
-  addBtn.textContent = folderSelect.value
-    ? `Add to "${selected.textContent}"`
-    : 'Add to Library';
+  updateAddBtnLabel();
 });
 
 init();

--- a/src/app/library_loader.rs
+++ b/src/app/library_loader.rs
@@ -177,7 +177,7 @@ pub fn LoadLibraryData() -> Element {
                 match view {
                     LibraryView::Collection(coll_id) => {
                         if let Ok(ids) =
-                            rotero_db::collections::list_paper_ids_in_collection(conn, &coll_id)
+                            rotero_db::collections::list_paper_ids_in_subtree(conn, &coll_id)
                                 .await
                         {
                             lib_state.with_mut(|s| s.filter.collection_paper_ids = Some(ids));

--- a/src/app/library_loader.rs
+++ b/src/app/library_loader.rs
@@ -177,8 +177,7 @@ pub fn LoadLibraryData() -> Element {
                 match view {
                     LibraryView::Collection(coll_id) => {
                         if let Ok(ids) =
-                            rotero_db::collections::list_paper_ids_in_subtree(conn, &coll_id)
-                                .await
+                            rotero_db::collections::list_paper_ids_in_subtree(conn, &coll_id).await
                         {
                             lib_state.with_mut(|s| s.filter.collection_paper_ids = Some(ids));
                         }

--- a/src/init/connector.rs
+++ b/src/init/connector.rs
@@ -63,13 +63,24 @@ pub(crate) fn start_connector(config: &crate::sync::engine::SyncConfig) {
                                 match rotero_db::papers::insert_paper(&conn, &paper).await {
                                     Ok(paper_id) => {
                                         if let Some(ref coll_id) = collection_id {
-                                            let _ = rotero_db::collections::add_paper_to_collection(&conn, &paper_id, coll_id).await;
+                                            let _ =
+                                                rotero_db::collections::add_paper_to_collection(
+                                                    &conn, &paper_id, coll_id,
+                                                )
+                                                .await;
                                         }
                                         for tag_id in &tag_ids {
-                                            let _ = rotero_db::tags::add_tag_to_paper(&conn, &paper_id, tag_id).await;
+                                            let _ = rotero_db::tags::add_tag_to_paper(
+                                                &conn, &paper_id, tag_id,
+                                            )
+                                            .await;
                                         }
                                         let _ = connector_tx.send(());
-                                        tracing::info!("Connector saved paper id={}: {}", paper_id, paper.title);
+                                        tracing::info!(
+                                            "Connector saved paper id={}: {}",
+                                            paper_id,
+                                            paper.title
+                                        );
 
                                         let paper_id_enrich = paper_id.clone();
                                         if let Some(pdf_url) = pdf_url {
@@ -87,7 +98,10 @@ pub(crate) fn start_connector(config: &crate::sync::engine::SyncConfig) {
                                                 )
                                                 .await
                                                 {
-                                                    tracing::error!("PDF download failed for paper id={}: {e}", paper_id);
+                                                    tracing::error!(
+                                                        "PDF download failed for paper id={}: {e}",
+                                                        paper_id
+                                                    );
                                                 } else {
                                                     let _ = connector_tx_pdf.send(());
                                                 }
@@ -97,11 +111,21 @@ pub(crate) fn start_connector(config: &crate::sync::engine::SyncConfig) {
                                         let conn_enrich = conn.clone();
                                         let connector_tx_enrich = connector_tx.clone();
                                         tokio::spawn(async move {
-                                            if let Some(enriched) = crate::metadata::enrich::enrich_paper(&paper).await
-                                                && rotero_db::papers::update_paper_metadata(&conn_enrich, &paper_id_enrich, &enriched).await.is_ok()
+                                            if let Some(enriched) =
+                                                crate::metadata::enrich::enrich_paper(&paper).await
+                                                && rotero_db::papers::update_paper_metadata(
+                                                    &conn_enrich,
+                                                    &paper_id_enrich,
+                                                    &enriched,
+                                                )
+                                                .await
+                                                .is_ok()
                                             {
                                                 let _ = connector_tx_enrich.send(());
-                                                tracing::info!("Connector enriched metadata for paper id={}", paper_id_enrich);
+                                                tracing::info!(
+                                                    "Connector enriched metadata for paper id={}",
+                                                    paper_id_enrich
+                                                );
                                             }
                                         });
                                     }

--- a/src/init/connector.rs
+++ b/src/init/connector.rs
@@ -55,124 +55,113 @@ pub(crate) fn start_connector(config: &crate::sync::engine::SyncConfig) {
                             let conn = conn_save.clone();
                             let connector_tx = connector_tx.clone();
                             let lib_path = lib_path.clone();
-                            tokio::task::block_in_place(|| {
-                                tokio::runtime::Handle::current().block_on(async {
-                                    let mut paper = paper;
-                                    if let Some(ref url) = pdf_url {
-                                        paper.links.pdf_url = Some(url.clone());
-                                    }
-                                    match rotero_db::papers::insert_paper(&conn, &paper).await {
-                                        Ok(paper_id) => {
-                                            if let Some(ref coll_id) = collection_id {
-                                                let _ = rotero_db::collections::add_paper_to_collection(&conn, &paper_id, coll_id).await;
-                                            }
-                                            for tag_id in &tag_ids {
-                                                let _ = rotero_db::tags::add_tag_to_paper(&conn, &paper_id, tag_id).await;
-                                            }
-                                            let _ = connector_tx.send(());
-                                            tracing::info!("Connector saved paper id={}: {}", paper_id, paper.title);
+                            Box::pin(async move {
+                                let mut paper = paper;
+                                if let Some(ref url) = pdf_url {
+                                    paper.links.pdf_url = Some(url.clone());
+                                }
+                                match rotero_db::papers::insert_paper(&conn, &paper).await {
+                                    Ok(paper_id) => {
+                                        if let Some(ref coll_id) = collection_id {
+                                            let _ = rotero_db::collections::add_paper_to_collection(&conn, &paper_id, coll_id).await;
+                                        }
+                                        for tag_id in &tag_ids {
+                                            let _ = rotero_db::tags::add_tag_to_paper(&conn, &paper_id, tag_id).await;
+                                        }
+                                        let _ = connector_tx.send(());
+                                        tracing::info!("Connector saved paper id={}: {}", paper_id, paper.title);
 
-                                            let paper_id_enrich = paper_id.clone();
-                                            if let Some(pdf_url) = pdf_url {
-                                                let conn_pdf = conn.clone();
-                                                let connector_tx_pdf = connector_tx.clone();
-                                                let paper_clone = paper.clone();
-                                                let lib_path = lib_path.clone();
-                                                tokio::spawn(async move {
-                                                    if let Err(e) = download_and_import_pdf(
-                                                        &conn_pdf,
-                                                        &lib_path,
-                                                        &paper_id,
-                                                        &paper_clone,
-                                                        &pdf_url,
-                                                    )
-                                                    .await
-                                                    {
-                                                        tracing::error!("PDF download failed for paper id={}: {e}", paper_id);
-                                                    } else {
-                                                        let _ = connector_tx_pdf.send(());
-                                                    }
-                                                });
-                                            }
-
-                                            let conn_enrich = conn.clone();
-                                            let connector_tx_enrich = connector_tx.clone();
+                                        let paper_id_enrich = paper_id.clone();
+                                        if let Some(pdf_url) = pdf_url {
+                                            let conn_pdf = conn.clone();
+                                            let connector_tx_pdf = connector_tx.clone();
+                                            let paper_clone = paper.clone();
+                                            let lib_path = lib_path.clone();
                                             tokio::spawn(async move {
-                                                if let Some(enriched) = crate::metadata::enrich::enrich_paper(&paper).await
-                                                    && rotero_db::papers::update_paper_metadata(&conn_enrich, &paper_id_enrich, &enriched).await.is_ok()
+                                                if let Err(e) = download_and_import_pdf(
+                                                    &conn_pdf,
+                                                    &lib_path,
+                                                    &paper_id,
+                                                    &paper_clone,
+                                                    &pdf_url,
+                                                )
+                                                .await
                                                 {
-                                                    let _ = connector_tx_enrich.send(());
-                                                    tracing::info!("Connector enriched metadata for paper id={}", paper_id_enrich);
+                                                    tracing::error!("PDF download failed for paper id={}: {e}", paper_id);
+                                                } else {
+                                                    let _ = connector_tx_pdf.send(());
                                                 }
                                             });
                                         }
-                                        Err(e) => {
-                                            tracing::error!("Connector failed to save paper: {e}");
-                                        }
+
+                                        let conn_enrich = conn.clone();
+                                        let connector_tx_enrich = connector_tx.clone();
+                                        tokio::spawn(async move {
+                                            if let Some(enriched) = crate::metadata::enrich::enrich_paper(&paper).await
+                                                && rotero_db::papers::update_paper_metadata(&conn_enrich, &paper_id_enrich, &enriched).await.is_ok()
+                                            {
+                                                let _ = connector_tx_enrich.send(());
+                                                tracing::info!("Connector enriched metadata for paper id={}", paper_id_enrich);
+                                            }
+                                        });
                                     }
-                                })
-                            });
+                                    Err(e) => {
+                                        tracing::error!("Connector failed to save paper: {e}");
+                                    }
+                                }
+                            })
                         }
                     })),
                     on_get_collections: Some(Box::new(move || {
                         let conn = conn_collections.clone();
-                        tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(async {
-                                match rotero_db::collections::list_collections(&conn).await {
-                                    Ok(colls) => colls
-                                        .into_iter()
-                                        .filter_map(|c| {
-                                            Some(rotero_connector::handlers::CollectionInfo {
-                                                id: c.id.clone()?,
-                                                name: c.name,
-                                            })
+                        Box::pin(async move {
+                            match rotero_db::collections::list_collections(&conn).await {
+                                Ok(colls) => colls
+                                    .into_iter()
+                                    .filter_map(|c| {
+                                        Some(rotero_connector::handlers::CollectionInfo {
+                                            id: c.id.clone()?,
+                                            name: c.name,
+                                            parent_id: c.parent_id,
                                         })
-                                        .collect(),
-                                    Err(_) => Vec::new(),
-                                }
-                            })
+                                    })
+                                    .collect(),
+                                Err(_) => Vec::new(),
+                            }
                         })
                     })),
                     on_get_tags: Some(Box::new(move || {
                         let conn = conn_tags.clone();
-                        tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(async {
-                                match rotero_db::tags::list_tags(&conn).await {
-                                    Ok(tags) => tags
-                                        .into_iter()
-                                        .filter_map(|t| {
-                                            Some(rotero_connector::handlers::TagInfo {
-                                                id: t.id.clone()?,
-                                                name: t.name,
-                                                color: t.color,
-                                            })
+                        Box::pin(async move {
+                            match rotero_db::tags::list_tags(&conn).await {
+                                Ok(tags) => tags
+                                    .into_iter()
+                                    .filter_map(|t| {
+                                        Some(rotero_connector::handlers::TagInfo {
+                                            id: t.id.clone()?,
+                                            name: t.name,
+                                            color: t.color,
                                         })
-                                        .collect(),
-                                    Err(_) => Vec::new(),
-                                }
-                            })
+                                    })
+                                    .collect(),
+                                Err(_) => Vec::new(),
+                            }
                         })
                     })),
-                    on_search_papers: Some(Box::new(move |query: &str| {
+                    on_search_papers: Some(Box::new(move |query: String| {
                         let conn = conn_search.clone();
-                        let query = query.to_string();
-                        tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(async {
-                                rotero_db::papers::search_papers(&conn, &query)
-                                    .await
-                                    .unwrap_or_default()
-                            })
+                        Box::pin(async move {
+                            rotero_db::papers::search_papers(&conn, &query)
+                                .await
+                                .unwrap_or_default()
                         })
                     })),
-                    on_get_papers_by_ids: Some(Box::new(move |ids: &[String]| {
+                    on_get_papers_by_ids: Some(Box::new(move |ids: Vec<String>| {
                         let conn = conn_get_by_ids.clone();
-                        let ids = ids.to_vec();
-                        tokio::task::block_in_place(|| {
-                            tokio::runtime::Handle::current().block_on(async {
-                                rotero_db::papers::get_papers_by_ids(&conn, &ids)
-                                    .await
-                                    .unwrap_or_default()
-                            })
+                        Box::pin(async move {
+                            rotero_db::papers::get_papers_by_ids(&conn, &ids)
+                                .await
+                                .unwrap_or_default()
                         })
                     })),
                     translation_server: tokio::sync::RwLock::new(None),

--- a/src/ui/library/context_menu.rs
+++ b/src/ui/library/context_menu.rs
@@ -330,7 +330,7 @@ pub fn PaperContextMenu(
                                     for pid in &pids {
                                         let _ = rotero_db::collections::remove_paper_from_collection(db.conn(), pid, &cid).await;
                                     }
-                                    if let Ok(ids) = rotero_db::collections::list_paper_ids_in_collection(db.conn(), &cid).await {
+                                    if let Ok(ids) = rotero_db::collections::list_paper_ids_in_subtree(db.conn(), &cid).await {
                                         lib_state.with_mut(|s| s.filter.collection_paper_ids = Some(ids));
                                     }
                                 });

--- a/src/ui/library/panel.rs
+++ b/src/ui/library/panel.rs
@@ -45,7 +45,7 @@ pub fn LibraryPanel() -> Element {
                 LibraryView::Collection(coll_id) => {
                     let db = db_coll.clone();
                     spawn(async move {
-                        match rotero_db::collections::list_paper_ids_in_collection(
+                        match rotero_db::collections::list_paper_ids_in_subtree(
                             db.conn(),
                             &coll_id,
                         )

--- a/src/ui/library/panel.rs
+++ b/src/ui/library/panel.rs
@@ -45,11 +45,8 @@ pub fn LibraryPanel() -> Element {
                 LibraryView::Collection(coll_id) => {
                     let db = db_coll.clone();
                     spawn(async move {
-                        match rotero_db::collections::list_paper_ids_in_subtree(
-                            db.conn(),
-                            &coll_id,
-                        )
-                        .await
+                        match rotero_db::collections::list_paper_ids_in_subtree(db.conn(), &coll_id)
+                            .await
                         {
                             Ok(ids) => {
                                 lib_state.with_mut(|s| s.filter.collection_paper_ids = Some(ids));

--- a/src/ui/sidebar/collections.rs
+++ b/src/ui/sidebar/collections.rs
@@ -101,7 +101,8 @@ pub(crate) fn CollectionTree(
                         ondragstart: move |_| {
                             drag_coll.set(Some(cid_drag.clone()));
                         },
-                        ondragenter: move |_| {
+                        ondragenter: move |evt: Event<DragData>| {
+                            evt.prevent_default();
                             drop_hover.set(Some(format!("coll-{}", cid_enter)));
                         },
                         ondragleave: move |_| {
@@ -141,7 +142,7 @@ pub(crate) fn CollectionTree(
                                     }
                                     let current_view = lib_state.read().view.clone();
                                     if current_view == LibraryView::Collection(target.clone())
-                                        && let Ok(ids) = rotero_db::collections::list_paper_ids_in_collection(db.conn(), &target).await {
+                                        && let Ok(ids) = rotero_db::collections::list_paper_ids_in_subtree(db.conn(), &target).await {
                                             lib_state.with_mut(|s| s.filter.collection_paper_ids = Some(ids));
                                         }
                                 });
@@ -212,8 +213,11 @@ pub(crate) fn NewCollectionRow(parent_id: Option<String>, depth: u32) -> Element
                 placeholder: "Collection name",
                 value: "{name_value}",
                 oninput: move |evt| name_value.set(evt.value()),
-                onmounted: move |evt| { drop(evt.set_focus(true)); },
+                onmounted: move |evt| async move {
+                    let _ = evt.set_focus(true).await;
+                },
                 onkeydown: move |evt| {
+                    evt.stop_propagation();
                     match evt.key() {
                         Key::Enter => {
                             let name = name_value().trim().to_string();


### PR DESCRIPTION
## What

Makes the browser extension's collection picker match the main app's sidebar and support the folder hierarchy, and makes viewing a parent collection show its whole subtree of papers.

## Changes

**Connector**
- Send `parent_id` with each collection so the extension can render the tree.
- Wrap the get-collections / get-tags callbacks in the async `BoxFuture` form used by the other handlers; add `host_permissions` so the popup can reach the local server.

**Extension popup**
- Replace the flat `<select>` with a nested, indented folder-row list styled like the app sidebar (folder icons, hover/selected states). Every collection is selectable — no chevron/collapse.

**App — aggregate parent view**
- Viewing a collection now aggregates papers from it **and every descendant**, deduplicated (Zotero-style). Parents still hold papers directly, so nesting under a non-empty collection is always safe.
- turso lacks `WITH RECURSIVE` (COMPAT.md / tursodatabase#6205), so `descendant_ids` walks the `parent_id` tree in Rust with a cycle guard, then a dynamic `IN` query gathers the papers. `list_paper_ids_in_subtree` is the single swap point for a recursive CTE once turso supports it (the CTE is kept in a doc comment).

## Testing

`collection_subtree_test` proves aggregation, dedup, nested children, leaf, and missing-id cases against the real turso engine. Full workspace compiles; test passes.