### PR TITLE
Unified library search: one ranked bar, web overview, robust import, resizable detail

### DIFF
--- a/assets/components.css
+++ b/assets/components.css
@@ -87,81 +87,46 @@
   color: var(--text-primary);
 }
 
-/* --- Search Source Dropdown --- */
-.search-source-wrapper {
-  position: relative;
+/* --- Unified Search Sections --- */
+.search-scroll {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
-.search-source-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-main);
-  color: var(--text-secondary);
+/* Inside a search section the outer .search-scroll owns scrolling, so the
+   per-section lists grow to their content height instead of each becoming
+   their own scroll area. */
+.search-scroll .library-list {
+  flex: none;
+  overflow-y: visible;
+}
+
+.search-section:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+
+.search-section-title {
+  margin: 0;
+  padding: 10px 16px 6px;
   font-size: var(--text-xs);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: border-color var(--transition-fast), color var(--transition-fast);
-}
-
-.search-source-btn:hover {
-  border-color: var(--text-tertiary);
-  color: var(--text-primary);
-}
-
-.search-source-btn--active {
-  border-color: var(--accent);
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 8%, var(--bg-main));
-}
-
-.search-source-chevron {
-  font-size: 10px;
-}
-
-.search-source-dropdown {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 4px;
-  background: var(--bg-main);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
-  z-index: 100;
-  min-width: 160px;
-  overflow: hidden;
-}
-
-.search-source-option {
-  display: block;
-  width: 100%;
-  padding: 8px 14px;
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-  text-align: left;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-}
-
-.search-source-option:hover {
-  background: var(--bg-muted);
-}
-
-.search-source-option--active {
-  color: var(--accent);
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
 }
 
-.search-source-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 99;
+.search-section-empty,
+.external-provider-empty {
+  padding: 6px 16px 10px;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+.search-section-spinner {
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
 }
 
 /* --- Search + Sort Row --- */

--- a/assets/components.css
+++ b/assets/components.css
@@ -307,9 +307,32 @@
   opacity: 0.7;
 }
 
