### PR TITLE
Redesign settings modal: stable size, left tab rail, reorganized tabs

### DIFF
--- a/assets/dialogs.css
+++ b/assets/dialogs.css
@@ -66,22 +66,33 @@
 
 /* === Settings Dialog === */
 .settings-dialog {
-  width: 500px;
+  width: clamp(560px, 60vw, 860px);
+  height: clamp(440px, 70vh, 680px);
   display: flex;
   flex-direction: column;
-  overflow-y: hidden;
+  overflow: hidden;
+}
+
+.settings-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: var(--space-4);
 }
 
 .settings-tabs {
   display: flex;
+  flex-direction: column;
   gap: var(--space-1);
-  margin-bottom: var(--space-4);
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: var(--space-2);
+  flex-shrink: 0;
+  width: 160px;
+  border-right: 1px solid var(--border-subtle);
+  padding-right: var(--space-3);
 }
 
 .settings-tab {
-  flex: 1;
+  text-align: left;
+  width: 100%;
   padding: var(--space-1_5) var(--space-2);
   border: none;
   background: transparent;

--- a/src/ui/settings/mod.rs
+++ b/src/ui/settings/mod.rs
@@ -20,7 +20,8 @@ enum SettingsTab {
     #[cfg(feature = "desktop")]
     Keybindings,
     AiAgent,
-    Advanced,
+    Connector,
+    About,
 }
 
 impl SettingsTab {
@@ -31,7 +32,8 @@ impl SettingsTab {
             #[cfg(feature = "desktop")]
             Self::Keybindings => "Keybindings",
             Self::AiAgent => "AI Agent",
-            Self::Advanced => "Advanced",
+            Self::Connector => "Connector",
+            Self::About => "About",
         }
     }
 }
@@ -42,7 +44,8 @@ const TABS: &[SettingsTab] = &[
     #[cfg(feature = "desktop")]
     SettingsTab::Keybindings,
     SettingsTab::AiAgent,
-    SettingsTab::Advanced,
+    SettingsTab::Connector,
+    SettingsTab::About,
 ];
 
 #[component]
@@ -84,6 +87,8 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                     }
                 }
 
+                div { class: "settings-body",
+
                 div { class: "settings-tabs",
                     for tab in TABS.iter().copied() {
                         button {
@@ -113,9 +118,10 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                         SettingsTab::AiAgent => rsx! {
                             claude::AgentSection {}
                         },
-                        SettingsTab::Advanced => rsx! {
+                        SettingsTab::Connector => rsx! {
                             connector::ConnectorSection {}
-                            div { class: "settings-divider" }
+                        },
+                        SettingsTab::About => rsx! {
                             {update_settings_element()}
                             div { class: "settings-section",
                                 h4 { class: "settings-section-title", "About" }
@@ -125,6 +131,7 @@ fn SettingsPanel(on_close: EventHandler<()>) -> Element {
                             }
                         },
                     }
+                }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Reworks the Settings modal to feel more like a modern app (Obsidian/VSCode style) and cleans up the catch-all Advanced tab.

- **Stable size across tabs.** The dialog was fixed-width but content-height, so it grew/shrank when switching tabs. It's now sized relative to the window with min/max caps (`clamp` on width and height); content scrolls internally instead of resizing the modal.
- **Left tab rail.** Tabs moved from a horizontal top bar to a full-height vertical rail on the left, with the header spanning the top and content on the right.
- **Advanced tab split.** The old "Advanced" grab-bag is gone. Browser Connector now has its own **Connector** tab; Updates and the version string live under a new **About** tab.

New tab order: General · PDF Viewer · Keybindings · AI Agent · Connector · About.

## Files
- `assets/dialogs.css` — clamped relative sizing on `.settings-dialog`, new `.settings-body` row container, vertical `.settings-tabs` rail, left-aligned `.settings-tab`.
- `src/ui/settings/mod.rs` — `.settings-body` wrapper; `SettingsTab` enum/labels/`TABS` updated; Advanced match arm split into Connector + About.

## Testing
- `cargo check -p rotero --features desktop` and default build both pass.
- Ran the app: verified the left rail, that the dialog holds its size across all tabs (long tabs scroll internally), window-resize stays within caps, and close/click-outside still work.