+.external-result-card--selected {
+  background: rgba(13, 148, 136, 0.06);
+}
+
+.external-result-card--selected:hover {
+  background: rgba(13, 148, 136, 0.09);
+}
+
 .external-result-card--imported {
   opacity: 0.55;
   border-left-color: var(--text-tertiary);
+}
+
+/* "From the web" tag on the read-only web-result preview panel. */
+.detail-web-badge {
+  align-self: flex-start;
+  margin: 0 var(--space-4) var(--space-2);
+  padding: 2px var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--border));
+  border-radius: var(--radius-sm);
 }
 
 .external-imported-btn {

--- a/assets/components.css
+++ b/assets/components.css
@@ -322,17 +322,31 @@
 
 /* "From the web" tag on the read-only web-result preview panel. */
 .detail-web-badge {
-  align-self: flex-start;
-  margin: 0 var(--space-4) var(--space-2);
-  padding: 2px var(--space-2);
-  font-size: var(--text-xs);
+  /* Hug the text so it reads as a compact chip; a plain block child of the
+     (non-flex) detail body would otherwise stretch full-width and look like a
+     flat bar. */
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  margin: 0 0 var(--space-3);
+  padding: 3px var(--space-2);
+  font-size: 10px;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--border));
-  border-radius: var(--radius-sm);
+  border-radius: 999px;
+}
+
+.detail-web-badge::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
 }
 
 .external-imported-btn {

--- a/assets/detail.css
+++ b/assets/detail.css
@@ -7,13 +7,23 @@
   width: 360px;
   min-width: 280px;
   max-width: 600px;
-  padding: var(--space-6);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
   font-size: var(--text-base);
   background: var(--bg-surface);
   border-left: 1px solid var(--border);
   position: relative;
+  overflow: hidden;
+}
+
+/* Scrolls independently of the resize handle, which is pinned as a sibling so
+   it covers the full panel height even when the content overflows. */
+.paper-detail-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-6);
 }
 
 .detail-header {

--- a/crates/rotero-db/src/papers.rs
+++ b/crates/rotero-db/src/papers.rs
@@ -484,8 +484,15 @@ async fn search_papers_fts(
     conn: &turso::Connection,
     query: &str,
 ) -> Result<Vec<Paper>, crate::DbError> {
+    // Require every query token (AND) rather than any (turso's bare-token OR
+    // default), so common words like "a" don't match the whole library and let
+    // BM25 surface an unrelated high-frequency document.
+    let match_query = rotero_models::build_fts_match_query(query);
+    if match_query.is_empty() {
+        return Ok(Vec::new());
+    }
     let sql = queries::PAPER_SEARCH_FTS.replace("{COLS}", queries::PAPER_SELECT_COLS);
-    let mut rows = conn.query(&sql, [Value::Text(query.to_string())]).await?;
+    let mut rows = conn.query(&sql, [Value::Text(match_query)]).await?;
     crate::collect_rows(&mut rows).await.map_err(Into::into)
 }
 

--- a/crates/rotero-db/src/papers.rs
+++ b/crates/rotero-db/src/papers.rs
@@ -118,14 +118,28 @@ impl Database {
         Ok(row.get_value(0)?.as_integer().copied().unwrap_or(0) as u32)
     }
 
-    /// Search papers using FTS, falling back to LIKE if FTS is unavailable.
+    /// Search papers. If the query parses as an identifier (DOI, arXiv id, …), a
+    /// direct lookup is tried first. Otherwise it runs BM25 full-text search and
+    /// applies a light re-rank that guarantees exact/prefix title matches land at
+    /// the very top; falls back to LIKE if FTS is unavailable.
     pub async fn search_papers(&self, query: &str) -> Result<Vec<Paper>, crate::DbError> {
         let conn = self.conn();
-        // FTS first, fall back to LIKE if unavailable
-        match search_papers_fts(conn, query).await {
-            Ok(results) => Ok(results),
-            Err(_) => search_papers_like(conn, query).await,
+        let trimmed = query.trim();
+
+        // Fast path: a bare identifier matches the stored `doi` string exactly.
+        // Canonicalize first so `10.48550/arXiv.X` finds the row stored as `arXiv:X`.
+        if let Some(pid) = rotero_models::PaperId::parse(trimmed) {
+            let hits = search_papers_by_doi(conn, &pid.to_stored_string()).await?;
+            if !hits.is_empty() {
+                return Ok(hits);
+            }
         }
+
+        let candidates = match search_papers_fts(conn, query).await {
+            Ok(results) => results,
+            Err(_) => search_papers_like(conn, query).await?,
+        };
+        Ok(rotero_models::rank_local_results(candidates, query))
     }
 
     /// Fetch papers by a list of IDs.
@@ -321,7 +335,7 @@ impl Database {
             if paper.id.as_ref().is_some_and(|id| doi_ids.contains(id)) {
                 continue;
             }
-            let normalized = normalize_title(&paper.title);
+            let normalized = rotero_models::normalize_title(&paper.title);
             if normalized.is_empty() {
                 continue;
             }
@@ -455,6 +469,17 @@ impl Database {
     }
 }
 
+async fn search_papers_by_doi(
+    conn: &turso::Connection,
+    stored_id: &str,
+) -> Result<Vec<Paper>, crate::DbError> {
+    let sql = queries::PAPER_SEARCH_BY_DOI.replace("{COLS}", queries::PAPER_SELECT_COLS);
+    let mut rows = conn
+        .query(&sql, [Value::Text(stored_id.to_string())])
+        .await?;
+    crate::collect_rows(&mut rows).await.map_err(Into::into)
+}
+
 async fn search_papers_fts(
     conn: &turso::Connection,
     query: &str,
@@ -472,17 +497,6 @@ async fn search_papers_like(
     let sql = queries::PAPER_SEARCH_LIKE.replace("{COLS}", queries::PAPER_SELECT_COLS);
     let mut rows = conn.query(&sql, [Value::Text(pattern)]).await?;
     crate::collect_rows(&mut rows).await.map_err(Into::into)
-}
-
-fn normalize_title(title: &str) -> String {
-    title
-        .to_lowercase()
-        .chars()
-        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 impl crate::FromRow for Paper {
@@ -529,6 +543,7 @@ impl crate::FromRow for Paper {
                 citation_key: get_opt_text(row, 19),
                 extra_meta: extra_meta_str.and_then(|s| serde_json::from_str(&s).ok()),
             },
+            search_rank: None,
         }
     }
 }

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub(super) const SCHEMA_VERSION: i64 = 9;
+pub(super) const SCHEMA_VERSION: i64 = 10;
 
 /// Create the application tables and run pending migrations.
 ///
@@ -17,6 +17,17 @@ pub async fn initialize_db(conn: &Connection) -> Result<(), turso::Error> {
     run_migrations(conn).await?;
 
     Ok(())
+}
+
+/// Drop and recreate the FTS index so it is consistent with the current
+/// `papers` rows. A stale index (from an older engine version or the
+/// table-rebuild migration) makes `fts_score` return 0.0 and `fts_match` return
+/// an unreliable row set; a fresh rebuild restores correct BM25 ranking. Called
+/// once from the version-10 migration — turso maintains the index incrementally
+/// on writes thereafter. Best-effort: search falls back to LIKE if this fails.
+async fn rebuild_fts_index(conn: &Connection) {
+    let _ = conn.execute("DROP INDEX IF EXISTS idx_papers_fts", ()).await;
+    let _ = conn.execute(CREATE_FTS_INDEX, ()).await;
 }
 
 async fn run_migrations(conn: &Connection) -> Result<(), turso::Error> {
@@ -126,6 +137,14 @@ async fn run_migrations(conn: &Connection) -> Result<(), turso::Error> {
         let _ = conn
             .execute("ALTER TABLE papers ADD COLUMN pdf_url TEXT", ())
             .await;
+    }
+
+    if current_version < 10 {
+        // One-time heal of FTS indexes left stale by earlier engine versions /
+        // the table-rebuild migration (they returned 0.0 scores and an unreliable
+        // match set). turso maintains the index incrementally on writes, so this
+        // only needs to run once — hence a versioned migration, not every open.
+        rebuild_fts_index(conn).await;
     }
 
     if current_version < SCHEMA_VERSION {

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -26,7 +26,9 @@ pub async fn initialize_db(conn: &Connection) -> Result<(), turso::Error> {
 /// once from the version-10 migration — turso maintains the index incrementally
 /// on writes thereafter. Best-effort: search falls back to LIKE if this fails.
 async fn rebuild_fts_index(conn: &Connection) {
-    let _ = conn.execute("DROP INDEX IF EXISTS idx_papers_fts", ()).await;
+    let _ = conn
+        .execute("DROP INDEX IF EXISTS idx_papers_fts", ())
+        .await;
     let _ = conn.execute(CREATE_FTS_INDEX, ()).await;
 }
 

--- a/crates/rotero-mcp/src/db.rs
+++ b/crates/rotero-mcp/src/db.rs
@@ -84,12 +84,35 @@ impl Database {
         self.papers_dir().join(rel_path)
     }
 
-    /// Search papers by query string, trying FTS first and falling back to LIKE.
+    /// Search papers by query string. Identifiers are looked up directly;
+    /// otherwise BM25 full-text search runs, re-ranked so exact/prefix title
+    /// matches lead; falls back to LIKE if FTS is unavailable.
     pub async fn search_papers(&self, query: &str) -> Result<Vec<Paper>, turso::Error> {
-        match self.search_papers_fts(query).await {
-            Ok(results) => Ok(results),
-            Err(_) => self.search_papers_like(query).await,
+        let trimmed = query.trim();
+        if let Some(pid) = rotero_models::PaperId::parse(trimmed) {
+            let hits = self.search_papers_by_doi(&pid.to_stored_string()).await?;
+            if !hits.is_empty() {
+                return Ok(hits);
+            }
         }
+        let candidates = match self.search_papers_fts(query).await {
+            Ok(results) => results,
+            Err(_) => self.search_papers_like(query).await?,
+        };
+        Ok(rotero_models::rank_local_results(candidates, query))
+    }
+
+    async fn search_papers_by_doi(&self, stored_id: &str) -> Result<Vec<Paper>, turso::Error> {
+        let sql = queries::PAPER_SEARCH_BY_DOI.replace("{COLS}", queries::PAPER_SELECT_COLS);
+        let mut rows = self
+            .conn
+            .query(&sql, [Value::Text(stored_id.to_string())])
+            .await?;
+        let mut papers = Vec::new();
+        while let Some(row) = rows.next().await? {
+            papers.push(Paper::from_row(&row));
+        }
+        Ok(papers)
     }
 
     async fn search_papers_fts(&self, query: &str) -> Result<Vec<Paper>, turso::Error> {

--- a/crates/rotero-mcp/src/db.rs
+++ b/crates/rotero-mcp/src/db.rs
@@ -116,11 +116,15 @@ impl Database {
     }
 
     async fn search_papers_fts(&self, query: &str) -> Result<Vec<Paper>, turso::Error> {
+        // AND-join query tokens so all terms must be present (turso defaults to
+        // OR, which lets a common word match the whole library). Mirrors
+        // rotero-db's search so both consumers rank identically.
+        let match_query = rotero_models::build_fts_match_query(query);
+        if match_query.is_empty() {
+            return Ok(Vec::new());
+        }
         let sql = queries::PAPER_SEARCH_FTS.replace("{COLS}", queries::PAPER_SELECT_COLS);
-        let mut rows = self
-            .conn
-            .query(&sql, [Value::Text(query.to_string())])
-            .await?;
+        let mut rows = self.conn.query(&sql, [Value::Text(match_query)]).await?;
         let mut papers = Vec::new();
         while let Some(row) = rows.next().await? {
             papers.push(Paper::from_row(&row));

--- a/crates/rotero-mcp/src/server/tools.rs
+++ b/crates/rotero-mcp/src/server/tools.rs
@@ -364,6 +364,7 @@ impl RoteroMcp {
             },
             status: rotero_models::LibraryStatus::default(),
             citation: rotero_models::CitationInfo::default(),
+            ..Default::default()
         };
         let id = self.db.insert_paper(&paper).await.map_err(err)?;
         json_result(&serde_json::json!({ "paper_id": id, "success": true }))

--- a/crates/rotero-models/src/lib.rs
+++ b/crates/rotero-models/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod annotation;
 /// Hierarchical folder-like groupings for papers.
 pub mod collection;
+/// Merge, dedup, and rank web-search results across providers.
+pub mod merge;
 /// Free-form notes attached to papers.
 pub mod note;
 /// Core paper metadata and helper methods.
@@ -20,7 +22,11 @@ pub mod tag;
 
 pub use annotation::{Annotation, AnnotationType};
 pub use collection::Collection;
+pub use merge::merge_and_rank;
 pub use note::Note;
-pub use paper::{CitationInfo, LibraryStatus, Paper, PaperId, PaperLinks, Publication};
+pub use paper::{
+    local_relevance_score, normalize_title, rank_local_results, CitationInfo, LibraryStatus, Paper,
+    PaperId, PaperLinks, Publication, ProviderKind, SearchRank,
+};
 pub use saved_search::SavedSearch;
 pub use tag::Tag;

--- a/crates/rotero-models/src/lib.rs
+++ b/crates/rotero-models/src/lib.rs
@@ -25,8 +25,8 @@ pub use collection::Collection;
 pub use merge::merge_and_rank;
 pub use note::Note;
 pub use paper::{
-    local_relevance_score, normalize_title, rank_local_results, CitationInfo, LibraryStatus, Paper,
-    PaperId, PaperLinks, Publication, ProviderKind, SearchRank,
+    build_fts_match_query, local_relevance_score, normalize_title, rank_local_results,
+    CitationInfo, LibraryStatus, Paper, PaperId, PaperLinks, Publication, ProviderKind, SearchRank,
 };
 pub use saved_search::SavedSearch;
 pub use tag::Tag;

--- a/crates/rotero-models/src/lib.rs
+++ b/crates/rotero-models/src/lib.rs
@@ -25,8 +25,8 @@ pub use collection::Collection;
 pub use merge::merge_and_rank;
 pub use note::Note;
 pub use paper::{
+    CitationInfo, LibraryStatus, Paper, PaperId, PaperLinks, ProviderKind, Publication, SearchRank,
     build_fts_match_query, local_relevance_score, normalize_title, rank_local_results,
-    CitationInfo, LibraryStatus, Paper, PaperId, PaperLinks, Publication, ProviderKind, SearchRank,
 };
 pub use saved_search::SavedSearch;
 pub use tag::Tag;

--- a/crates/rotero-models/src/merge.rs
+++ b/crates/rotero-models/src/merge.rs
@@ -1,0 +1,375 @@
+//! Merge, deduplicate, and rank web-search results across providers.
+//!
+//! Each provider (OpenAlex, arXiv, Semantic Scholar) returns its own list of
+//! [`Paper`]s for a query. The same paper commonly appears in several of them,
+//! so [`merge_and_rank`] collapses duplicates into a single richer paper and
+//! orders the result by a blended relevance score.
+
+use std::collections::HashMap;
+
+use crate::paper::{normalize_title, Paper, PaperId};
+
+/// Key used to detect that two results describe the same paper.
+///
+/// Prefers the canonical [`PaperId`] (which collapses `arXiv:X` and
+/// `10.48550/arXiv.X` to the same value), falling back to the normalized title,
+/// and finally to a per-input-index unique key for title-less results so they
+/// are never merged together by accident.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum DedupKey {
+    Id(PaperId),
+    Title(String),
+    Unique(usize),
+}
+
+fn dedup_key(paper: &Paper, index: usize) -> DedupKey {
+    if let Some(pid) = paper.paper_id() {
+        return DedupKey::Id(pid);
+    }
+    let nt = normalize_title(&paper.title);
+    if nt.is_empty() {
+        DedupKey::Unique(index)
+    } else {
+        DedupKey::Title(nt)
+    }
+}
+
+/// Whether a DOI string is a real publisher DOI rather than arXiv's stored
+/// `arXiv:ID` pseudo-DOI.
+fn is_real_doi(doi: &Option<String>) -> bool {
+    matches!(doi.as_deref().and_then(PaperId::parse), Some(PaperId::Doi(_)))
+}
+
+/// Merge `other` into `keep`, filling gaps and keeping the strongest signal from
+/// each. `keep` is expected to be the more metadata-complete of the two.
+fn merge_into(keep: &mut Paper, other: Paper) {
+    if keep.abstract_text.is_none() {
+        keep.abstract_text = other.abstract_text;
+    }
+    if keep.year.is_none() {
+        keep.year = other.year;
+    }
+    if keep.authors.is_empty() {
+        keep.authors = other.authors;
+    }
+    if keep.publication.journal.is_none() {
+        keep.publication = other.publication;
+    }
+    if keep.links.pdf_url.is_none() {
+        keep.links.pdf_url = other.links.pdf_url;
+    }
+    if keep.links.url.is_none() {
+        keep.links.url = other.links.url;
+    }
+
+    // Prefer a real publisher DOI over arXiv's `arXiv:ID` pseudo-DOI, and fill
+    // in a missing DOI from the other source.
+    let keep_missing = keep.doi.as_deref().unwrap_or("").is_empty();
+    let upgrade_to_real = !is_real_doi(&keep.doi) && is_real_doi(&other.doi);
+    if keep_missing || upgrade_to_real {
+        keep.doi = other.doi;
+    }
+
+    // Citation count: keep the larger.
+    keep.citation.citation_count = keep
+        .citation
+        .citation_count
+        .max(other.citation.citation_count);
+}
+
+/// Normalize a single provider's batch of results to a [0, 1] relevance value,
+/// so scores from different providers (whose raw scales differ by orders of
+/// magnitude) become comparable. Returns `norm` keyed by the paper's index in
+/// `papers`.
+///
+/// - If any result carries a raw API score, min-max normalize the raw scores.
+/// - Otherwise fall back to rank position (`1 - i/len`), so the top result ≈ 1.0.
+fn normalize_batch(papers: &[Paper]) -> Vec<f64> {
+    let len = papers.len();
+    if len == 0 {
+        return Vec::new();
+    }
+
+    let raw: Vec<Option<f64>> = papers
+        .iter()
+        .map(|p| p.search_rank.and_then(|r| r.raw_score))
+        .collect();
+
+    let scored: Vec<f64> = raw.iter().filter_map(|r| *r).collect();
+    if scored.is_empty() {
+        // No raw scores in this batch — derive from rank position.
+        return (0..len).map(|i| 1.0 - (i as f64) / (len as f64)).collect();
+    }
+
+    let min = scored.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = scored.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let span = max - min;
+
+    raw.iter()
+        .enumerate()
+        .map(|(i, r)| match r {
+            Some(v) if span > 0.0 => (v - min) / span,
+            Some(_) => 1.0, // all raw scores equal → treat as top relevance
+            None => 1.0 - (i as f64) / (len as f64), // mixed batch: fall back to rank
+        })
+        .collect()
+}
+
+/// A merged paper plus the ranking signals accumulated across its sources.
+struct Merged {
+    paper: Paper,
+    /// Best (max) normalized relevance across contributing sources.
+    norm_relevance: f64,
+    /// Number of distinct providers that returned this paper.
+    source_count: u32,
+}
+
+/// Merge all providers' results into one deduplicated, relevance-ranked list.
+///
+/// `provider_results` is the per-provider batches in a fixed order. Each batch
+/// is normalized independently, then results are folded on [`DedupKey`]; the
+/// list is scored against `query` and sorted best-first.
+pub fn merge_and_rank(provider_results: &[Vec<Paper>], query: &str) -> Vec<Paper> {
+    let nq = normalize_title(query);
+    let query_tokens: Vec<&str> = nq.split_whitespace().collect();
+
+    let mut map: HashMap<DedupKey, Merged> = HashMap::new();
+    // Preserve first-seen order for stable output before the final sort.
+    let mut order: Vec<DedupKey> = Vec::new();
+    let mut global_index = 0usize;
+
+    for batch in provider_results {
+        let norms = normalize_batch(batch);
+        for (i, paper) in batch.iter().enumerate() {
+            let key = dedup_key(paper, global_index);
+            global_index += 1;
+            let norm = norms.get(i).copied().unwrap_or(0.0);
+
+            match map.get_mut(&key) {
+                Some(existing) => {
+                    existing.norm_relevance = existing.norm_relevance.max(norm);
+                    existing.source_count += 1;
+                    // Keep the more complete paper as the base.
+                    if paper.metadata_completeness_score()
+                        > existing.paper.metadata_completeness_score()
+                    {
+                        let mut base = paper.clone();
+                        merge_into(&mut base, std::mem::take(&mut existing.paper));
+                        existing.paper = base;
+                    } else {
+                        merge_into(&mut existing.paper, paper.clone());
+                    }
+                }
+                None => {
+                    order.push(key.clone());
+                    map.insert(
+                        key,
+                        Merged {
+                            paper: paper.clone(),
+                            norm_relevance: norm,
+                            source_count: 1,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    let mut merged: Vec<Merged> = order.into_iter().filter_map(|k| map.remove(&k)).collect();
+
+    // Sort by blended score, best first. Ties fall back to normalized relevance,
+    // then citation count, then title for a deterministic order.
+    merged.sort_by(|a, b| {
+        let sa = score(a, &nq, &query_tokens);
+        let sb = score(b, &nq, &query_tokens);
+        sb.partial_cmp(&sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(
+                b.norm_relevance
+                    .partial_cmp(&a.norm_relevance)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(
+                b.paper
+                    .citation
+                    .citation_count
+                    .cmp(&a.paper.citation.citation_count),
+            )
+            .then(a.paper.title.cmp(&b.paper.title))
+    });
+
+    merged.into_iter().map(|m| m.paper).collect()
+}
+
+/// Blend the ranking signals into a single score (higher = more relevant).
+/// Exact/prefix title match dominates so the searched-for paper lands first;
+/// below that, normalized API relevance orders the list.
+fn score(m: &Merged, nq: &str, query_tokens: &[&str]) -> f64 {
+    let nt = normalize_title(&m.paper.title);
+    let mut s = 0.0;
+
+    if !nq.is_empty() {
+        if nt == nq {
+            s += 1000.0;
+        } else if nt.starts_with(nq) {
+            s += 400.0;
+        }
+    }
+
+    // Fraction of query tokens present in the title.
+    if !query_tokens.is_empty() {
+        let title_tokens: Vec<&str> = nt.split_whitespace().collect();
+        let hits = query_tokens
+            .iter()
+            .filter(|t| title_tokens.contains(t))
+            .count();
+        s += 200.0 * (hits as f64) / (query_tokens.len() as f64);
+    }
+
+    s += 300.0 * m.norm_relevance;
+
+    let citations = m.paper.citation.citation_count.unwrap_or(0).max(0) as f64;
+    s += 3.0 * (1.0 + citations).ln();
+
+    s += 10.0 * ((m.source_count.saturating_sub(1)) as f64);
+
+    if let Some(year) = m.paper.year {
+        s += 0.2 * ((year - 2000).clamp(0, 25) as f64);
+    }
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paper::{ProviderKind, SearchRank};
+
+    fn paper(title: &str, doi: Option<&str>) -> Paper {
+        Paper {
+            title: title.to_string(),
+            doi: doi.map(|d| d.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn with_rank(mut p: Paper, source: ProviderKind, raw: Option<f64>, pos: usize) -> Paper {
+        p.search_rank = Some(SearchRank {
+            source,
+            raw_score: raw,
+            position: pos,
+        });
+        p
+    }
+
+    #[test]
+    fn dedups_same_paper_across_sources() {
+        // arXiv stores the pseudo-DOI; OpenAlex/S2 carry the arXiv DOI form and a real one.
+        let arxiv = with_rank(
+            paper("Attention Is All You Need", Some("arXiv:1706.03762")),
+            ProviderKind::ArXiv,
+            None,
+            0,
+        );
+        let openalex = {
+            let mut p = with_rank(
+                paper("Attention Is All You Need", Some("10.48550/arXiv.1706.03762")),
+                ProviderKind::OpenAlex,
+                Some(850.0),
+                0,
+            );
+            p.citation.citation_count = Some(100000);
+            p.authors = vec!["Vaswani".into()];
+            p
+        };
+        // Semantic Scholar returns the same paper by its arXiv DOI (the common
+        // case for a preprint) — canonicalizes to the same PaperId::ArXiv.
+        let s2 = with_rank(
+            paper("Attention Is All You Need", Some("10.48550/arXiv.1706.03762")),
+            ProviderKind::SemanticScholar,
+            Some(0.9),
+            0,
+        );
+        // An unrelated paper that must NOT be merged in.
+        let other = with_rank(
+            paper("A Completely Different Paper", Some("10.9/other")),
+            ProviderKind::OpenAlex,
+            Some(300.0),
+            1,
+        );
+
+        let out = merge_and_rank(
+            &[vec![arxiv], vec![openalex, other], vec![s2]],
+            "attention is all you need",
+        );
+
+        // The three copies of the transformer paper collapse into one; the
+        // unrelated paper stays separate.
+        assert_eq!(out.len(), 2);
+        let p = out
+            .iter()
+            .find(|p| p.title == "Attention Is All You Need")
+            .expect("merged paper present");
+        // Citation count survives from OpenAlex.
+        assert_eq!(p.citation.citation_count, Some(100000));
+        // Authors filled from the richer source.
+        assert_eq!(p.authors, vec!["Vaswani".to_string()]);
+        // The exact-title paper ranks first.
+        assert_eq!(out[0].title, "Attention Is All You Need");
+    }
+
+    #[test]
+    fn normalization_makes_scales_comparable() {
+        // OpenAlex raw scores on one scale, S2 on a totally different one.
+        let oa = vec![
+            with_rank(paper("A", Some("10.1/a")), ProviderKind::OpenAlex, Some(850.0), 0),
+            with_rank(paper("B", Some("10.1/b")), ProviderKind::OpenAlex, Some(12.0), 1),
+        ];
+        let s2 = vec![
+            with_rank(paper("C", Some("10.2/c")), ProviderKind::SemanticScholar, Some(0.9), 0),
+            with_rank(paper("D", Some("10.2/d")), ProviderKind::SemanticScholar, Some(0.1), 1),
+        ];
+        let oa_norm = normalize_batch(&oa);
+        let s2_norm = normalize_batch(&s2);
+        // Each source's top hit normalizes to ~1.0 and weakest to ~0.0.
+        assert!((oa_norm[0] - 1.0).abs() < 1e-9);
+        assert!((oa_norm[1] - 0.0).abs() < 1e-9);
+        assert!((s2_norm[0] - 1.0).abs() < 1e-9);
+        assert!((s2_norm[1] - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn arxiv_rank_derived_norm() {
+        let batch = vec![
+            with_rank(paper("A", Some("arXiv:1")), ProviderKind::ArXiv, None, 0),
+            with_rank(paper("B", Some("arXiv:2")), ProviderKind::ArXiv, None, 1),
+            with_rank(paper("C", Some("arXiv:3")), ProviderKind::ArXiv, None, 2),
+        ];
+        let norm = normalize_batch(&batch);
+        assert!((norm[0] - 1.0).abs() < 1e-9);
+        assert!(norm[0] > norm[1] && norm[1] > norm[2]);
+    }
+
+    #[test]
+    fn exact_title_beats_higher_cited_partial() {
+        // Partial match with huge citation count...
+        let mut partial = with_rank(
+            paper("Attention and Memory in Deep Learning", Some("10.1/partial")),
+            ProviderKind::OpenAlex,
+            Some(500.0),
+            0,
+        );
+        partial.citation.citation_count = Some(999999);
+        // ...vs the exact title with modest citations.
+        let mut exact = with_rank(
+            paper("Attention Is All You Need", Some("10.1/exact")),
+            ProviderKind::OpenAlex,
+            Some(400.0),
+            1,
+        );
+        exact.citation.citation_count = Some(10);
+
+        let out = merge_and_rank(&[vec![partial, exact]], "attention is all you need");
+        assert_eq!(out[0].title, "Attention Is All You Need");
+    }
+}

--- a/crates/rotero-models/src/merge.rs
+++ b/crates/rotero-models/src/merge.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use crate::paper::{normalize_title, Paper, PaperId};
+use crate::paper::{Paper, PaperId, normalize_title};
 
 /// Key used to detect that two results describe the same paper.
 ///
@@ -37,7 +37,10 @@ fn dedup_key(paper: &Paper, index: usize) -> DedupKey {
 /// Whether a DOI string is a real publisher DOI rather than arXiv's stored
 /// `arXiv:ID` pseudo-DOI.
 fn is_real_doi(doi: &Option<String>) -> bool {
-    matches!(doi.as_deref().and_then(PaperId::parse), Some(PaperId::Doi(_)))
+    matches!(
+        doi.as_deref().and_then(PaperId::parse),
+        Some(PaperId::Doi(_))
+    )
 }
 
 /// Merge `other` into `keep`, filling gaps and keeping the strongest signal from
@@ -273,7 +276,10 @@ mod tests {
         );
         let openalex = {
             let mut p = with_rank(
-                paper("Attention Is All You Need", Some("10.48550/arXiv.1706.03762")),
+                paper(
+                    "Attention Is All You Need",
+                    Some("10.48550/arXiv.1706.03762"),
+                ),
                 ProviderKind::OpenAlex,
                 Some(850.0),
                 0,
@@ -285,7 +291,10 @@ mod tests {
         // Semantic Scholar returns the same paper by its arXiv DOI (the common
         // case for a preprint) — canonicalizes to the same PaperId::ArXiv.
         let s2 = with_rank(
-            paper("Attention Is All You Need", Some("10.48550/arXiv.1706.03762")),
+            paper(
+                "Attention Is All You Need",
+                Some("10.48550/arXiv.1706.03762"),
+            ),
             ProviderKind::SemanticScholar,
             Some(0.9),
             0,
@@ -322,12 +331,32 @@ mod tests {
     fn normalization_makes_scales_comparable() {
         // OpenAlex raw scores on one scale, S2 on a totally different one.
         let oa = vec![
-            with_rank(paper("A", Some("10.1/a")), ProviderKind::OpenAlex, Some(850.0), 0),
-            with_rank(paper("B", Some("10.1/b")), ProviderKind::OpenAlex, Some(12.0), 1),
+            with_rank(
+                paper("A", Some("10.1/a")),
+                ProviderKind::OpenAlex,
+                Some(850.0),
+                0,
+            ),
+            with_rank(
+                paper("B", Some("10.1/b")),
+                ProviderKind::OpenAlex,
+                Some(12.0),
+                1,
+            ),
         ];
         let s2 = vec![
-            with_rank(paper("C", Some("10.2/c")), ProviderKind::SemanticScholar, Some(0.9), 0),
-            with_rank(paper("D", Some("10.2/d")), ProviderKind::SemanticScholar, Some(0.1), 1),
+            with_rank(
+                paper("C", Some("10.2/c")),
+                ProviderKind::SemanticScholar,
+                Some(0.9),
+                0,
+            ),
+            with_rank(
+                paper("D", Some("10.2/d")),
+                ProviderKind::SemanticScholar,
+                Some(0.1),
+                1,
+            ),
         ];
         let oa_norm = normalize_batch(&oa);
         let s2_norm = normalize_batch(&s2);
@@ -354,7 +383,10 @@ mod tests {
     fn exact_title_beats_higher_cited_partial() {
         // Partial match with huge citation count...
         let mut partial = with_rank(
-            paper("Attention and Memory in Deep Learning", Some("10.1/partial")),
+            paper(
+                "Attention and Memory in Deep Learning",
+                Some("10.1/partial"),
+            ),
             ProviderKind::OpenAlex,
             Some(500.0),
             0,

--- a/crates/rotero-models/src/paper.rs
+++ b/crates/rotero-models/src/paper.rs
@@ -266,6 +266,42 @@ pub fn normalize_title(title: &str) -> String {
         .join(" ")
 }
 
+/// Build the match string passed to turso's `fts_match()` from a raw user query.
+///
+/// turso combines bare space-separated tokens with **OR**, and does not strip
+/// stopwords — so `a bitter lesson` matches any paper containing "a", which is
+/// nearly all of them, and BM25 then surfaces long documents that merely repeat
+/// common words rather than papers about the actual topic. Joining the tokens
+/// with `AND` requires every term to be present, which is the behavior users
+/// expect from a search box (and correctly returns nothing when the searched
+/// title isn't in the library, rather than a confident wrong answer).
+///
+/// Each token is quoted so punctuation (hyphens, colons) and the FTS operator
+/// keywords (`AND`/`OR`/`NOT`) a user might type are treated as literal terms,
+/// not query syntax. Returns an empty string when the query has no usable
+/// tokens, which callers should treat as "no FTS query".
+pub fn build_fts_match_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|tok| {
+            // Keep alphanumerics; drop other punctuation so a token like
+            // "low-rank" becomes the phrase "low rank" and colons/quotes can't
+            // break out of the quoted term.
+            let cleaned: String = tok
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+                .collect::<String>()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            cleaned
+        })
+        .filter(|t| !t.is_empty())
+        .map(|t| format!("\"{t}\""))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
 /// Relevance score of a local library paper against a query. Higher is better.
 ///
 /// Exact and prefix normalized-title matches dominate so the searched-for paper
@@ -453,5 +489,31 @@ mod tests {
             PaperId::Pmid("12345678".into()).semantic_scholar_query(),
             "PMID:12345678"
         );
+    }
+
+    #[test]
+    fn fts_query_and_joins_tokens() {
+        // Every token becomes a required, quoted term — so a paper must contain
+        // all of them, not just one common word.
+        assert_eq!(
+            build_fts_match_query("a bitter lesson"),
+            "\"a\" AND \"bitter\" AND \"lesson\""
+        );
+    }
+
+    #[test]
+    fn fts_query_splits_punctuation_into_phrase() {
+        // Hyphens/colons become spaces inside the quoted term rather than FTS
+        // syntax, so "low-rank" stays a single phrase term.
+        assert_eq!(
+            build_fts_match_query("low-rank adaptation"),
+            "\"low rank\" AND \"adaptation\""
+        );
+    }
+
+    #[test]
+    fn fts_query_empty_when_no_tokens() {
+        assert_eq!(build_fts_match_query("   "), "");
+        assert_eq!(build_fts_match_query("!!! ---"), "");
     }
 }

--- a/crates/rotero-models/src/paper.rs
+++ b/crates/rotero-models/src/paper.rs
@@ -161,6 +161,29 @@ pub struct CitationInfo {
     pub extra_meta: Option<serde_json::Value>,
 }
 
+/// Which online source a web-search result came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    OpenAlex,
+    ArXiv,
+    SemanticScholar,
+}
+
+/// Transient relevance signal attached to a web-search result. Not persisted —
+/// it exists only on the in-memory results of a live search so they can be
+/// ranked, and is `None` on any paper loaded from the DB.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SearchRank {
+    /// The source this result came from.
+    pub source: ProviderKind,
+    /// The API's raw relevance score, if the provider returns one (OpenAlex,
+    /// Semantic Scholar). `None` for arXiv, which has no score.
+    pub raw_score: Option<f64>,
+    /// Zero-based position in that provider's returned batch (used as the
+    /// relevance signal when `raw_score` is absent).
+    pub position: usize,
+}
+
 /// A research paper with full metadata, links, library status, and citation info.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct Paper {
@@ -174,6 +197,9 @@ pub struct Paper {
     pub links: PaperLinks,
     pub status: LibraryStatus,
     pub citation: CitationInfo,
+    /// Live web-search relevance signal; never serialized (see [`SearchRank`]).
+    #[serde(skip)]
+    pub search_rank: Option<SearchRank>,
 }
 
 impl Paper {
@@ -227,9 +253,116 @@ impl Paper {
     }
 }
 
+/// Normalize a title for fuzzy comparison: lowercase, strip punctuation, and
+/// collapse whitespace. Used for duplicate detection and exact-match ranking.
+pub fn normalize_title(title: &str) -> String {
+    title
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Relevance score of a local library paper against a query. Higher is better.
+///
+/// Exact and prefix normalized-title matches dominate so the searched-for paper
+/// ranks first; below that, results order by how many query tokens appear in the
+/// title (weighted heavily) and abstract (lightly), with citation count and
+/// recency as mild tiebreakers.
+pub fn local_relevance_score(paper: &Paper, query_norm: &str, query_tokens: &[&str]) -> f64 {
+    if query_norm.is_empty() {
+        return 0.0;
+    }
+    let nt = normalize_title(&paper.title);
+    let mut s = 0.0;
+
+    if nt == query_norm {
+        s += 1000.0;
+    } else if nt.starts_with(query_norm) {
+        s += 400.0;
+    } else if nt.contains(query_norm) {
+        s += 250.0;
+    }
+
+    if !query_tokens.is_empty() {
+        let title_tokens: Vec<&str> = nt.split_whitespace().collect();
+        let title_hits = query_tokens
+            .iter()
+            .filter(|t| title_tokens.contains(t))
+            .count();
+        s += 120.0 * (title_hits as f64) / (query_tokens.len() as f64);
+
+        if let Some(abstract_text) = &paper.abstract_text {
+            let na = normalize_title(abstract_text);
+            let abs_hits = query_tokens.iter().filter(|t| na.contains(**t)).count();
+            s += 20.0 * (abs_hits as f64) / (query_tokens.len() as f64);
+        }
+    }
+
+    let citations = paper.citation.citation_count.unwrap_or(0).max(0) as f64;
+    s += 2.0 * (1.0 + citations).ln();
+
+    if let Some(year) = paper.year {
+        s += 0.1 * ((year - 2000).clamp(0, 25) as f64);
+    }
+
+    s
+}
+
+/// Sort local search candidates by [`local_relevance_score`], best first.
+pub fn rank_local_results(mut papers: Vec<Paper>, query: &str) -> Vec<Paper> {
+    let nq = normalize_title(query);
+    if nq.is_empty() {
+        return papers;
+    }
+    let tokens: Vec<&str> = nq.split_whitespace().collect();
+    papers.sort_by(|a, b| {
+        let sa = local_relevance_score(a, &nq, &tokens);
+        let sb = local_relevance_score(b, &nq, &tokens);
+        sb.partial_cmp(&sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.title.cmp(&b.title))
+    });
+    papers.truncate(50);
+    papers
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn titled(title: &str) -> Paper {
+        Paper {
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rank_puts_exact_title_first() {
+        // Exact title given last, buried among partial matches.
+        let papers = vec![
+            titled("Attention and Working Memory"),
+            titled("You Only Need Attention Sometimes"),
+            titled("A Study of Needs"),
+            titled("Attention Is All You Need"),
+        ];
+        let ranked = rank_local_results(papers, "attention is all you need");
+        assert_eq!(ranked[0].title, "Attention Is All You Need");
+    }
+
+    #[test]
+    fn rank_prefers_more_token_overlap() {
+        let papers = vec![
+            titled("Deep Learning"),
+            titled("Neural Machine Translation by Jointly Learning to Align"),
+        ];
+        let ranked = rank_local_results(papers, "neural machine translation");
+        assert!(ranked[0].title.starts_with("Neural Machine Translation"));
+    }
 
     #[test]
     fn parse_standard_doi() {

--- a/crates/rotero-models/src/paper.rs
+++ b/crates/rotero-models/src/paper.rs
@@ -101,6 +101,19 @@ impl PaperId {
     pub fn is_arxiv(&self) -> bool {
         matches!(self, Self::ArXiv(_))
     }
+
+    /// Canonical web URL that resolves this identifier in a browser.
+    ///
+    /// Only real DOIs go to `doi.org`; arXiv's `arXiv:ID` pseudo-DOI is not a
+    /// DOI and doi.org rejects it, so it resolves to its arXiv abstract page.
+    pub fn resolve_url(&self) -> String {
+        match self {
+            Self::Doi(d) => format!("https://doi.org/{d}"),
+            Self::ArXiv(id) => format!("https://arxiv.org/abs/{id}"),
+            Self::Pmid(id) => format!("https://pubmed.ncbi.nlm.nih.gov/{id}/"),
+            Self::Isbn(id) => format!("https://www.worldcat.org/isbn/{id}"),
+        }
+    }
 }
 
 impl fmt::Display for PaperId {
@@ -225,6 +238,20 @@ impl Paper {
     /// Parse the `doi` field into a typed [`PaperId`], if present and recognized.
     pub fn paper_id(&self) -> Option<PaperId> {
         self.doi.as_deref().and_then(PaperId::parse)
+    }
+
+    /// Web URL that resolves this paper's identifier in a browser, or `None` if
+    /// it has no identifier. Routes arXiv/PMID/ISBN to their own resolvers
+    /// rather than doi.org (which rejects non-DOIs like `arXiv:ID`); an
+    /// unrecognized but non-empty `doi` falls back to doi.org.
+    pub fn resolve_url(&self) -> Option<String> {
+        if let Some(pid) = self.paper_id() {
+            return Some(pid.resolve_url());
+        }
+        match self.doi.as_deref() {
+            Some(d) if !d.is_empty() => Some(format!("https://doi.org/{d}")),
+            _ => None,
+        }
     }
 
     /// Score how complete the metadata is (higher = more complete).
@@ -489,6 +516,35 @@ mod tests {
             PaperId::Pmid("12345678".into()).semantic_scholar_query(),
             "PMID:12345678"
         );
+    }
+
+    #[test]
+    fn resolve_url_routes_by_identifier_type() {
+        assert_eq!(
+            PaperId::Doi("10.1038/nature12373".into()).resolve_url(),
+            "https://doi.org/10.1038/nature12373"
+        );
+        // arXiv must NOT go to doi.org (it rejects the pseudo-DOI).
+        assert_eq!(
+            PaperId::ArXiv("2508.18081".into()).resolve_url(),
+            "https://arxiv.org/abs/2508.18081"
+        );
+        assert_eq!(
+            PaperId::Pmid("12345678".into()).resolve_url(),
+            "https://pubmed.ncbi.nlm.nih.gov/12345678/"
+        );
+    }
+
+    #[test]
+    fn paper_resolve_url_handles_arxiv_stored_doi() {
+        // A Paper whose stored `doi` is the arXiv pseudo-DOI resolves to arXiv.
+        let mut p = titled("Some Preprint");
+        p.doi = Some("arXiv:2508.18081".into());
+        assert_eq!(p.resolve_url().as_deref(), Some("https://arxiv.org/abs/2508.18081"));
+
+        // No identifier -> no URL.
+        let bare = titled("No DOI");
+        assert_eq!(bare.resolve_url(), None);
     }
 
     #[test]

--- a/crates/rotero-models/src/paper.rs
+++ b/crates/rotero-models/src/paper.rs
@@ -540,7 +540,10 @@ mod tests {
         // A Paper whose stored `doi` is the arXiv pseudo-DOI resolves to arXiv.
         let mut p = titled("Some Preprint");
         p.doi = Some("arXiv:2508.18081".into());
-        assert_eq!(p.resolve_url().as_deref(), Some("https://arxiv.org/abs/2508.18081"));
+        assert_eq!(
+            p.resolve_url().as_deref(),
+            Some("https://arxiv.org/abs/2508.18081")
+        );
 
         // No identifier -> no URL.
         let bare = titled("No DOI");

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -19,6 +19,11 @@ pub const PAPER_SEARCH_BY_DOI: &str = "SELECT {COLS} FROM papers WHERE doi = ?1 
 /// `(cols) MATCH ?` operator form is not supported and errors). Both take the
 /// same argument order: the indexed columns, then the query string. The score
 /// is the trailing column, read separately from the model columns.
+///
+/// The bound query string is expected to already be an AND-joined match
+/// expression (see [`build_fts_match_query`](crate::build_fts_match_query)):
+/// turso combines bare tokens with OR and keeps stopwords, so a raw multi-word
+/// query would match nearly the whole library on a common word like "a".
 pub const PAPER_SEARCH_FTS: &str = "\
     SELECT {COLS}, fts_score(title, authors, abstract_text, journal, fulltext, ?1) AS score \
     FROM papers \

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -9,19 +9,28 @@ pub const PAPER_INSERT: &str = "\
 /// Count total papers in the library.
 pub const PAPER_COUNT: &str = "SELECT COUNT(*) FROM papers";
 
-/// Full-text search across paper metadata and body text, ranked by score.
+/// Direct identifier lookup, used as a fast path when the query parses as a DOI
+/// or other [`PaperId`](crate::PaperId).
+pub const PAPER_SEARCH_BY_DOI: &str = "SELECT {COLS} FROM papers WHERE doi = ?1 LIMIT 50";
+
+/// Full-text search ranked by BM25 relevance.
+///
+/// turso's FTS is invoked via the `fts_match()` / `fts_score()` functions (the
+/// `(cols) MATCH ?` operator form is not supported and errors). Both take the
+/// same argument order: the indexed columns, then the query string. The score
+/// is the trailing column, read separately from the model columns.
 pub const PAPER_SEARCH_FTS: &str = "\
     SELECT {COLS}, fts_score(title, authors, abstract_text, journal, fulltext, ?1) AS score \
     FROM papers \
-    WHERE (title, authors, abstract_text, journal, fulltext) MATCH ?1 OR doi = ?1 \
+    WHERE fts_match(title, authors, abstract_text, journal, fulltext, ?1) \
     ORDER BY score DESC \
     LIMIT 50";
 
-/// Fallback LIKE-based search when FTS is unavailable.
+/// Fallback LIKE-based search when FTS is unavailable (e.g. index missing).
 pub const PAPER_SEARCH_LIKE: &str = "\
     SELECT {COLS} FROM papers \
     WHERE title LIKE ?1 OR authors LIKE ?1 OR abstract_text LIKE ?1 OR journal LIKE ?1 OR doi LIKE ?1 OR fulltext LIKE ?1 \
-    ORDER BY date_added DESC LIMIT 50";
+    LIMIT 500";
 
 /// Toggle a paper's favorite flag.
 pub const PAPER_SET_FAVORITE: &str = "UPDATE papers SET is_favorite = ?1 WHERE id = ?2";

--- a/crates/rotero-search/src/arxiv.rs
+++ b/crates/rotero-search/src/arxiv.rs
@@ -1,4 +1,4 @@
-use rotero_models::{Paper, PaperId, PaperLinks, Publication};
+use rotero_models::{Paper, PaperId, PaperLinks, Publication, ProviderKind, SearchRank};
 
 const ARXIV_API: &str = "https://export.arxiv.org/api/query";
 
@@ -47,7 +47,13 @@ fn parse_arxiv_entries(xml: &str) -> Result<Vec<Paper>, String> {
         // Remove version suffix (e.g. "1802.06070v2" -> "1802.06070")
         let arxiv_id = arxiv_id.split('v').next().unwrap_or(&arxiv_id);
 
-        if let Ok(paper) = parse_arxiv_atom(entry, arxiv_id) {
+        if let Ok(mut paper) = parse_arxiv_atom(entry, arxiv_id) {
+            // arXiv returns no relevance score → rank by result position.
+            paper.search_rank = Some(SearchRank {
+                source: ProviderKind::ArXiv,
+                raw_score: None,
+                position: results.len(),
+            });
             results.push(paper);
         }
 

--- a/crates/rotero-search/src/arxiv.rs
+++ b/crates/rotero-search/src/arxiv.rs
@@ -1,4 +1,4 @@
-use rotero_models::{Paper, PaperId, PaperLinks, Publication, ProviderKind, SearchRank};
+use rotero_models::{Paper, PaperId, PaperLinks, ProviderKind, Publication, SearchRank};
 
 const ARXIV_API: &str = "https://export.arxiv.org/api/query";
 

--- a/crates/rotero-search/src/arxiv.rs
+++ b/crates/rotero-search/src/arxiv.rs
@@ -123,6 +123,9 @@ fn parse_arxiv_atom(xml: &str, arxiv_id: &str) -> Result<Paper, String> {
         },
         links: PaperLinks {
             url: Some(format!("https://arxiv.org/abs/{arxiv_id}")),
+            // Direct PDF so import can download it without hitting the OA APIs,
+            // which don't resolve arXiv's pseudo-DOI.
+            pdf_url: Some(format!("https://arxiv.org/pdf/{arxiv_id}")),
             ..Default::default()
         },
         ..Default::default()

--- a/crates/rotero-search/src/openalex.rs
+++ b/crates/rotero-search/src/openalex.rs
@@ -1,4 +1,4 @@
-use rotero_models::{CitationInfo, Paper, Publication};
+use rotero_models::{CitationInfo, Paper, ProviderKind, Publication, SearchRank};
 use serde::Deserialize;
 
 const OPENALEX_API: &str = "https://api.openalex.org/works";
@@ -16,6 +16,7 @@ struct OpenAlexWork {
     abstract_inverted_index: Option<serde_json::Value>,
     cited_by_count: Option<i64>,
     open_access: Option<OpenAlexOA>,
+    relevance_score: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,13 +94,21 @@ pub async fn search_papers(query: &str, limit: usize) -> Result<Vec<Paper>, Stri
         .results
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|work| {
+        .enumerate()
+        .filter_map(|(position, work)| {
             let doi = work
                 .doi
                 .as_deref()
                 .unwrap_or("")
                 .replace("https://doi.org/", "");
-            work_to_paper(work, &doi).ok()
+            let raw_score = work.relevance_score;
+            let mut paper = work_to_paper(work, &doi).ok()?;
+            paper.search_rank = Some(SearchRank {
+                source: ProviderKind::OpenAlex,
+                raw_score,
+                position,
+            });
+            Some(paper)
         })
         .collect();
     Ok(results)
@@ -183,7 +192,7 @@ pub async fn autocomplete(query: &str) -> Result<Vec<Paper>, String> {
         .map_err(|e| format!("Failed to parse autocomplete response: {e}"))?;
 
     let mut results = Vec::new();
-    for item in data.results.unwrap_or_default() {
+    for (position, item) in data.results.unwrap_or_default().into_iter().enumerate() {
         let title = item.display_name.unwrap_or_default();
         if title.is_empty() {
             continue;
@@ -204,6 +213,12 @@ pub async fn autocomplete(query: &str) -> Result<Vec<Paper>, String> {
                 citation_count: item.cited_by_count,
                 ..Default::default()
             },
+            // Autocomplete has no relevance score → rank by position.
+            search_rank: Some(SearchRank {
+                source: ProviderKind::OpenAlex,
+                raw_score: None,
+                position,
+            }),
             ..Default::default()
         });
     }

--- a/crates/rotero-search/src/semantic_scholar.rs
+++ b/crates/rotero-search/src/semantic_scholar.rs
@@ -1,9 +1,9 @@
-use rotero_models::{CitationInfo, Paper, PaperId, Publication};
+use rotero_models::{CitationInfo, Paper, PaperId, ProviderKind, Publication, SearchRank};
 use serde::Deserialize;
 
 const S2_API: &str = "https://api.semanticscholar.org/graph/v1/paper";
 const S2_FIELDS: &str =
-    "title,authors,year,abstract,venue,externalIds,publicationVenue,citationCount,openAccessPdf";
+    "title,authors,year,abstract,venue,externalIds,publicationVenue,citationCount,openAccessPdf,matchScore";
 
 #[derive(Debug, Deserialize)]
 struct S2Paper {
@@ -21,6 +21,8 @@ struct S2Paper {
     citation_count: Option<i64>,
     #[serde(rename = "openAccessPdf")]
     open_access_pdf: Option<S2OpenAccessPdf>,
+    #[serde(rename = "matchScore")]
+    match_score: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,13 +82,19 @@ pub async fn search_papers(query: &str, limit: usize) -> Result<Vec<Paper>, Stri
 
     let papers = data.data.unwrap_or_default();
     let mut results = Vec::new();
-    for paper in papers {
+    for (position, paper) in papers.into_iter().enumerate() {
         let doi = paper
             .external_ids
             .as_ref()
             .and_then(|e| e.doi.clone())
             .unwrap_or_default();
-        if let Ok(p) = s2_to_paper(paper, &doi) {
+        let raw_score = paper.match_score;
+        if let Ok(mut p) = s2_to_paper(paper, &doi) {
+            p.search_rank = Some(SearchRank {
+                source: ProviderKind::SemanticScholar,
+                raw_score,
+                position,
+            });
             results.push(p);
         }
     }

--- a/crates/rotero-search/src/semantic_scholar.rs
+++ b/crates/rotero-search/src/semantic_scholar.rs
@@ -2,8 +2,7 @@ use rotero_models::{CitationInfo, Paper, PaperId, ProviderKind, Publication, Sea
 use serde::Deserialize;
 
 const S2_API: &str = "https://api.semanticscholar.org/graph/v1/paper";
-const S2_FIELDS: &str =
-    "title,authors,year,abstract,venue,externalIds,publicationVenue,citationCount,openAccessPdf,matchScore";
+const S2_FIELDS: &str = "title,authors,year,abstract,venue,externalIds,publicationVenue,citationCount,openAccessPdf,matchScore";
 
 #[derive(Debug, Deserialize)]
 struct S2Paper {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -163,6 +163,12 @@ pub fn App() -> Element {
                 move || db.clone()
             });
 
+            // App-root import coroutine: owns insert + OA-download so the
+            // download future outlives the card/panel that queued it.
+            let lib_state = use_context::<Signal<LibraryState>>();
+            let import_channel = commands::use_import_coroutine(db.clone(), lib_state);
+            use_context_provider(|| import_channel);
+
             rsx! {
                 document::Style { {FONTS_CSS} }
                 document::Style { {TOKENS_CSS} }

--- a/src/metadata/pdf_download.rs
+++ b/src/metadata/pdf_download.rs
@@ -17,12 +17,33 @@ impl fmt::Display for PdfDownloadError {
     }
 }
 
-/// Resolve candidate PDF URLs for a paper: the in-process translators (which
-/// often surface a direct publisher PDF link) first, then the open-access
-/// metadata APIs (OpenAlex, Semantic Scholar, Unpaywall).
-pub async fn resolve_pdf_urls(doi: Option<&str>, title: &str) -> Vec<String> {
-    tracing::info!("resolve_pdf_urls: doi={:?}, title={:?}", doi, title);
+/// Resolve candidate PDF URLs for a paper, in priority order: a direct PDF link
+/// the paper already carries (e.g. arXiv's `pdf_url`, an OA hit's location),
+/// then the in-process translators (which often surface a direct publisher PDF
+/// link), then the open-access metadata APIs (OpenAlex, Semantic Scholar,
+/// Unpaywall).
+///
+/// The direct link matters most for arXiv results: their DOI is a pseudo-DOI
+/// (`arXiv:ID`) the OA APIs don't resolve, so without it the download finds
+/// nothing even though a public PDF exists.
+pub async fn resolve_pdf_urls(
+    direct_url: Option<&str>,
+    doi: Option<&str>,
+    title: &str,
+) -> Vec<String> {
+    tracing::info!(
+        "resolve_pdf_urls: direct_url={:?}, doi={:?}, title={:?}",
+        direct_url,
+        doi,
+        title
+    );
     let mut urls = Vec::new();
+
+    if let Some(url) = direct_url
+        && !url.is_empty()
+    {
+        urls.push(url.to_string());
+    }
 
     // Translator scrape: resolve the DOI to its publisher page and let the site
     // translator surface a direct PDF attachment (arXiv "Preprint PDF", a Nature
@@ -218,13 +239,18 @@ async fn try_download_pdf(client: &reqwest::Client, url: &str) -> Result<Vec<u8>
 }
 
 /// Resolve URLs and download in one call.
+///
+/// `direct_url` is any PDF link the paper already carries (arXiv `pdf_url`, an
+/// OA location); it is tried first before falling back to translator scraping
+/// and the OA metadata APIs.
 pub async fn find_and_download_pdf(
     db: &Database,
+    direct_url: Option<&str>,
     doi: Option<&str>,
     title: &str,
     first_author: Option<&str>,
     year: Option<i32>,
 ) -> Result<String, PdfDownloadError> {
-    let urls = resolve_pdf_urls(doi, title).await;
+    let urls = resolve_pdf_urls(direct_url, doi, title).await;
     download_and_save_pdf(db, &urls, title, first_author, year).await
 }

--- a/src/metadata/pdf_download.rs
+++ b/src/metadata/pdf_download.rs
@@ -141,11 +141,14 @@ async fn translator_pdf_urls(doi: &str) -> Result<Vec<String>, String> {
         "http://127.0.0.1:{}/api/scrape",
         rotero_connector::CONNECTOR_PORT
     );
+    // Resolve to the correct landing page: doi.org rejects arXiv's `arXiv:ID`
+    // pseudo-DOI, so an arXiv id must scrape its arxiv.org abstract page instead.
+    let scrape_url = rotero_models::PaperId::parse(doi)
+        .map(|pid| pid.resolve_url())
+        .unwrap_or_else(|| format!("https://doi.org/{doi}"));
     let resp = reqwest::Client::new()
         .post(&endpoint)
-        .json(&ScrapeReq {
-            url: format!("https://doi.org/{doi}"),
-        })
+        .json(&ScrapeReq { url: scrape_url })
         .timeout(std::time::Duration::from_secs(20))
         .send()
         .await

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -415,6 +415,10 @@ pub struct LibraryState {
     pub tags: Vec<Tag>,
     pub selected_paper_ids: HashSet<String>,
     pub anchor_paper_id: Option<String>,
+    /// A web search result being previewed in the detail panel. Mutually
+    /// exclusive with a library-paper selection: previewing a web hit clears
+    /// the selection, and selecting a library paper clears this.
+    pub previewed_web: Option<Paper>,
     pub confirm_delete: Option<Vec<String>>,
     pub view: LibraryView,
     pub search: LibrarySearchState,
@@ -465,12 +469,14 @@ impl LibraryState {
     }
 
     pub fn select_one(&mut self, id: String) {
+        self.previewed_web = None;
         self.selected_paper_ids.clear();
         self.selected_paper_ids.insert(id.clone());
         self.anchor_paper_id = Some(id);
     }
 
     pub fn toggle_select(&mut self, id: &str) {
+        self.previewed_web = None;
         if self.selected_paper_ids.contains(id) {
             self.selected_paper_ids.remove(id);
         } else {
@@ -479,7 +485,16 @@ impl LibraryState {
         self.anchor_paper_id = Some(id.to_string());
     }
 
+    /// Show a web search result in the detail panel. Clears any library-paper
+    /// selection so the two detail surfaces stay mutually exclusive.
+    pub fn preview_web(&mut self, paper: Paper) {
+        self.selected_paper_ids.clear();
+        self.anchor_paper_id = None;
+        self.previewed_web = Some(paper);
+    }
+
     pub fn range_select(&mut self, target_id: &str, ordered_ids: &[String]) {
+        self.previewed_web = None;
         let anchor = self.anchor_paper_id.as_deref().unwrap_or(target_id);
         let anchor_pos = ordered_ids.iter().position(|id| id == anchor);
         let target_pos = ordered_ids.iter().position(|id| id == target_id);
@@ -500,6 +515,7 @@ impl LibraryState {
     pub fn clear_selection(&mut self) {
         self.selected_paper_ids.clear();
         self.anchor_paper_id = None;
+        self.previewed_web = None;
     }
 
     pub fn selection_count(&self) -> usize {

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -311,51 +311,52 @@ impl From<RenderedPage> for RenderedPageData {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq)]
-pub enum SearchSource {
-    #[default]
-    Local,
-    OpenAlex,
-    ArXiv,
-    SemanticScholar,
-}
-
-impl SearchSource {
-    pub fn label(&self) -> &'static str {
-        match self {
-            Self::Local => "Local",
-            Self::OpenAlex => "OpenAlex",
-            Self::ArXiv => "arXiv",
-            Self::SemanticScholar => "Semantic Scholar",
-        }
-    }
-
-    pub fn all() -> &'static [SearchSource] {
-        &[
-            SearchSource::Local,
-            SearchSource::OpenAlex,
-            SearchSource::ArXiv,
-            SearchSource::SemanticScholar,
-        ]
-    }
-
-    pub fn provider(&self) -> Option<rotero_search::SearchProvider> {
-        match self {
-            Self::OpenAlex => Some(rotero_search::SearchProvider::OpenAlex),
-            Self::ArXiv => Some(rotero_search::SearchProvider::ArXiv),
-            Self::SemanticScholar => Some(rotero_search::SearchProvider::SemanticScholar),
-            Self::Local => None,
-        }
-    }
+/// One online provider's slice of a search. Owns its own results and in-flight
+/// flag so it can render the instant its response lands, independent of the
+/// other providers.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderResults {
+    /// `None` = not yet returned for the current query; `Some(vec)` = returned
+    /// (possibly empty).
+    pub results: Option<Vec<Paper>>,
+    pub searching: bool,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct LibrarySearchState {
     pub query: String,
+    /// Bumped once per committed (post-debounce) query. Every async search task
+    /// captures the generation it fired under and only writes its slice if it
+    /// still matches, so a slow response from an older query can never overwrite
+    /// results for a newer one.
+    pub generation: u64,
+    /// Local DB results.
     pub results: Option<Vec<Paper>>,
-    pub source: SearchSource,
-    pub external_results: Option<Vec<Paper>>,
-    pub external_searching: bool,
+    // Online providers, in fixed order (== render order).
+    pub openalex: ProviderResults,
+    pub arxiv: ProviderResults,
+    pub semantic_scholar: ProviderResults,
+}
+
+impl LibrarySearchState {
+    /// True when the user has an active query, driving the two-section search
+    /// view instead of the normal library view.
+    pub fn is_active(&self) -> bool {
+        !self.query.trim().is_empty()
+    }
+
+    /// True while any online provider is still in flight.
+    pub fn web_searching(&self) -> bool {
+        self.openalex.searching || self.arxiv.searching || self.semantic_scholar.searching
+    }
+
+    /// Clears every result slice and in-flight flag.
+    pub fn reset_results(&mut self) {
+        self.results = None;
+        self.openalex = ProviderResults::default();
+        self.arxiv = ProviderResults::default();
+        self.semantic_scholar = ProviderResults::default();
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/state/commands/import.rs
+++ b/src/state/commands/import.rs
@@ -1,0 +1,131 @@
+use dioxus::prelude::*;
+use futures_util::StreamExt;
+use rotero_db::Database;
+use rotero_models::Paper;
+
+use crate::state::app_state::LibraryState;
+
+/// A paper to bring into the library, along with what should happen after it
+/// lands: metadata enrichment and an open-access PDF download.
+pub struct ImportRequest {
+    pub paper: Paper,
+}
+
+/// Insert a paper into the library and, in the background, download its
+/// open-access PDF.
+///
+/// This runs in the app-root coroutine (see [`use_import_coroutine`]) rather
+/// than a component event handler so the download future outlives the card or
+/// panel that triggered it — clearing the search or navigating away no longer
+/// cancels an in-flight download.
+///
+/// Sparse web results (a DOI but no authors, typical of autocomplete hits) are
+/// enriched from OpenAlex/CrossRef before insertion so the stored record and
+/// the PDF filename are complete.
+async fn run_import(db: &Database, mut lib_state: Signal<LibraryState>, paper: Paper) {
+    let paper = enrich_before_import(paper).await;
+
+    let id = match db.insert_paper(&paper).await {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!("Import failed: {e}");
+            return;
+        }
+    };
+
+    let mut paper = paper;
+    paper.id = Some(id.clone());
+    lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
+
+    download_pdf_into_library(db, &mut lib_state, &paper, &id).await;
+}
+
+/// Resolve and download the open-access PDF for an already-imported paper,
+/// writing the resulting path back into both the DB and the library signal.
+/// Failure is non-fatal — many papers simply have no OA copy.
+pub async fn download_pdf_into_library(
+    db: &Database,
+    lib_state: &mut Signal<LibraryState>,
+    paper: &Paper,
+    paper_id: &str,
+) {
+    let title = paper.title.clone();
+    tracing::info!("Downloading OA PDF for: {title}");
+    match crate::metadata::pdf_download::find_and_download_pdf(
+        db,
+        paper.links.pdf_url.as_deref(),
+        paper.doi.as_deref(),
+        &paper.title,
+        paper.authors.first().map(|a| a.as_str()),
+        paper.year,
+    )
+    .await
+    {
+        Ok(rel_path) => {
+            let _ = db.update_pdf_path(paper_id, &rel_path).await;
+            let pid = paper_id.to_string();
+            lib_state.with_mut(|s| {
+                if let Some(p) = s
+                    .papers
+                    .iter_mut()
+                    .find(|p| p.id.as_deref() == Some(pid.as_str()))
+                {
+                    p.links.pdf_path = Some(rel_path.clone());
+                }
+            });
+            tracing::info!("Downloaded OA PDF for: {title} -> {rel_path}");
+        }
+        Err(e) => {
+            tracing::debug!("No OA PDF for: {title}: {e}");
+        }
+    }
+}
+
+/// If a paper has a DOI but missing authors, fetch full metadata before
+/// inserting so the stored record isn't a sparse autocomplete stub.
+async fn enrich_before_import(paper: Paper) -> Paper {
+    let needs_enrichment =
+        paper.authors.is_empty() && paper.doi.as_ref().is_some_and(|d| !d.is_empty());
+    if !needs_enrichment {
+        return paper;
+    }
+
+    let doi = paper.doi.as_deref().unwrap_or_default();
+    if let Ok(enriched) = crate::metadata::openalex::fetch_by_doi(doi).await {
+        return enriched;
+    }
+    if let Ok(enriched) = crate::metadata::crossref::fetch_by_doi(doi).await {
+        return enriched;
+    }
+    paper
+}
+
+/// Handle to the app-root import coroutine. Cloneable and `Copy`, so any
+/// component can queue an import without threading the DB/signal through.
+#[derive(Clone, Copy)]
+pub struct ImportChannel {
+    inner: Coroutine<ImportRequest>,
+}
+
+impl ImportChannel {
+    /// Queue a paper for import + OA download. Returns immediately; the work
+    /// runs in the app-root scope and survives the caller unmounting.
+    pub fn import(&self, paper: Paper) {
+        self.inner.send(ImportRequest { paper });
+    }
+}
+
+/// Spawn the app-root import coroutine and expose it via context. Call once,
+/// near the top of the component tree, after the `Database` and `LibraryState`
+/// signal are in context.
+pub fn use_import_coroutine(db: Database, lib_state: Signal<LibraryState>) -> ImportChannel {
+    let coro = use_coroutine(move |mut rx: UnboundedReceiver<ImportRequest>| {
+        let db = db.clone();
+        async move {
+            while let Some(req) = rx.next().await {
+                run_import(&db, lib_state, req.paper).await;
+            }
+        }
+    });
+    ImportChannel { inner: coro }
+}

--- a/src/state/commands/mod.rs
+++ b/src/state/commands/mod.rs
@@ -1,8 +1,10 @@
+mod import;
 mod library_helpers;
 mod pdf_cache;
 mod pdf_extract;
 mod pdf_loading;
 
+pub use import::*;
 pub use library_helpers::*;
 pub use pdf_cache::*;
 pub use pdf_extract::*;

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -49,6 +49,10 @@ pub struct UiConfig {
     pub ui_scale: String,
     #[serde(default = "default_annotation_color")]
     pub default_annotation_color: String,
+    /// Persisted width (px) of the right-hand detail panel, set by dragging its
+    /// resize handle. Clamped to the panel's CSS min/max (280–600).
+    #[serde(default = "default_detail_width")]
+    pub detail_width: f32,
 }
 
 impl Default for UiConfig {
@@ -57,8 +61,13 @@ impl Default for UiConfig {
             dark_mode: false,
             ui_scale: default_ui_scale(),
             default_annotation_color: default_annotation_color(),
+            detail_width: default_detail_width(),
         }
     }
+}
+
+fn default_detail_width() -> f32 {
+    360.0
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src/ui/chat_panel/resize_handle.rs
+++ b/src/ui/chat_panel/resize_handle.rs
@@ -1,7 +1,13 @@
 use dioxus::prelude::*;
 
+/// Draggable left-edge handle that resizes a panel by directly mutating its
+/// width in the DOM during the drag (cheap, no per-frame Rust round-trip).
+///
+/// When `on_resize` is provided, the final width is reported back once on mouse
+/// up so the caller can persist it. Panels without a callback (e.g. chat) resize
+/// for the session only.
 #[component]
-pub fn ResizeHandle(target: String) -> Element {
+pub fn ResizeHandle(target: String, on_resize: Option<EventHandler<f64>>) -> Element {
     let handle_class = format!("{target}-resize-handle");
 
     rsx! {
@@ -17,11 +23,15 @@ pub fn ResizeHandle(target: String) -> Element {
                     format!(".{target}-panel")
                 };
                 spawn(async move {
+                    // Register the drag listeners and keep the eval alive by
+                    // awaiting a Promise that resolves (via `dioxus.send`) only on
+                    // mouse up. A synchronous IIFE would close the eval channel
+                    // before `onUp` fires, dropping the final width.
                     let js = format!(
                         r#"
-                        (function() {{
+                        new Promise(function(resolve) {{
                             var panel = document.querySelector('{selector}');
-                            if (!panel) return;
+                            if (!panel) {{ dioxus.send(0); return; }}
                             var startX = {start_x};
                             var startW = panel.offsetWidth;
                             function onMove(e) {{
@@ -35,15 +45,23 @@ pub fn ResizeHandle(target: String) -> Element {
                                 document.removeEventListener('mouseup', onUp);
                                 document.body.style.cursor = '';
                                 document.body.style.userSelect = '';
+                                dioxus.send(panel.offsetWidth);
                             }}
                             document.body.style.cursor = 'col-resize';
                             document.body.style.userSelect = 'none';
                             document.addEventListener('mousemove', onMove);
                             document.addEventListener('mouseup', onUp);
-                        }})()
+                        }})
                         "#
                     );
-                    let _ = dioxus::document::eval(&js);
+                    let mut eval = dioxus::document::eval(&js);
+                    // The handle sends the final width on mouse up; forward it to
+                    // the caller so it can persist the new size.
+                    if let Ok(final_width) = eval.recv::<f64>().await
+                        && let Some(cb) = on_resize
+                    {
+                        cb.call(final_width);
+                    }
                 });
             },
         }

--- a/src/ui/import_export.rs
+++ b/src/ui/import_export.rs
@@ -11,6 +11,9 @@ use rotero_db::Database;
 pub struct OaPending {
     pub id: String,
     pub doi: Option<String>,
+    /// A direct PDF link the paper already carries (arXiv `pdf_url`, an OA
+    /// location), tried first during download.
+    pub pdf_url: Option<String>,
     pub title: String,
     pub first_author: Option<String>,
     pub year: Option<i32>,
@@ -145,6 +148,7 @@ fn ImportButton() -> Element {
                                                     needs_oa.push(OaPending {
                                                         id,
                                                         doi: paper.doi.clone(),
+                                                        pdf_url: paper.links.pdf_url.clone(),
                                                         title: paper.title.clone(),
                                                         first_author: paper.authors.first().cloned(),
                                                         year: paper.year,
@@ -225,7 +229,7 @@ fn OaPromptDialog(papers: Vec<OaPending>) -> Element {
                                     break;
                                 }
                                 oa_state.set(Some(OaState::Downloading { done: i + 1, total, downloaded }));
-                                let urls = crate::metadata::pdf_download::resolve_pdf_urls(p.doi.as_deref(), &p.title).await;
+                                let urls = crate::metadata::pdf_download::resolve_pdf_urls(p.pdf_url.as_deref(), p.doi.as_deref(), &p.title).await;
                                 if cancelled.load(Ordering::Relaxed) { break; }
                                 if let Ok(rel_path) = crate::metadata::pdf_download::download_and_save_pdf(
                                     &db, &urls, &p.title, p.first_author.as_deref(), p.year,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -5,7 +5,7 @@ use super::graph_view::GraphView;
 #[cfg(feature = "desktop")]
 use super::keybindings::GlobalKeyHandler;
 use super::library::LibraryPanel;
-use super::paper_detail::{MultiSelectSummary, PaperDetail};
+use super::paper_detail::{MultiSelectSummary, PaperDetail, WebPreview};
 use super::pdf::{PdfTabBar, PdfViewer};
 use super::sidebar::Sidebar;
 use crate::agent::types::ChatState;
@@ -72,10 +72,17 @@ pub fn Layout() -> Element {
                     _ => rsx! {
                         div { style: "flex: 1; display: flex; min-height: 0;",
                             LibraryPanel {}
-                            match lib_state.read().selection_count() {
-                                0 => rsx! {},
-                                1 => rsx! { PaperDetail {} },
-                                _ => rsx! { MultiSelectSummary {} },
+                            {
+                                let state = lib_state.read();
+                                if state.previewed_web.is_some() {
+                                    rsx! { WebPreview {} }
+                                } else {
+                                    match state.selection_count() {
+                                        0 => rsx! {},
+                                        1 => rsx! { PaperDetail {} },
+                                        _ => rsx! { MultiSelectSummary {} },
+                                    }
+                                }
                             }
                         }
                     },

--- a/src/ui/library/add_paper.rs
+++ b/src/ui/library/add_paper.rs
@@ -80,13 +80,10 @@ pub(crate) fn AddPaperButtons() -> Element {
 
 #[component]
 pub(crate) fn AddPaperDOIInput() -> Element {
-    let mut lib_state = use_context::<Signal<LibraryState>>();
-    let db = use_context::<rotero_db::Database>();
+    let import_channel = use_context::<crate::state::commands::ImportChannel>();
     let mut error_msg = use_context::<Signal<Option<String>>>();
     let mut show_doi_input = use_context::<Signal<bool>>();
     let mut doi_value = use_signal(String::new);
-
-    let db_for_doi = db.clone();
 
     rsx! {
         if show_doi_input() {
@@ -105,22 +102,16 @@ pub(crate) fn AddPaperDOIInput() -> Element {
                         if doi.is_empty() {
                             return;
                         }
-                        let db = db_for_doi.clone();
-
+                        // Fetch metadata, then hand off to the import coroutine,
+                        // which inserts and downloads the OA PDF (same path as a
+                        // web-result import) — outliving this input closing.
                         spawn(async move {
                             match crate::metadata::crossref::fetch_by_doi(&doi).await {
                                 Ok(paper) => {
-                                    match db.insert_paper(&paper).await {
-                                        Ok(id) => {
-                                            let mut paper = paper;
-                                            paper.id = Some(id);
-                                            lib_state.with_mut(|s| s.papers.insert(0, paper));
-                                            show_doi_input.set(false);
-                                            doi_value.set(String::new());
-                                            error_msg.set(None);
-                                        }
-                                        Err(e) => error_msg.set(Some(format!("{e}"))),
-                                    }
+                                    import_channel.import(paper);
+                                    show_doi_input.set(false);
+                                    doi_value.set(String::new());
+                                    error_msg.set(None);
                                 }
                                 Err(e) => error_msg.set(Some(e)),
                             }

--- a/src/ui/library/external_results.rs
+++ b/src/ui/library/external_results.rs
@@ -3,166 +3,179 @@ use dioxus::prelude::*;
 use crate::state::app_state::LibraryState;
 use rotero_db::Database;
 
+/// The "From the web" panel: a single consolidated list of results merged and
+/// deduplicated across all online providers, ranked by relevance. The merge
+/// recomputes as each provider streams in, so the list grows and re-ranks
+/// without waiting for the slowest source.
 #[component]
-pub(crate) fn ExternalResults(results: Vec<rotero_models::Paper>, searching: bool) -> Element {
+pub(crate) fn ExternalResults() -> Element {
     let mut lib_state = use_context::<Signal<LibraryState>>();
     let db = use_context::<Database>();
-    let source_label = lib_state.read().search.source.label();
 
-    let existing_dois: std::collections::HashSet<String> = lib_state
-        .read()
-        .papers
+    // Merged, deduped, ranked results. Recomputes whenever any provider slot,
+    // the query, or the library changes.
+    let merged = use_memo(move || {
+        let state = lib_state.read();
+        let batches: Vec<Vec<rotero_models::Paper>> = vec![
+            state.search.openalex.results.clone().unwrap_or_default(),
+            state.search.arxiv.results.clone().unwrap_or_default(),
+            state.search.semantic_scholar.results.clone().unwrap_or_default(),
+        ];
+        rotero_models::merge_and_rank(&batches, &state.search.query)
+    });
+
+    let (existing_dois, still_searching) = {
+        let state = lib_state.read();
+        let dois: std::collections::HashSet<String> = state
+            .papers
+            .iter()
+            .filter_map(|p| p.doi.clone())
+            .filter(|d| !d.is_empty())
+            .collect();
+        (dois, state.search.web_searching())
+    };
+
+    let results = merged.read().clone();
+
+    if results.is_empty() {
+        // Nothing yet — say so only once every provider has finished, so the
+        // header spinner (driven by web_searching) isn't contradicted.
+        if still_searching {
+            return rsx! { div { class: "library-list" } };
+        }
+        return rsx! {
+            div { class: "library-list",
+                div { class: "external-provider-empty", "No results from the web." }
+            }
+        };
+    }
+
+    let importable_count = results
         .iter()
-        .filter_map(|p| p.doi.clone())
-        .filter(|d| !d.is_empty())
-        .collect();
+        .filter(|p| {
+            p.doi
+                .as_ref()
+                .is_none_or(|d| d.is_empty() || !existing_dois.contains(d))
+        })
+        .count();
+    let all_imported = importable_count == 0;
+    let db_banner = db.clone();
 
     rsx! {
         div { class: "library-list",
-            if searching {
-                div { class: "external-search-status",
-                    i { class: "bi bi-arrow-repeat external-spinner" }
-                    "Searching {source_label}..."
+            div { class: "external-results-banner",
+                span { "{results.len()} results from the web" }
+                button {
+                    class: "btn btn--sm btn--primary",
+                    disabled: all_imported,
+                    onclick: move |_| {
+                        let papers = merged.read().clone();
+                        let existing: std::collections::HashSet<String> = lib_state.read().papers.iter()
+                            .filter_map(|p| p.doi.clone())
+                            .filter(|d| !d.is_empty())
+                            .collect();
+                        let db = db_banner.clone();
+                        spawn(async move {
+                            let mut imported_papers: Vec<(rotero_models::Paper, String)> = Vec::new();
+                            for paper in papers {
+                                if let Some(ref doi) = paper.doi
+                                    && !doi.is_empty() && existing.contains(doi) {
+                                        continue;
+                                    }
+                                let paper = enrich_before_import(paper).await;
+                                if let Ok(id) = db.insert_paper(&paper).await {
+                                    let mut paper = paper;
+                                    paper.id = Some(id.clone());
+                                    lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
+                                    imported_papers.push((paper, id));
+                                }
+                            }
+                            tracing::info!("Imported {} papers, starting OA PDF downloads", imported_papers.len());
+                            for (paper, paper_id) in imported_papers {
+                                try_download_oa_pdf(&db, &mut lib_state, &paper, &paper_id).await;
+                            }
+                        });
+                    },
+                    if all_imported { "All Imported" } else { "Import All" }
                 }
-            } else if results.is_empty() {
-                div { class: "library-empty",
-                    if lib_state.read().search.query.is_empty() {
-                        p { class: "library-empty-heading", "Search {source_label}" }
-                        p { class: "library-empty-sub", "Type a query and press Enter to search." }
-                    } else if lib_state.read().search.external_results.is_some() {
-                        p { class: "library-empty-heading", "No results found" }
-                        p { class: "library-empty-sub", "Try a different search term." }
-                    } else {
-                        p { class: "library-empty-heading", "Search {source_label}" }
-                        p { class: "library-empty-sub", "Press Enter to search." }
-                    }
-                }
-            } else {
+            }
+            for paper in results.iter() {
                 {
-                    let importable_count = results.iter().filter(|p| {
-                        p.doi.as_ref().is_none_or(|d| d.is_empty() || !existing_dois.contains(d))
-                    }).count();
-                    let all_imported = importable_count == 0;
-                    let db_banner = db.clone();
+                    let title = paper.title.clone();
+                    let authors = paper.formatted_authors();
+                    let year = paper.year.map(|y| y.to_string()).unwrap_or_default();
+                    let journal = paper.publication.journal.clone().unwrap_or_default();
+                    let citation_count = paper.citation.citation_count;
+                    let doi = paper.doi.clone().unwrap_or_default();
+                    let abstract_text = paper.abstract_text.clone().unwrap_or_default();
+                    let has_abstract = !abstract_text.is_empty();
+                    let already_imported = !doi.is_empty() && existing_dois.contains(&doi);
+                    let row_key = result_key(paper);
+                    let paper_clone = paper.clone();
+                    let db_import = db.clone();
 
                     rsx! {
-                        div { class: "external-results-banner",
-                            span { "{results.len()} results from {source_label}" }
-                            button {
-                                class: "btn btn--sm btn--primary",
-                                disabled: all_imported,
-                                onclick: move |_| {
-                                    let state = lib_state.read();
-                                    let papers = state.search.external_results.clone().unwrap_or_default();
-                                    let existing: std::collections::HashSet<String> = state.papers.iter()
-                                        .filter_map(|p| p.doi.clone())
-                                        .filter(|d| !d.is_empty())
-                                        .collect();
-                                    drop(state);
-                                    let db = db_banner.clone();
-                                    spawn(async move {
-                                        let mut imported_papers: Vec<(rotero_models::Paper, String)> = Vec::new();
-                                        for paper in papers {
-                                            if let Some(ref doi) = paper.doi
-                                                && !doi.is_empty() && existing.contains(doi) {
-                                                    continue;
-                                                }
-                                            if let Ok(id) = db.insert_paper(&paper).await {
-                                                let mut paper = paper;
-                                                paper.id = Some(id.clone());
-                                                lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
-                                                imported_papers.push((paper, id));
-                                            }
-                                        }
-                                        tracing::info!("Imported {} papers, starting OA PDF downloads", imported_papers.len());
-                                        // Auto-download OA PDFs after all imports
-                                        for (paper, paper_id) in imported_papers {
-                                            try_download_oa_pdf(&db, &mut lib_state, &paper, &paper_id).await;
-                                        }
-                                    });
-                                },
-                                if all_imported { "All Imported" } else { "Import All" }
-                            }
-                        }
-                    }
-                }
-                for (i, paper) in results.iter().enumerate() {
-                    {
-                        let title = paper.title.clone();
-                        let authors = paper.formatted_authors();
-                        let year = paper.year.map(|y| y.to_string()).unwrap_or_default();
-                        let journal = paper.publication.journal.clone().unwrap_or_default();
-                        let citation_count = paper.citation.citation_count;
-                        let doi = paper.doi.clone().unwrap_or_default();
-                        let abstract_text = paper.abstract_text.clone().unwrap_or_default();
-                        let has_abstract = !abstract_text.is_empty();
-                        let already_imported = !doi.is_empty() && existing_dois.contains(&doi);
-                        let paper_clone = paper.clone();
-                        let db_import = db.clone();
+                        div {
+                            key: "{row_key}",
+                            class: if already_imported { "library-card external-result-card external-result-card--imported" } else { "library-card external-result-card" },
 
-                        rsx! {
-                            div {
-                                key: "ext-{i}",
-                                class: if already_imported { "library-card external-result-card external-result-card--imported" } else { "library-card external-result-card" },
-
-                                div { class: "library-card-body",
-                                    div { class: "library-card-title", "{title}" }
-                                    div { class: "library-card-meta",
-                                        span { class: "library-card-authors", "{authors}" }
-                                        if !year.is_empty() {
-                                            span { class: "library-card-sep", "\u{00b7}" }
-                                            span { class: "library-card-year", "{year}" }
-                                        }
-                                        if !journal.is_empty() {
-                                            span { class: "library-card-sep", "\u{00b7}" }
-                                            span { class: "library-card-journal", "{journal}" }
-                                        }
-                                        if let Some(count) = citation_count {
-                                            span { class: "library-card-sep", "\u{00b7}" }
-                                            span { class: "library-card-citations", title: "Citation count", "{count} cited" }
-                                        }
-                                        if !doi.is_empty() {
-                                            span { class: "library-card-sep", "\u{00b7}" }
-                                            span { class: "library-card-doi", "{doi}" }
-                                        }
+                            div { class: "library-card-body",
+                                div { class: "library-card-title", "{title}" }
+                                div { class: "library-card-meta",
+                                    span { class: "library-card-authors", "{authors}" }
+                                    if !year.is_empty() {
+                                        span { class: "library-card-sep", "\u{00b7}" }
+                                        span { class: "library-card-year", "{year}" }
                                     }
-                                    if has_abstract {
-                                        div { class: "external-result-abstract", "{abstract_text}" }
+                                    if !journal.is_empty() {
+                                        span { class: "library-card-sep", "\u{00b7}" }
+                                        span { class: "library-card-journal", "{journal}" }
+                                    }
+                                    if let Some(count) = citation_count {
+                                        span { class: "library-card-sep", "\u{00b7}" }
+                                        span { class: "library-card-citations", title: "Citation count", "{count} cited" }
+                                    }
+                                    if !doi.is_empty() {
+                                        span { class: "library-card-sep", "\u{00b7}" }
+                                        span { class: "library-card-doi", "{doi}" }
                                     }
                                 }
+                                if has_abstract {
+                                    div { class: "external-result-abstract", "{abstract_text}" }
+                                }
+                            }
 
-                                div { class: "library-card-actions",
-                                    if already_imported {
-                                        button {
-                                            class: "btn btn--sm btn--ghost external-imported-btn",
-                                            disabled: true,
-                                            i { class: "bi bi-check-lg" }
-                                            "Imported"
-                                        }
-                                    } else {
-                                        button {
-                                            class: "btn btn--sm btn--primary",
-                                            onclick: move |_| {
-                                                let paper = paper_clone.clone();
-                                                let db = db_import.clone();
-                                                spawn(async move {
-                                                    // If we have a DOI but sparse metadata (autocomplete result),
-                                                    // fetch full details first
-                                                    let paper = enrich_before_import(paper).await;
-                                                    match db.insert_paper(&paper).await {
-                                                        Ok(id) => {
-                                                            let mut paper = paper;
-                                                            paper.id = Some(id.clone());
-                                                            lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
-                                                            // Auto-download OA PDF
-                                                            try_download_oa_pdf(&db, &mut lib_state, &paper, &id).await;
-                                                        }
-                                                        Err(e) => tracing::error!("Failed to import: {e}"),
+                            div { class: "library-card-actions",
+                                if already_imported {
+                                    button {
+                                        class: "btn btn--sm btn--ghost external-imported-btn",
+                                        disabled: true,
+                                        i { class: "bi bi-check-lg" }
+                                        "Imported"
+                                    }
+                                } else {
+                                    button {
+                                        class: "btn btn--sm btn--primary",
+                                        onclick: move |_| {
+                                            let paper = paper_clone.clone();
+                                            let db = db_import.clone();
+                                            spawn(async move {
+                                                // If we have a DOI but sparse metadata (autocomplete result),
+                                                // fetch full details first
+                                                let paper = enrich_before_import(paper).await;
+                                                match db.insert_paper(&paper).await {
+                                                    Ok(id) => {
+                                                        let mut paper = paper;
+                                                        paper.id = Some(id.clone());
+                                                        lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
+                                                        // Auto-download OA PDF
+                                                        try_download_oa_pdf(&db, &mut lib_state, &paper, &id).await;
                                                     }
-                                                });
-                                            },
-                                            "Import"
-                                        }
+                                                    Err(e) => tracing::error!("Failed to import: {e}"),
+                                                }
+                                            });
+                                        },
+                                        "Import"
                                     }
                                 }
                             }
@@ -171,6 +184,15 @@ pub(crate) fn ExternalResults(results: Vec<rotero_models::Paper>, searching: boo
                 }
             }
         }
+    }
+}
+
+/// Stable identity for a merged result row, so Dioxus diffing survives the list
+/// re-ranking as slower providers stream in.
+fn result_key(paper: &rotero_models::Paper) -> String {
+    match paper.paper_id() {
+        Some(pid) => pid.to_stored_string(),
+        None => rotero_models::normalize_title(&paper.title),
     }
 }
 

--- a/src/ui/library/external_results.rs
+++ b/src/ui/library/external_results.rs
@@ -1,16 +1,20 @@
 use dioxus::prelude::*;
 
 use crate::state::app_state::LibraryState;
-use rotero_db::Database;
+use crate::state::commands::ImportChannel;
 
 /// The "From the web" panel: a single consolidated list of results merged and
 /// deduplicated across all online providers, ranked by relevance. The merge
 /// recomputes as each provider streams in, so the list grows and re-ranks
 /// without waiting for the slowest source.
+///
+/// Clicking a row opens its overview in the detail panel; importing routes
+/// through the app-root [`ImportChannel`] so the insert + OA-PDF download
+/// survives the search being cleared.
 #[component]
 pub(crate) fn ExternalResults() -> Element {
     let mut lib_state = use_context::<Signal<LibraryState>>();
-    let db = use_context::<Database>();
+    let import_channel = use_context::<ImportChannel>();
 
     // Merged, deduped, ranked results. Recomputes whenever any provider slot,
     // the query, or the library changes.
@@ -24,7 +28,7 @@ pub(crate) fn ExternalResults() -> Element {
         rotero_models::merge_and_rank(&batches, &state.search.query)
     });
 
-    let (existing_dois, still_searching) = {
+    let (existing_dois, still_searching, previewed_key) = {
         let state = lib_state.read();
         let dois: std::collections::HashSet<String> = state
             .papers
@@ -32,7 +36,8 @@ pub(crate) fn ExternalResults() -> Element {
             .filter_map(|p| p.doi.clone())
             .filter(|d| !d.is_empty())
             .collect();
-        (dois, state.search.web_searching())
+        let previewed = state.previewed_web.as_ref().map(result_key);
+        (dois, state.search.web_searching(), previewed)
     };
 
     let results = merged.read().clone();
@@ -52,14 +57,9 @@ pub(crate) fn ExternalResults() -> Element {
 
     let importable_count = results
         .iter()
-        .filter(|p| {
-            p.doi
-                .as_ref()
-                .is_none_or(|d| d.is_empty() || !existing_dois.contains(d))
-        })
+        .filter(|p| !is_imported(p, &existing_dois))
         .count();
     let all_imported = importable_count == 0;
-    let db_banner = db.clone();
 
     rsx! {
         div { class: "library-list",
@@ -69,32 +69,12 @@ pub(crate) fn ExternalResults() -> Element {
                     class: "btn btn--sm btn--primary",
                     disabled: all_imported,
                     onclick: move |_| {
-                        let papers = merged.read().clone();
-                        let existing: std::collections::HashSet<String> = lib_state.read().papers.iter()
-                            .filter_map(|p| p.doi.clone())
-                            .filter(|d| !d.is_empty())
-                            .collect();
-                        let db = db_banner.clone();
-                        spawn(async move {
-                            let mut imported_papers: Vec<(rotero_models::Paper, String)> = Vec::new();
-                            for paper in papers {
-                                if let Some(ref doi) = paper.doi
-                                    && !doi.is_empty() && existing.contains(doi) {
-                                        continue;
-                                    }
-                                let paper = enrich_before_import(paper).await;
-                                if let Ok(id) = db.insert_paper(&paper).await {
-                                    let mut paper = paper;
-                                    paper.id = Some(id.clone());
-                                    lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
-                                    imported_papers.push((paper, id));
-                                }
+                        let existing = existing_dois.clone();
+                        for paper in merged.read().iter() {
+                            if !is_imported(paper, &existing) {
+                                import_channel.import(paper.clone());
                             }
-                            tracing::info!("Imported {} papers, starting OA PDF downloads", imported_papers.len());
-                            for (paper, paper_id) in imported_papers {
-                                try_download_oa_pdf(&db, &mut lib_state, &paper, &paper_id).await;
-                            }
-                        });
+                        }
                     },
                     if all_imported { "All Imported" } else { "Import All" }
                 }
@@ -109,15 +89,27 @@ pub(crate) fn ExternalResults() -> Element {
                     let doi = paper.doi.clone().unwrap_or_default();
                     let abstract_text = paper.abstract_text.clone().unwrap_or_default();
                     let has_abstract = !abstract_text.is_empty();
-                    let already_imported = !doi.is_empty() && existing_dois.contains(&doi);
+                    let already_imported = is_imported(paper, &existing_dois);
                     let row_key = result_key(paper);
-                    let paper_clone = paper.clone();
-                    let db_import = db.clone();
+                    let selected = previewed_key.as_deref() == Some(row_key.as_str());
+                    let paper_select = paper.clone();
+                    let paper_import = paper.clone();
+
+                    let card_class = if selected {
+                        "library-card external-result-card external-result-card--selected"
+                    } else if already_imported {
+                        "library-card external-result-card external-result-card--imported"
+                    } else {
+                        "library-card external-result-card"
+                    };
 
                     rsx! {
                         div {
                             key: "{row_key}",
-                            class: if already_imported { "library-card external-result-card external-result-card--imported" } else { "library-card external-result-card" },
+                            class: "{card_class}",
+                            onclick: move |_| {
+                                lib_state.with_mut(|s| s.preview_web(paper_select.clone()));
+                            },
 
                             div { class: "library-card-body",
                                 div { class: "library-card-title", "{title}" }
@@ -156,24 +148,9 @@ pub(crate) fn ExternalResults() -> Element {
                                 } else {
                                     button {
                                         class: "btn btn--sm btn--primary",
-                                        onclick: move |_| {
-                                            let paper = paper_clone.clone();
-                                            let db = db_import.clone();
-                                            spawn(async move {
-                                                // If we have a DOI but sparse metadata (autocomplete result),
-                                                // fetch full details first
-                                                let paper = enrich_before_import(paper).await;
-                                                match db.insert_paper(&paper).await {
-                                                    Ok(id) => {
-                                                        let mut paper = paper;
-                                                        paper.id = Some(id.clone());
-                                                        lib_state.with_mut(|s| s.papers.insert(0, paper.clone()));
-                                                        // Auto-download OA PDF
-                                                        try_download_oa_pdf(&db, &mut lib_state, &paper, &id).await;
-                                                    }
-                                                    Err(e) => tracing::error!("Failed to import: {e}"),
-                                                }
-                                            });
+                                        onclick: move |evt| {
+                                            evt.stop_propagation();
+                                            import_channel.import(paper_import.clone());
                                         },
                                         "Import"
                                     }
@@ -187,66 +164,21 @@ pub(crate) fn ExternalResults() -> Element {
     }
 }
 
+/// A web result counts as imported when a library paper carries the same
+/// non-empty DOI.
+fn is_imported(paper: &rotero_models::Paper, existing_dois: &std::collections::HashSet<String>) -> bool {
+    paper
+        .doi
+        .as_ref()
+        .is_some_and(|d| !d.is_empty() && existing_dois.contains(d))
+}
+
 /// Stable identity for a merged result row, so Dioxus diffing survives the list
-/// re-ranking as slower providers stream in.
+/// re-ranking as slower providers stream in. Also used to mark the previewed
+/// row as selected.
 fn result_key(paper: &rotero_models::Paper) -> String {
     match paper.paper_id() {
         Some(pid) => pid.to_stored_string(),
         None => rotero_models::normalize_title(&paper.title),
     }
-}
-
-async fn try_download_oa_pdf(
-    db: &Database,
-    lib_state: &mut Signal<LibraryState>,
-    paper: &rotero_models::Paper,
-    paper_id: &str,
-) {
-    let title = &paper.title;
-    tracing::info!("Auto-downloading OA PDF for: {title}");
-    match crate::metadata::pdf_download::find_and_download_pdf(
-        db,
-        paper.doi.as_deref(),
-        &paper.title,
-        paper.authors.first().map(|a| a.as_str()),
-        paper.year,
-    )
-    .await
-    {
-        Ok(rel_path) => {
-            let _ = db.update_pdf_path(paper_id, &rel_path).await;
-            let pid = paper_id.to_string();
-            lib_state.with_mut(|s| {
-                if let Some(p) = s
-                    .papers
-                    .iter_mut()
-                    .find(|p| p.id.as_deref() == Some(pid.as_str()))
-                {
-                    p.links.pdf_path = Some(rel_path.clone());
-                }
-            });
-            tracing::info!("Auto-downloaded OA PDF for: {title} -> {rel_path}");
-        }
-        Err(e) => {
-            tracing::debug!("No OA PDF for: {title}: {e}");
-        }
-    }
-}
-
-/// If a paper has a DOI but missing authors, fetch full metadata before inserting.
-async fn enrich_before_import(paper: rotero_models::Paper) -> rotero_models::Paper {
-    let needs_enrichment =
-        paper.authors.is_empty() && paper.doi.as_ref().is_some_and(|d| !d.is_empty());
-    if !needs_enrichment {
-        return paper;
-    }
-
-    let doi = paper.doi.as_deref().unwrap_or_default();
-    if let Ok(enriched) = crate::metadata::openalex::fetch_by_doi(doi).await {
-        return enriched;
-    }
-    if let Ok(enriched) = crate::metadata::crossref::fetch_by_doi(doi).await {
-        return enriched;
-    }
-    paper
 }

--- a/src/ui/library/external_results.rs
+++ b/src/ui/library/external_results.rs
@@ -23,7 +23,12 @@ pub(crate) fn ExternalResults() -> Element {
         let batches: Vec<Vec<rotero_models::Paper>> = vec![
             state.search.openalex.results.clone().unwrap_or_default(),
             state.search.arxiv.results.clone().unwrap_or_default(),
-            state.search.semantic_scholar.results.clone().unwrap_or_default(),
+            state
+                .search
+                .semantic_scholar
+                .results
+                .clone()
+                .unwrap_or_default(),
         ];
         rotero_models::merge_and_rank(&batches, &state.search.query)
     });
@@ -166,7 +171,10 @@ pub(crate) fn ExternalResults() -> Element {
 
 /// A web result counts as imported when a library paper carries the same
 /// non-empty DOI.
-fn is_imported(paper: &rotero_models::Paper, existing_dois: &std::collections::HashSet<String>) -> bool {
+fn is_imported(
+    paper: &rotero_models::Paper,
+    existing_dois: &std::collections::HashSet<String>,
+) -> bool {
     paper
         .doi
         .as_ref()

--- a/src/ui/library/panel.rs
+++ b/src/ui/library/panel.rs
@@ -101,13 +101,15 @@ pub fn LibraryPanel() -> Element {
 
     let state = lib_state.read();
 
-    let is_external = state.search.source != crate::state::app_state::SearchSource::Local;
-    let external_results = state.search.external_results.clone();
-    let external_searching = state.search.external_searching;
-    let is_searching = state.search.results.is_some();
+    // A query is active whenever the search box is non-empty. The local list
+    // then shows `search.results` (which may briefly be None until the local
+    // DB task returns); the "From the web" section renders alongside it.
+    let query_active = state.search.is_active();
+    let is_searching = query_active;
+    let web_searching = state.search.web_searching();
 
-    let mut filtered: Vec<_> = if is_searching {
-        state.search.results.as_ref().unwrap().clone()
+    let mut filtered: Vec<_> = if query_active {
+        state.search.results.clone().unwrap_or_default()
     } else {
         match &state.view {
             LibraryView::AllPapers => state.papers.clone(),
@@ -350,37 +352,65 @@ pub fn LibraryPanel() -> Element {
                 SortButton {}
             }
 
-            if is_external {
-                ExternalResults {
-                    results: external_results.clone().unwrap_or_default(),
-                    searching: external_searching,
+            if query_active {
+                div { class: "search-scroll",
+                    section { class: "search-section",
+                        h3 { class: "search-section-title", "In your library" }
+                        div { class: "library-list",
+                            if filtered.is_empty() {
+                                div { class: "search-section-empty", "No matches in your library." }
+                            } else {
+                                for paper in filtered.iter() {
+                                    {
+                                        let paper_id = paper.id.clone().unwrap_or_default();
+                                        let selected = state.is_selected(&paper_id);
+                                        rsx! {
+                                            super::paper_card::PaperCard {
+                                                key: "{paper_id}",
+                                                paper: paper.clone(),
+                                                selected,
+                                                ctx_menu,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    section { class: "search-section",
+                        h3 { class: "search-section-title",
+                            "From the web"
+                            if web_searching {
+                                i { class: "bi bi-arrow-repeat external-spinner search-section-spinner" }
+                            }
+                        }
+                        ExternalResults {}
+                    }
                 }
-            }
-
-            if !is_external {
-            div { class: "library-list",
-                if filtered.is_empty() {
-                    LibraryEmptyState { view: state.view.clone(), is_searching }
-                } else if let Some(ref groups) = duplicate_groups {
-                    DuplicatesView { groups: groups.clone() }
-                } else {
-                    for paper in filtered.iter() {
-                        {
-                            let paper_id = paper.id.clone().unwrap_or_default();
-                            let selected = state.is_selected(&paper_id);
-                            rsx! {
-                                super::paper_card::PaperCard {
-                                    key: "{paper_id}",
-                                    paper: paper.clone(),
-                                    selected,
-                                    ctx_menu,
+            } else {
+                div { class: "library-list",
+                    if filtered.is_empty() {
+                        LibraryEmptyState { view: state.view.clone(), is_searching }
+                    } else if let Some(ref groups) = duplicate_groups {
+                        DuplicatesView { groups: groups.clone() }
+                    } else {
+                        for paper in filtered.iter() {
+                            {
+                                let paper_id = paper.id.clone().unwrap_or_default();
+                                let selected = state.is_selected(&paper_id);
+                                rsx! {
+                                    super::paper_card::PaperCard {
+                                        key: "{paper_id}",
+                                        paper: paper.clone(),
+                                        selected,
+                                        ctx_menu,
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-            } // end if !is_external
 
             if let Some((menu_paper_id, mx, my)) = ctx_menu() {
                 {

--- a/src/ui/paper_detail/detail.rs
+++ b/src/ui/paper_detail/detail.rs
@@ -2,10 +2,10 @@ use dioxus::prelude::*;
 
 use crate::state::app_state::{LibraryState, PdfTabManager};
 use crate::sync::engine::SyncConfig;
-use crate::ui::chat_panel::ResizeHandle;
-use crate::ui::components::context_menu::{ContextMenu, ContextMenuItem};
 use rotero_db::Database;
 
+use super::DetailShell;
+use super::detail_fields::DetailFields;
 use super::fields::{AddToCollectionSelect, TagEditor};
 use super::notes::NotesSection;
 
@@ -28,13 +28,6 @@ pub fn PaperDetail() -> Element {
     let pid_oa = paper_id.clone();
     let pid_del = paper_id.clone();
     let pid_open = paper_id.clone();
-    let authors_display = if paper.authors.is_empty() {
-        "Unknown".to_string()
-    } else {
-        paper.authors.join(", ")
-    };
-
-    let mut doi_ctx = use_signal(|| None::<(String, f64, f64)>);
 
     let mut editing_key = use_signal(|| false);
     let mut edit_key_value = use_signal(|| paper.citation.citation_key.clone().unwrap_or_default());
@@ -44,9 +37,7 @@ pub fn PaperDetail() -> Element {
     let oa_status_value = oa_statuses.read().get(&paper_id).cloned();
 
     rsx! {
-        div { class: "paper-detail",
-            ResizeHandle { target: "detail" }
-
+        DetailShell {
             div { class: "detail-header",
                 h3 { class: "detail-heading", "Details" }
                 button {
@@ -58,29 +49,7 @@ pub fn PaperDetail() -> Element {
                 }
             }
 
-            div { class: "detail-field",
-                label { class: "detail-label", "Title" }
-                div { class: "detail-value detail-value--title", "{paper.title}" }
-            }
-
-            div { class: "detail-field",
-                label { class: "detail-label", "Authors" }
-                div { class: "detail-value", "{authors_display}" }
-            }
-
-            if let Some(year) = paper.year {
-                div { class: "detail-field",
-                    label { class: "detail-label", "Year" }
-                    div { class: "detail-value", "{year}" }
-                }
-            }
-
-            if let Some(count) = paper.citation.citation_count {
-                div { class: "detail-field",
-                    label { class: "detail-label", "Citations" }
-                    div { class: "detail-value detail-value--citations", "{count}" }
-                }
-            }
+            DetailFields { paper: paper.clone() }
 
             if let Some(ref cite_key) = paper.citation.citation_key {
                 {
@@ -185,42 +154,6 @@ pub fn PaperDetail() -> Element {
                 }
             }
 
-            if let Some(ref journal) = paper.publication.journal {
-                div { class: "detail-field",
-                    label { class: "detail-label", "Journal" }
-                    div { class: "detail-value detail-value--journal", "{journal}" }
-                }
-            }
-
-            if let Some(ref doi) = paper.doi {
-                {
-                    let doi_for_ctx = doi.clone();
-                    rsx! {
-                        div { class: "detail-field",
-                            label { class: "detail-label", "DOI" }
-                            div {
-                                class: "detail-value detail-value--doi",
-                                oncontextmenu: move |evt: Event<MouseData>| {
-                                    evt.prevent_default();
-                                    doi_ctx.set(Some((doi_for_ctx.clone(), evt.client_coordinates().x, evt.client_coordinates().y)));
-                                },
-                                "{doi}"
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let Some(ref abstract_text) = paper.abstract_text {
-                div { class: "detail-field",
-                    label { class: "detail-label", "Abstract" }
-                    div {
-                        class: "detail-value detail-value--abstract rendered-latex",
-                        dangerous_inner_html: "{crate::ui::markdown::text_with_latex(abstract_text)}",
-                    }
-                }
-            }
-
             div { class: "detail-field",
                 label { class: "detail-label", "Collection" }
                 AddToCollectionSelect { paper_id: paper_id.clone() }
@@ -260,6 +193,7 @@ pub fn PaperDetail() -> Element {
                     if paper.links.pdf_path.is_none() {
                         {
                             let doi_for_oa = paper.doi.clone();
+                            let url_for_oa = paper.links.pdf_url.clone();
                             let paper_title = paper.title.clone();
                             let paper_authors = paper.authors.clone();
                             let paper_year = paper.year;
@@ -319,13 +253,14 @@ pub fn PaperDetail() -> Element {
                                             // Automated OA search
                                             let db = db_oa.clone();
                                             let doi = doi_for_oa.clone();
+                                            let direct_url = url_for_oa.clone();
                                             let title = paper_title.clone();
                                             let authors = paper_authors.clone();
                                             let year = paper_year;
                                             let paper_id = pid_oa.clone();
                                             oa_statuses.with_mut(|m| { m.insert(paper_id.clone(), "Searching...".into()); });
                                             spawn(async move {
-                                                let urls = crate::metadata::pdf_download::resolve_pdf_urls(doi.as_deref(), &title).await;
+                                                let urls = crate::metadata::pdf_download::resolve_pdf_urls(direct_url.as_deref(), doi.as_deref(), &title).await;
                                                 if urls.is_empty() {
                                                     oa_statuses.with_mut(|m| { m.insert(paper_id.clone(), "ask_agent".into()); });
                                                     return;
@@ -382,43 +317,6 @@ pub fn PaperDetail() -> Element {
                             }
                         },
                         "Delete Paper"
-                    }
-                }
-            }
-
-            if let Some((doi_str, mx, my)) = doi_ctx() {
-                {
-                    let doi_copy = doi_str.clone();
-                    let doi_open = doi_str.clone();
-                    rsx! {
-                        ContextMenu {
-                            x: mx,
-                            y: my,
-                            on_close: move |_| {
-                                doi_ctx.set(None);
-                            },
-
-                            ContextMenuItem {
-                                label: "Copy DOI".to_string(),
-                                icon: Some("bi-clipboard".to_string()),
-                                on_click: move |_| {
-                                    if let Ok(mut clip) = arboard::Clipboard::new() {
-                                        let _ = clip.set_text(&*doi_copy);
-                                    }
-                                    doi_ctx.set(None);
-                                },
-                            }
-
-                            ContextMenuItem {
-                                label: "Open in browser".to_string(),
-                                icon: Some("bi-box-arrow-up-right".to_string()),
-                                on_click: move |_| {
-                                    let url = format!("https://doi.org/{}", doi_open);
-                                    let _ = open::that(&url);
-                                    doi_ctx.set(None);
-                                },
-                            }
-                        }
                     }
                 }
             }

--- a/src/ui/paper_detail/detail_fields.rs
+++ b/src/ui/paper_detail/detail_fields.rs
@@ -1,0 +1,119 @@
+use dioxus::prelude::*;
+
+use crate::ui::components::context_menu::{ContextMenu, ContextMenuItem};
+use rotero_models::Paper;
+
+/// The read-only bibliographic block shared by the library detail panel and the
+/// web-result preview: title, authors, year, citations, journal, DOI (with a
+/// copy / open-in-browser context menu), and abstract.
+///
+/// Fields that are missing on the paper are simply skipped, so the same
+/// component renders a fully-populated library record and a sparse web hit
+/// without either side special-casing.
+#[component]
+pub fn DetailFields(paper: Paper) -> Element {
+    let authors_display = if paper.authors.is_empty() {
+        "Unknown".to_string()
+    } else {
+        paper.authors.join(", ")
+    };
+
+    let mut doi_ctx = use_signal(|| None::<(String, f64, f64)>);
+
+    rsx! {
+        div { class: "detail-field",
+            label { class: "detail-label", "Title" }
+            div { class: "detail-value detail-value--title", "{paper.title}" }
+        }
+
+        div { class: "detail-field",
+            label { class: "detail-label", "Authors" }
+            div { class: "detail-value", "{authors_display}" }
+        }
+
+        if let Some(year) = paper.year {
+            div { class: "detail-field",
+                label { class: "detail-label", "Year" }
+                div { class: "detail-value", "{year}" }
+            }
+        }
+
+        if let Some(count) = paper.citation.citation_count {
+            div { class: "detail-field",
+                label { class: "detail-label", "Citations" }
+                div { class: "detail-value detail-value--citations", "{count}" }
+            }
+        }
+
+        if let Some(ref journal) = paper.publication.journal {
+            div { class: "detail-field",
+                label { class: "detail-label", "Journal" }
+                div { class: "detail-value detail-value--journal", "{journal}" }
+            }
+        }
+
+        if let Some(ref doi) = paper.doi {
+            {
+                let doi_for_ctx = doi.clone();
+                rsx! {
+                    div { class: "detail-field",
+                        label { class: "detail-label", "DOI" }
+                        div {
+                            class: "detail-value detail-value--doi",
+                            oncontextmenu: move |evt: Event<MouseData>| {
+                                evt.prevent_default();
+                                doi_ctx.set(Some((doi_for_ctx.clone(), evt.client_coordinates().x, evt.client_coordinates().y)));
+                            },
+                            "{doi}"
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(ref abstract_text) = paper.abstract_text {
+            div { class: "detail-field",
+                label { class: "detail-label", "Abstract" }
+                div {
+                    class: "detail-value detail-value--abstract rendered-latex",
+                    dangerous_inner_html: "{crate::ui::markdown::text_with_latex(abstract_text)}",
+                }
+            }
+        }
+
+        if let Some((doi_str, mx, my)) = doi_ctx() {
+            {
+                let doi_copy = doi_str.clone();
+                let doi_open = doi_str.clone();
+                rsx! {
+                    ContextMenu {
+                        x: mx,
+                        y: my,
+                        on_close: move |_| doi_ctx.set(None),
+
+                        ContextMenuItem {
+                            label: "Copy DOI".to_string(),
+                            icon: Some("bi-clipboard".to_string()),
+                            on_click: move |_| {
+                                if let Ok(mut clip) = arboard::Clipboard::new() {
+                                    let _ = clip.set_text(&*doi_copy);
+                                }
+                                doi_ctx.set(None);
+                            },
+                        }
+
+                        ContextMenuItem {
+                            label: "Open in browser".to_string(),
+                            icon: Some("bi-box-arrow-up-right".to_string()),
+                            on_click: move |_| {
+                                let url = format!("https://doi.org/{}", doi_open);
+                                let _ = open::that(&url);
+                                doi_ctx.set(None);
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/paper_detail/detail_fields.rs
+++ b/src/ui/paper_detail/detail_fields.rs
@@ -106,7 +106,11 @@ pub fn DetailFields(paper: Paper) -> Element {
                             label: "Open in browser".to_string(),
                             icon: Some("bi-box-arrow-up-right".to_string()),
                             on_click: move |_| {
-                                let url = format!("https://doi.org/{}", doi_open);
+                                // Route to the right resolver: doi.org rejects
+                                // arXiv's `arXiv:ID` pseudo-DOI, so parse first.
+                                let url = rotero_models::PaperId::parse(&doi_open)
+                                    .map(|pid| pid.resolve_url())
+                                    .unwrap_or_else(|| format!("https://doi.org/{doi_open}"));
                                 let _ = open::that(&url);
                                 doi_ctx.set(None);
                             },

--- a/src/ui/paper_detail/mod.rs
+++ b/src/ui/paper_detail/mod.rs
@@ -1,7 +1,13 @@
 mod detail;
+mod detail_fields;
 mod fields;
 mod multi_select;
 mod notes;
+mod shell;
+mod web_preview;
 
 pub use detail::PaperDetail;
 pub use multi_select::MultiSelectSummary;
+pub use web_preview::WebPreview;
+
+use shell::DetailShell;

--- a/src/ui/paper_detail/multi_select.rs
+++ b/src/ui/paper_detail/multi_select.rs
@@ -4,6 +4,8 @@ use crate::state::app_state::LibraryState;
 use rotero_db::Database;
 use rotero_models::Paper;
 
+use super::DetailShell;
+
 #[component]
 pub fn MultiSelectSummary() -> Element {
     let mut lib_state = use_context::<Signal<LibraryState>>();
@@ -16,7 +18,7 @@ pub fn MultiSelectSummary() -> Element {
     drop(state);
 
     rsx! {
-        div { class: "paper-detail",
+        DetailShell {
             div { class: "detail-header",
                 h3 { class: "detail-heading", "{count} papers selected" }
                 button {

--- a/src/ui/paper_detail/shell.rs
+++ b/src/ui/paper_detail/shell.rs
@@ -1,0 +1,40 @@
+use dioxus::prelude::*;
+
+use crate::sync::engine::SyncConfig;
+use crate::ui::chat_panel::ResizeHandle;
+
+/// The right-hand detail panel shell shared by the library detail, web-result
+/// preview, and multi-select summary.
+///
+/// Owns the left-edge resize handle and a scrolling body. The handle is a
+/// sibling of the scroll area (not inside it), so it stays pinned over the full
+/// panel height even when the content scrolls — otherwise a tall panel leaves
+/// its lower edge un-draggable.
+///
+/// The panel width is persisted to [`SyncConfig`]: it opens at the saved width
+/// and writes the new width back when a drag ends, so the size survives panel
+/// switches and restarts.
+#[component]
+pub fn DetailShell(children: Element) -> Element {
+    let mut config = use_context::<Signal<SyncConfig>>();
+    let width = config.read().ui.detail_width;
+
+    rsx! {
+        div {
+            class: "paper-detail",
+            style: "width: {width}px; min-width: {width}px;",
+            ResizeHandle {
+                target: "detail",
+                on_resize: move |w: f64| {
+                    config.with_mut(|cfg| {
+                        cfg.ui.detail_width = w as f32;
+                        let _ = cfg.save();
+                    });
+                },
+            }
+            div { class: "paper-detail-body",
+                {children}
+            }
+        }
+    }
+}

--- a/src/ui/paper_detail/web_preview.rs
+++ b/src/ui/paper_detail/web_preview.rs
@@ -33,7 +33,14 @@ pub fn WebPreview() -> Element {
     });
     drop(state);
 
-    let doi_open = paper.doi.clone();
+    // Resolve the identifier to its correct site (doi.org for real DOIs,
+    // arxiv.org for arXiv, …) and label the button accordingly.
+    let open_url = paper.resolve_url();
+    let open_label = if paper.paper_id().is_some_and(|p| p.is_arxiv()) {
+        "Open on arXiv"
+    } else {
+        "Open DOI"
+    };
     let paper_for_import = paper.clone();
 
     rsx! {
@@ -75,16 +82,13 @@ pub fn WebPreview() -> Element {
                         }
                     }
 
-                    if let Some(doi) = doi_open {
-                        if !doi.is_empty() {
-                            button {
-                                class: "btn btn--secondary",
-                                onclick: move |_| {
-                                    let url = format!("https://doi.org/{doi}");
-                                    let _ = open::that(&url);
-                                },
-                                "Open DOI"
-                            }
+                    if let Some(url) = open_url {
+                        button {
+                            class: "btn btn--secondary",
+                            onclick: move |_| {
+                                let _ = open::that(&url);
+                            },
+                            "{open_label}"
                         }
                     }
                 }

--- a/src/ui/paper_detail/web_preview.rs
+++ b/src/ui/paper_detail/web_preview.rs
@@ -1,0 +1,94 @@
+use dioxus::prelude::*;
+
+use crate::state::app_state::LibraryState;
+use crate::state::commands::ImportChannel;
+
+use super::DetailShell;
+use super::detail_fields::DetailFields;
+
+/// Read-only overview of a web search result that hasn't been imported yet.
+///
+/// Shares the [`DetailFields`] bibliographic block with the library detail
+/// panel, so a web hit and a library record present identically. Since the
+/// paper isn't in the library, this offers only Import and Open-DOI — no tags,
+/// notes, or collections, which require a stored record.
+#[component]
+pub fn WebPreview() -> Element {
+    let mut lib_state = use_context::<Signal<LibraryState>>();
+    let import_channel = use_context::<ImportChannel>();
+
+    let state = lib_state.read();
+    let paper = match state.previewed_web.clone() {
+        Some(p) => p,
+        None => return rsx! {},
+    };
+    // A web hit counts as already-imported when a library paper carries the
+    // same non-empty DOI.
+    let already_imported = paper.doi.as_deref().is_some_and(|doi| {
+        !doi.is_empty()
+            && state
+                .papers
+                .iter()
+                .any(|p| p.doi.as_deref() == Some(doi))
+    });
+    drop(state);
+
+    let doi_open = paper.doi.clone();
+    let paper_for_import = paper.clone();
+
+    rsx! {
+        DetailShell {
+            div { class: "detail-header",
+                h3 { class: "detail-heading", "Details" }
+                button {
+                    class: "detail-close",
+                    onclick: move |_| {
+                        lib_state.with_mut(|s| s.previewed_web = None);
+                    },
+                    "\u{00d7}"
+                }
+            }
+
+            div { class: "detail-web-badge", "From the web" }
+
+            DetailFields { paper: paper.clone() }
+
+            div { class: "detail-delete-section",
+                div { class: "detail-actions",
+                    if already_imported {
+                        button {
+                            class: "btn btn--ghost",
+                            disabled: true,
+                            i { class: "bi bi-check-lg" }
+                            " In library"
+                        }
+                    } else {
+                        button {
+                            class: "btn btn--primary",
+                            onclick: move |_| {
+                                import_channel.import(paper_for_import.clone());
+                                // Reflect the import immediately: drop the preview
+                                // so the panel returns to the library view.
+                                lib_state.with_mut(|s| s.previewed_web = None);
+                            },
+                            "Import"
+                        }
+                    }
+
+                    if let Some(doi) = doi_open {
+                        if !doi.is_empty() {
+                            button {
+                                class: "btn btn--secondary",
+                                onclick: move |_| {
+                                    let url = format!("https://doi.org/{doi}");
+                                    let _ = open::that(&url);
+                                },
+                                "Open DOI"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/paper_detail/web_preview.rs
+++ b/src/ui/paper_detail/web_preview.rs
@@ -25,11 +25,7 @@ pub fn WebPreview() -> Element {
     // A web hit counts as already-imported when a library paper carries the
     // same non-empty DOI.
     let already_imported = paper.doi.as_deref().is_some_and(|doi| {
-        !doi.is_empty()
-            && state
-                .papers
-                .iter()
-                .any(|p| p.doi.as_deref() == Some(doi))
+        !doi.is_empty() && state.papers.iter().any(|p| p.doi.as_deref() == Some(doi))
     });
     drop(state);
 

--- a/src/ui/search_bar.rs
+++ b/src/ui/search_bar.rs
@@ -1,15 +1,16 @@
 use dioxus::prelude::*;
 use futures_util::StreamExt;
 
-use crate::state::app_state::{LibraryState, SearchSource};
+use crate::state::app_state::{LibraryState, ProviderResults};
 use rotero_db::Database;
+use rotero_search::SearchProvider;
 
 const MIN_QUERY_LEN: usize = 3;
 const DEBOUNCE_MS: u64 = 250;
 
 #[derive(Clone)]
 enum SearchMsg {
-    Query(SearchSource, String),
+    Query(String),
     Clear,
 }
 
@@ -17,96 +18,76 @@ enum SearchMsg {
 pub fn SearchBar() -> Element {
     let mut lib_state = use_context::<Signal<LibraryState>>();
     let db = use_context::<Database>();
-    let (query, source) = {
-        let state = lib_state.read();
-        (state.search.query.clone(), state.search.source.clone())
-    };
-    let mut show_dropdown = use_signal(|| false);
+    let query = lib_state.read().search.query.clone();
 
-    let search_coro = use_coroutine(move |mut rx: UnboundedReceiver<SearchMsg>| async move {
-        while let Some(msg) = rx.next().await {
-            match msg {
-                SearchMsg::Clear => {
-                    lib_state.with_mut(|s| {
-                        s.search.external_results = None;
-                        s.search.external_searching = false;
+    let search_coro = use_coroutine({
+        let db = db.clone();
+        move |mut rx: UnboundedReceiver<SearchMsg>| {
+            let db = db.clone();
+            async move {
+            while let Some(msg) = rx.next().await {
+                let query = match msg {
+                    SearchMsg::Clear => {
+                        lib_state.with_mut(|s| s.search.reset_results());
+                        continue;
+                    }
+                    SearchMsg::Query(q) => drain_latest(&mut rx, q),
+                };
+
+                if query.trim().len() < MIN_QUERY_LEN {
+                    lib_state.with_mut(|s| s.search.reset_results());
+                    continue;
+                }
+
+                // Debounce, then coalesce anything typed during the sleep.
+                tokio::time::sleep(std::time::Duration::from_millis(DEBOUNCE_MS)).await;
+                let query = drain_latest(&mut rx, query);
+                if query.trim().len() < MIN_QUERY_LEN {
+                    lib_state.with_mut(|s| s.search.reset_results());
+                    continue;
+                }
+
+                // Commit this query: bump the generation, mark every provider
+                // in-flight and clear stale results so old hits don't linger
+                // under the new query.
+                let generation = lib_state.with_mut(|s| {
+                    s.search.generation += 1;
+                    s.search.results = None;
+                    s.search.openalex = ProviderResults { results: None, searching: true };
+                    s.search.arxiv = ProviderResults { results: None, searching: true };
+                    s.search.semantic_scholar =
+                        ProviderResults { results: None, searching: true };
+                    s.search.generation
+                });
+
+                // Fan out. Each task writes only its own slice, guarded by the
+                // generation, and nothing awaits anything else — local and each
+                // provider render the instant they return.
+                {
+                    let db = db.clone();
+                    let q = query.clone();
+                    spawn(async move {
+                        let results = db.search_papers(&q).await.unwrap_or_default();
+                        lib_state.with_mut(|s| {
+                            if s.search.generation == generation {
+                                s.search.results = Some(results);
+                            }
+                        });
                     });
                 }
-                SearchMsg::Query(source, query) => {
-                    let (source, query) = drain_latest(&mut rx, source, query);
 
-                    if query.trim().len() < MIN_QUERY_LEN {
-                        lib_state.with_mut(|s| {
-                            s.search.external_results = None;
-                            s.search.external_searching = false;
-                        });
-                        continue;
-                    }
-
-                    lib_state.with_mut(|s| s.search.external_searching = true);
-
-                    tokio::time::sleep(std::time::Duration::from_millis(DEBOUNCE_MS)).await;
-                    let (source, query) = drain_latest(&mut rx, source, query);
-
-                    if query.trim().len() < MIN_QUERY_LEN {
-                        lib_state.with_mut(|s| {
-                            s.search.external_results = None;
-                            s.search.external_searching = false;
-                        });
-                        continue;
-                    }
-
-                    let Some(provider) = source.provider() else {
-                        continue;
-                    };
-
-                    match provider.search(&query, 20).await {
-                        Ok(metas) => {
-                            let papers: Vec<_> = metas;
-                            lib_state.with_mut(|s| {
-                                s.search.external_searching = false;
-                                s.search.external_results = Some(papers);
-                            });
-                        }
-                        Err(e) => {
-                            tracing::error!("External search error: {e}");
-                            lib_state.with_mut(|s| {
-                                s.search.external_searching = false;
-                                s.search.external_results = Some(Vec::new());
-                            });
-                        }
-                    }
-
-                    if provider.needs_enrichment() {
-                        if rx.try_recv().is_ok() {
-                            continue;
-                        }
-                        match provider.search_full(&query, 20).await {
-                            Ok(metas) => {
-                                let papers: Vec<_> = metas;
-                                if lib_state.read().search.query == query {
-                                    lib_state
-                                        .with_mut(|s| s.search.external_results = Some(papers));
-                                }
-                            }
-                            Err(e) => {
-                                tracing::error!("Full search enrichment error: {e}");
-                            }
-                        }
-                    }
-                }
+                spawn_provider(SearchProvider::OpenAlex, generation, query.clone(), lib_state);
+                spawn_provider(SearchProvider::ArXiv, generation, query.clone(), lib_state);
+                spawn_provider(
+                    SearchProvider::SemanticScholar,
+                    generation,
+                    query.clone(),
+                    lib_state,
+                );
+            }
             }
         }
     });
-
-    let is_external = source != SearchSource::Local;
-
-    let placeholder = match source {
-        SearchSource::Local => "Search papers...",
-        SearchSource::OpenAlex => "Search OpenAlex...",
-        SearchSource::ArXiv => "Search arXiv...",
-        SearchSource::SemanticScholar => "Search Semantic Scholar...",
-    };
 
     rsx! {
         div { class: "search-bar",
@@ -115,37 +96,20 @@ pub fn SearchBar() -> Element {
                 id: "library-search-input",
                 class: "input input--lg search-input",
                 r#type: "text",
-                placeholder: "{placeholder}",
+                placeholder: "Search your library and the web...",
                 value: "{query}",
                 oninput: move |evt| {
                     let q = evt.value();
                     lib_state.with_mut(|s| s.search.query = q.clone());
-
-                    let current_source = lib_state.read().search.source.clone();
-
-                    if current_source == SearchSource::Local {
-                        if q.trim().is_empty() {
-                            lib_state.with_mut(|s| s.search.results = None);
-                            return;
-                        }
-                        let db = db.clone();
-                        spawn(async move {
-                            match db.search_papers(&q).await {
-                                Ok(results) => {
-                                    lib_state.with_mut(|s| s.search.results = Some(results));
-                                }
-                                Err(_) => {
-                                    lib_state.with_mut(|s| s.search.results = Some(Vec::new()));
-                                }
-                            }
-                        });
+                    if q.trim().is_empty() {
+                        search_coro.send(SearchMsg::Clear);
                     } else {
-                        search_coro.send(SearchMsg::Query(current_source, q));
+                        search_coro.send(SearchMsg::Query(q));
                     }
                 },
             }
 
-            if !query.is_empty() && !is_external {
+            if !query.is_empty() {
                 button {
                     class: "btn btn--ghost btn--sm search-save",
                     title: "Save this search",
@@ -166,84 +130,91 @@ pub fn SearchBar() -> Element {
                     },
                     i { class: "bi bi-bookmark-plus" }
                 }
-            }
-            if !query.is_empty() {
                 button {
                     class: "search-clear",
                     onclick: move |_| {
                         search_coro.send(SearchMsg::Clear);
                         lib_state.with_mut(|s| {
                             s.search.query.clear();
-                            s.search.results = None;
-                            s.search.external_results = None;
-                            s.search.external_searching = false;
+                            s.search.reset_results();
                         });
                     },
                     i { class: "bi bi-x-lg" }
-                }
-            }
-
-            div { class: "search-source-wrapper",
-                button {
-                    class: if is_external { "btn btn--sm search-source-btn search-source-btn--active" } else { "btn btn--sm search-source-btn" },
-                    onclick: move |_| show_dropdown.toggle(),
-                    "{source.label()}"
-                    i { class: "bi bi-chevron-down search-source-chevron" }
-                }
-                if show_dropdown() {
-                    div { class: "search-source-dropdown",
-                        for src in SearchSource::all().iter() {
-                            {
-                                let s = src.clone();
-                                let label = src.label();
-                                let is_active = *src == source;
-                                rsx! {
-                                    button {
-                                        key: "{label}",
-                                        class: if is_active { "search-source-option search-source-option--active" } else { "search-source-option" },
-                                        onclick: move |_| {
-                                            search_coro.send(SearchMsg::Clear);
-                                            lib_state.with_mut(|st| {
-                                                st.search.source = s.clone();
-                                                st.search.results = None;
-                                                st.search.external_results = None;
-                                                st.search.external_searching = false;
-                                            });
-                                            show_dropdown.set(false);
-                                        },
-                                        "{label}"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    div {
-                        class: "search-source-backdrop",
-                        onclick: move |_| show_dropdown.set(false),
-                    }
                 }
             }
         }
     }
 }
 
-fn drain_latest(
-    rx: &mut UnboundedReceiver<SearchMsg>,
-    source: SearchSource,
+/// Spawns one provider search task. Writes only that provider's slice, guarded
+/// by `generation`, and runs OpenAlex's two-phase enrichment within the same
+/// task so it stays independent of the other providers.
+fn spawn_provider(
+    provider: SearchProvider,
+    generation: u64,
     query: String,
-) -> (SearchSource, String) {
-    let mut latest_source = source;
+    mut lib_state: Signal<LibraryState>,
+) {
+    spawn(async move {
+        match provider.search(&query, 20).await {
+            Ok(papers) => lib_state.with_mut(|s| {
+                if s.search.generation == generation {
+                    let slot = provider_slot(provider, s);
+                    slot.results = Some(papers);
+                    // Stay "searching" if a richer follow-up call is coming.
+                    slot.searching = provider.needs_enrichment();
+                }
+            }),
+            Err(e) => {
+                tracing::error!("{} search error: {e}", provider.name());
+                lib_state.with_mut(|s| {
+                    if s.search.generation == generation {
+                        let slot = provider_slot(provider, s);
+                        slot.results = Some(Vec::new());
+                        slot.searching = false;
+                    }
+                });
+            }
+        }
+
+        if provider.needs_enrichment() {
+            match provider.search_full(&query, 20).await {
+                Ok(papers) => lib_state.with_mut(|s| {
+                    if s.search.generation == generation {
+                        let slot = provider_slot(provider, s);
+                        slot.results = Some(papers);
+                        slot.searching = false;
+                    }
+                }),
+                Err(e) => {
+                    tracing::error!("{} enrichment error: {e}", provider.name());
+                    lib_state.with_mut(|s| {
+                        if s.search.generation == generation {
+                            provider_slot(provider, s).searching = false;
+                        }
+                    });
+                }
+            }
+        }
+    });
+}
+
+/// Returns the mutable state slice belonging to a provider.
+fn provider_slot(provider: SearchProvider, state: &mut LibraryState) -> &mut ProviderResults {
+    match provider {
+        SearchProvider::OpenAlex => &mut state.search.openalex,
+        SearchProvider::ArXiv => &mut state.search.arxiv,
+        SearchProvider::SemanticScholar => &mut state.search.semantic_scholar,
+    }
+}
+
+fn drain_latest(rx: &mut UnboundedReceiver<SearchMsg>, query: String) -> String {
     let mut latest_query = query;
     while let Ok(msg) = rx.try_recv() {
         match msg {
-            SearchMsg::Query(s, q) => {
-                latest_source = s;
-                latest_query = q;
-            }
-            SearchMsg::Clear => {
-                latest_query = String::new();
-            }
+            SearchMsg::Query(q) => latest_query = q,
+            SearchMsg::Clear => latest_query = String::new(),
         }
     }
-    (latest_source, latest_query)
+    latest_query
 }

--- a/src/ui/search_bar.rs
+++ b/src/ui/search_bar.rs
@@ -25,71 +25,84 @@ pub fn SearchBar() -> Element {
         move |mut rx: UnboundedReceiver<SearchMsg>| {
             let db = db.clone();
             async move {
-            while let Some(msg) = rx.next().await {
-                let query = match msg {
-                    SearchMsg::Clear => {
-                        lib_state.with_mut(|s| {
-                            s.search.reset_results();
-                            // Drop any web-result preview: its source list is
-                            // gone, so the detail panel shouldn't keep showing it.
-                            s.previewed_web = None;
-                        });
+                while let Some(msg) = rx.next().await {
+                    let query = match msg {
+                        SearchMsg::Clear => {
+                            lib_state.with_mut(|s| {
+                                s.search.reset_results();
+                                // Drop any web-result preview: its source list is
+                                // gone, so the detail panel shouldn't keep showing it.
+                                s.previewed_web = None;
+                            });
+                            continue;
+                        }
+                        SearchMsg::Query(q) => drain_latest(&mut rx, q),
+                    };
+
+                    if query.trim().len() < MIN_QUERY_LEN {
+                        lib_state.with_mut(|s| s.search.reset_results());
                         continue;
                     }
-                    SearchMsg::Query(q) => drain_latest(&mut rx, q),
-                };
 
-                if query.trim().len() < MIN_QUERY_LEN {
-                    lib_state.with_mut(|s| s.search.reset_results());
-                    continue;
-                }
+                    // Debounce, then coalesce anything typed during the sleep.
+                    tokio::time::sleep(std::time::Duration::from_millis(DEBOUNCE_MS)).await;
+                    let query = drain_latest(&mut rx, query);
+                    if query.trim().len() < MIN_QUERY_LEN {
+                        lib_state.with_mut(|s| s.search.reset_results());
+                        continue;
+                    }
 
-                // Debounce, then coalesce anything typed during the sleep.
-                tokio::time::sleep(std::time::Duration::from_millis(DEBOUNCE_MS)).await;
-                let query = drain_latest(&mut rx, query);
-                if query.trim().len() < MIN_QUERY_LEN {
-                    lib_state.with_mut(|s| s.search.reset_results());
-                    continue;
-                }
-
-                // Commit this query: bump the generation, mark every provider
-                // in-flight and clear stale results so old hits don't linger
-                // under the new query.
-                let generation = lib_state.with_mut(|s| {
-                    s.search.generation += 1;
-                    s.search.results = None;
-                    s.search.openalex = ProviderResults { results: None, searching: true };
-                    s.search.arxiv = ProviderResults { results: None, searching: true };
-                    s.search.semantic_scholar =
-                        ProviderResults { results: None, searching: true };
-                    s.search.generation
-                });
-
-                // Fan out. Each task writes only its own slice, guarded by the
-                // generation, and nothing awaits anything else — local and each
-                // provider render the instant they return.
-                {
-                    let db = db.clone();
-                    let q = query.clone();
-                    spawn(async move {
-                        let results = db.search_papers(&q).await.unwrap_or_default();
-                        lib_state.with_mut(|s| {
-                            if s.search.generation == generation {
-                                s.search.results = Some(results);
-                            }
-                        });
+                    // Commit this query: bump the generation, mark every provider
+                    // in-flight and clear stale results so old hits don't linger
+                    // under the new query.
+                    let generation = lib_state.with_mut(|s| {
+                        s.search.generation += 1;
+                        s.search.results = None;
+                        s.search.openalex = ProviderResults {
+                            results: None,
+                            searching: true,
+                        };
+                        s.search.arxiv = ProviderResults {
+                            results: None,
+                            searching: true,
+                        };
+                        s.search.semantic_scholar = ProviderResults {
+                            results: None,
+                            searching: true,
+                        };
+                        s.search.generation
                     });
-                }
 
-                spawn_provider(SearchProvider::OpenAlex, generation, query.clone(), lib_state);
-                spawn_provider(SearchProvider::ArXiv, generation, query.clone(), lib_state);
-                spawn_provider(
-                    SearchProvider::SemanticScholar,
-                    generation,
-                    query.clone(),
-                    lib_state,
-                );
-            }
+                    // Fan out. Each task writes only its own slice, guarded by the
+                    // generation, and nothing awaits anything else — local and each
+                    // provider render the instant they return.
+                    {
+                        let db = db.clone();
+                        let q = query.clone();
+                        spawn(async move {
+                            let results = db.search_papers(&q).await.unwrap_or_default();
+                            lib_state.with_mut(|s| {
+                                if s.search.generation == generation {
+                                    s.search.results = Some(results);
+                                }
+                            });
+                        });
+                    }
+
+                    spawn_provider(
+                        SearchProvider::OpenAlex,
+                        generation,
+                        query.clone(),
+                        lib_state,
+                    );
+                    spawn_provider(SearchProvider::ArXiv, generation, query.clone(), lib_state);
+                    spawn_provider(
+                        SearchProvider::SemanticScholar,
+                        generation,
+                        query.clone(),
+                        lib_state,
+                    );
+                }
             }
         }
     });

--- a/src/ui/search_bar.rs
+++ b/src/ui/search_bar.rs
@@ -28,7 +28,12 @@ pub fn SearchBar() -> Element {
             while let Some(msg) = rx.next().await {
                 let query = match msg {
                     SearchMsg::Clear => {
-                        lib_state.with_mut(|s| s.search.reset_results());
+                        lib_state.with_mut(|s| {
+                            s.search.reset_results();
+                            // Drop any web-result preview: its source list is
+                            // gone, so the detail panel shouldn't keep showing it.
+                            s.previewed_web = None;
+                        });
                         continue;
                     }
                     SearchMsg::Query(q) => drain_latest(&mut rx, q),
@@ -137,6 +142,7 @@ pub fn SearchBar() -> Element {
                         lib_state.with_mut(|s| {
                             s.search.query.clear();
                             s.search.reset_results();
+                            s.previewed_web = None;
                         });
                     },
                     i { class: "bi bi-x-lg" }


### PR DESCRIPTION
Consolidates the library search into a single streaming, ranked bar and builds out the surrounding UX: a web-result overview, reliable import→PDF-download, a resizable/persistent detail panel, and two search-correctness fixes.

## Unified search (02c7e75)
- One search box, no source picker. Local + OpenAlex + arXiv + Semantic Scholar run concurrently, generation-guarded, fully non-blocking — results stream in as each source returns.
- Web results are merged, deduplicated (via canonical `PaperId`, so the same paper across sources collapses to one), and ranked with per-source min-max normalized relevance blended with an exact/prefix title boost.

## Web-result overview + coherent detail refactor (1487c0f)
- Clicking a web result opens a read-only overview in the detail panel (title/authors/year/citations/journal/DOI/abstract + Import / Open).
- Extracted the shared bibliographic block into a reusable `DetailFields`, rendered by both the library detail and the web preview — no duplicated markup.
- `LibraryState.previewed_web` is mutually exclusive with a library selection; `layout` branches to `WebPreview` / `PaperDetail` / `MultiSelectSummary`.

## Import always downloads the PDF (1487c0f)
- New app-root `ImportChannel` coroutine owns enrich → insert → OA download, so the download future outlives the card/panel that queued it (clearing the search no longer cancels it). Every path routes through it (web card, Import All, web preview, +DOI).
- Thread a direct `pdf_url` as the first-priority download candidate, and give arXiv results their `arxiv.org/pdf/{id}` link, since arXiv's pseudo-DOI doesn't resolve through the OA APIs.

## Resizable, persistent detail panel (1487c0f)
- New `DetailShell` wraps all three detail surfaces; the resize handle is a sibling of the scrolling body so it stays pinned over the full height even when content overflows.
- Width persists to `SyncConfig` (`ui.detail_width`) — reported on mouse-up via a Promise-backed eval, so it survives panel switches and restarts.

## Search correctness
- **FTS AND-join (1487c0f):** turso combines bare tokens with OR and keeps stopwords, so `a bitter lesson` matched nearly the whole library on "a" and BM25 surfaced an unrelated paper. `build_fts_match_query` AND-joins quoted tokens so all terms must be present; wired into rotero-db and rotero-mcp.
- **Identifier URL resolution (6156982):** doi.org rejects arXiv's `arXiv:ID` pseudo-DOI. `PaperId::resolve_url()` routes real DOIs → doi.org, arXiv → arxiv.org, PMID → PubMed, ISBN → WorldCat, applied at all "Open" call sites and the translator scrape.

## UI polish (b0d476e)
- "From the web" marker restyled as a compact chip (was stretching full-width because `align-self` had no flex parent).

## Testing
- `cargo test -p rotero-models` — 20 pass (merge/dedup/normalization, exact-title rank, FTS query builder, identifier URL resolution).
- `cargo check --workspace` + clippy clean (one pre-existing unrelated `sort_by_key` warning in sidebar/nav.rs).
- FTS behavior verified against the real library DB.