### PR TITLE
Let the user rename a paper

### DIFF
--- a/assets/detail.css
+++ b/assets/detail.css
@@ -102,6 +102,32 @@
   letter-spacing: var(--tracking-tight);
 }
 
+/* Click-to-rename affordance on the library detail title. The web preview's
+   title reuses .detail-value--title alone and stays inert. */
+.detail-value--editable {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  margin-left: -4px;
+  padding: 0 4px;
+  transition: background var(--transition-fast);
+}
+
+.detail-value--editable:hover {
+  background: var(--bg-hover);
+}
+
+/* The title editor matches the rendered title's type so committing an edit
+   doesn't visibly reflow the field. A textarea wraps long titles; Enter still
+   commits, so it behaves as a one-line field. */
+.detail-title-input {
+  width: 100%;
+  font-size: var(--text-xl);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  resize: vertical;
+}
+
 .detail-value--journal {
   color: var(--text-secondary);
 }

--- a/crates/rotero-db/src/papers.rs
+++ b/crates/rotero-db/src/papers.rs
@@ -364,6 +364,29 @@ impl Database {
         Ok(())
     }
 
+    /// Set a paper's title, leaving its other bibliographic fields untouched.
+    ///
+    /// Distinct from [`Database::update_paper_metadata`], which rewrites the
+    /// whole bibliographic row: a user renaming one paper should not overwrite
+    /// fields enrichment may have filled in since, nor mark them all dirty for
+    /// sync. The FTS index covers `title` directly, so it follows this write.
+    pub async fn update_paper_title(&self, id: &str, title: &str) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            queries::PAPER_UPDATE_TITLE,
+            turso::params::Params::Positional(vec![
+                Value::Text(title.to_string()),
+                Value::Text(Utc::now().to_rfc3339()),
+                Value::Text(id.to_string()),
+            ]),
+        )
+        .await?;
+        self.crr()
+            .track_update("papers", id, &[Papers::TITLE, Papers::DATE_MODIFIED])
+            .await?;
+        Ok(())
+    }
+
     /// Update the relative PDF file path for a paper.
     pub async fn update_pdf_path(&self, id: &str, pdf_path: &str) -> Result<(), crate::DbError> {
         let conn = self.conn();

--- a/crates/rotero-db/tests/paper_rename_test.rs
+++ b/crates/rotero-db/tests/paper_rename_test.rs
@@ -1,0 +1,96 @@
+//! Covers `update_paper_title`, the write behind the UI's rename action.
+//!
+//! Renaming deliberately does not go through `update_paper_metadata`, which
+//! rewrites every bibliographic column. These tests pin the two properties that
+//! distinction exists for: unrelated fields keep their values, and only the
+//! title's sync clock advances.
+
+mod common;
+
+use common::{col_ver, open_test_db};
+use rotero_models::{Paper, Publication};
+
+fn sample_paper() -> Paper {
+    Paper {
+        title: "Attention Is All You Need".into(),
+        year: Some(2017),
+        doi: Some("10.48550/arXiv.1706.03762".into()),
+        abstract_text: Some("The dominant sequence transduction models…".into()),
+        publication: Publication {
+            journal: Some("NeurIPS".into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn rename_replaces_only_the_title() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_test_db(dir.path()).await;
+    let id = db.insert_paper(&sample_paper()).await.unwrap();
+
+    db.update_paper_title(&id, "Attention Is All You Need (v2)")
+        .await
+        .unwrap();
+
+    let papers = db.list_papers().await.unwrap();
+    let p = papers.iter().find(|p| p.id.as_deref() == Some(&id)).unwrap();
+    assert_eq!(p.title, "Attention Is All You Need (v2)");
+    // The whole point of a title-only write: a rename must not blank the fields
+    // enrichment filled in, which a full-row rewrite from a stale Paper would.
+    assert_eq!(p.year, Some(2017));
+    // Stored in canonical arXiv form, as insert wrote it.
+    assert_eq!(p.doi.as_deref(), Some("arXiv:1706.03762"));
+    assert_eq!(p.publication.journal.as_deref(), Some("NeurIPS"));
+    assert!(p.abstract_text.is_some());
+}
+
+#[tokio::test]
+async fn rename_bumps_only_the_title_clock() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_test_db(dir.path()).await;
+    let id = db.insert_paper(&sample_paper()).await.unwrap();
+
+    let doi_before = col_ver(&db, "papers", &id, "doi").await;
+    let title_before = col_ver(&db, "papers", &id, "title").await;
+
+    db.update_paper_title(&id, "Renamed").await.unwrap();
+
+    assert!(
+        col_ver(&db, "papers", &id, "title").await > title_before,
+        "renaming must advance the title's column version so the change syncs"
+    );
+    assert_eq!(
+        col_ver(&db, "papers", &id, "doi").await,
+        doi_before,
+        "renaming must not mark untouched columns dirty — that would let a \
+         rename overwrite a peer's newer DOI on merge"
+    );
+}
+
+/// The FTS index covers `title`, and the app's search box goes through
+/// `search_papers`. A rename that updated the row but not the index would leave
+/// the paper findable only under its old name.
+#[tokio::test]
+async fn rename_is_reflected_in_search() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_test_db(dir.path()).await;
+    let id = db.insert_paper(&sample_paper()).await.unwrap();
+
+    db.update_paper_title(&id, "Sparse Autoencoders For Interpretability")
+        .await
+        .unwrap();
+
+    let hits = db.search_papers("Sparse Autoencoders").await.unwrap();
+    assert!(
+        hits.iter().any(|p| p.id.as_deref() == Some(&id)),
+        "the renamed paper must be findable under its new title"
+    );
+
+    let stale = db.search_papers("Attention Is All You Need").await.unwrap();
+    assert!(
+        !stale.iter().any(|p| p.id.as_deref() == Some(&id)),
+        "the renamed paper must no longer match its old title"
+    );
+}

--- a/crates/rotero-db/tests/paper_rename_test.rs
+++ b/crates/rotero-db/tests/paper_rename_test.rs
@@ -35,7 +35,10 @@ async fn rename_replaces_only_the_title() {
         .unwrap();
 
     let papers = db.list_papers().await.unwrap();
-    let p = papers.iter().find(|p| p.id.as_deref() == Some(&id)).unwrap();
+    let p = papers
+        .iter()
+        .find(|p| p.id.as_deref() == Some(&id))
+        .unwrap();
     assert_eq!(p.title, "Attention Is All You Need (v2)");
     // The whole point of a title-only write: a rename must not blank the fields
     // enrichment filled in, which a full-row rewrite from a stale Paper would.

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -59,6 +59,9 @@ pub const PAPER_UPDATE_METADATA: &str = "\
 /// Set or replace the local PDF file path for a paper.
 pub const PAPER_UPDATE_PDF_PATH: &str =
     "UPDATE papers SET pdf_path = ?1, date_modified = ?2 WHERE id = ?3";
+/// Set the title for a paper, leaving every other bibliographic field alone.
+pub const PAPER_UPDATE_TITLE: &str =
+    "UPDATE papers SET title = ?1, date_modified = ?2 WHERE id = ?3";
 /// Bump the date_modified timestamp on a paper.
 pub const PAPER_TOUCH: &str = "UPDATE papers SET date_modified = ?1 WHERE id = ?2";
 /// Delete a paper by ID.

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -514,6 +514,11 @@ pub struct LibraryState {
     /// the selection, and selecting a library paper clears this.
     pub previewed_web: Option<Paper>,
     pub confirm_delete: Option<Vec<String>>,
+    /// The paper whose title the detail panel should open in its inline title
+    /// editor. Set by the library context menu's Rename action, which lives in
+    /// a different component tree than the editor it drives; the editor clears
+    /// it once it has taken focus.
+    pub rename_paper_id: Option<String>,
     pub view: LibraryView,
     pub search: LibrarySearchState,
     pub filter: LibraryFilterState,
@@ -622,6 +627,12 @@ impl LibraryState {
         self.selected_paper_ids.clear();
         self.selected_paper_ids.insert(id.clone());
         self.anchor_paper_id = Some(id);
+    }
+
+    /// Select `id` and ask the detail panel to open its title editor for it.
+    pub fn start_rename(&mut self, id: String) {
+        self.select_one(id.clone());
+        self.rename_paper_id = Some(id);
     }
 
     pub fn toggle_select(&mut self, id: &str) {

--- a/src/ui/library/context_menu.rs
+++ b/src/ui/library/context_menu.rs
@@ -246,6 +246,22 @@ pub fn PaperContextMenu(
                         &db,
                         lib_state,
                     )}
+
+                    // Rename — selects the paper and hands off to the detail
+                    // panel's inline title editor, so there is one edit surface.
+                    {
+                        let pid = pids[0].clone();
+                        rsx! {
+                            ContextMenuItem {
+                                label: "Rename".to_string(),
+                                icon: Some("bi-pencil".to_string()),
+                                on_click: move |_| {
+                                    let pid = pid.clone();
+                                    lib_state.with_mut(|s| s.start_rename(pid));
+                                },
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/ui/paper_detail/detail.rs
+++ b/src/ui/paper_detail/detail.rs
@@ -8,6 +8,7 @@ use super::DetailShell;
 use super::detail_fields::DetailFields;
 use super::fields::{CollectionsField, TagsField};
 use super::notes::NotesSection;
+use super::title_field::EditableTitleField;
 
 #[component]
 pub fn PaperDetail() -> Element {
@@ -29,6 +30,13 @@ pub fn PaperDetail() -> Element {
     let pid_del = paper_id.clone();
     let pid_open = paper_id.clone();
 
+    // A Rename raised from the library context menu, for this paper.
+    let rename_requested = lib_state
+        .read()
+        .rename_paper_id
+        .as_deref()
+        .is_some_and(|id| id == paper_id);
+
     let mut editing_key = use_signal(|| false);
     let mut edit_key_value = use_signal(|| paper.citation.citation_key.clone().unwrap_or_default());
     let mut copied_hint = use_signal(|| false);
@@ -47,6 +55,13 @@ pub fn PaperDetail() -> Element {
                     },
                     "\u{00d7}"
                 }
+            }
+
+            EditableTitleField {
+                paper_id: paper_id.clone(),
+                title: paper.title.clone(),
+                item_type: paper.item_type.clone(),
+                external_trigger: rename_requested,
             }
 
             DetailFields { paper: paper.clone() }

--- a/src/ui/paper_detail/detail_fields.rs
+++ b/src/ui/paper_detail/detail_fields.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::ui::components::context_menu::{ContextMenu, ContextMenuItem};
-use crate::ui::helpers::{item_type_icon, item_type_is_special, item_type_label, venue_label};
+use crate::ui::helpers::venue_label;
 use rotero_models::{CreatorRole, Paper};
 
 /// Non-author creators (editors, translators, …) grouped by role, so the detail
@@ -41,9 +41,13 @@ fn contributor_groups(paper: &Paper) -> Vec<(&'static str, String)> {
 }
 
 /// The read-only bibliographic block shared by the library detail panel and the
-/// web-result preview: item-type badge, title, authors, role-grouped
-/// contributors, year, citations, venue, venue identifiers, DOI (with a copy /
-/// open-in-browser context menu), and abstract.
+/// web-result preview: authors, role-grouped contributors, year, citations,
+/// venue, venue identifiers, DOI (with a copy / open-in-browser context menu),
+/// and abstract.
+///
+/// The title sits above this block rather than in it, because the library panel
+/// renders it as an editor and the web preview as static text — see
+/// [`super::title_field`].
 ///
 /// Fields that are missing on the paper are simply skipped, so the same
 /// component renders a fully-populated library record and a sparse web hit
@@ -73,28 +77,9 @@ pub fn DetailFields(paper: Paper) -> Element {
     .filter_map(|(label, val)| val.filter(|v| !v.is_empty()).map(|v| (label, v)))
     .collect();
 
-    let type_label = item_type_label(&paper.item_type);
-    let type_icon = item_type_icon(&paper.item_type);
-    let type_badge_class = if item_type_is_special(&paper.item_type) {
-        "type-badge type-badge--special"
-    } else {
-        "type-badge"
-    };
-
     let mut doi_ctx = use_signal(|| None::<(String, f64, f64)>);
 
     rsx! {
-        div { class: "detail-field",
-            div { class: "detail-title-row",
-                label { class: "detail-label", "Title" }
-                span { class: "{type_badge_class}", title: "{type_label}",
-                    i { class: "bi {type_icon}" }
-                    "{type_label}"
-                }
-            }
-            div { class: "detail-value detail-value--title", "{paper.title}" }
-        }
-
         div { class: "detail-field",
             label { class: "detail-label", "Authors" }
             div { class: "detail-value", "{authors_display}" }

--- a/src/ui/paper_detail/mod.rs
+++ b/src/ui/paper_detail/mod.rs
@@ -4,6 +4,7 @@ mod fields;
 mod multi_select;
 mod notes;
 mod shell;
+mod title_field;
 mod web_preview;
 
 pub use detail::PaperDetail;

--- a/src/ui/paper_detail/title_field.rs
+++ b/src/ui/paper_detail/title_field.rs
@@ -1,0 +1,175 @@
+use dioxus::prelude::*;
+
+use crate::state::app_state::LibraryState;
+use crate::ui::helpers::{item_type_icon, item_type_is_special, item_type_label};
+use rotero_db::Database;
+
+/// The "Title" label paired with the item-type badge, shared by the read-only
+/// and editable title fields so both render an identical header row.
+#[component]
+pub fn TitleLabelRow(item_type: String) -> Element {
+    let type_label = item_type_label(&item_type);
+    let type_icon = item_type_icon(&item_type);
+    let badge_class = if item_type_is_special(&item_type) {
+        "type-badge type-badge--special"
+    } else {
+        "type-badge"
+    };
+
+    rsx! {
+        div { class: "detail-title-row",
+            label { class: "detail-label", "Title" }
+            span { class: "{badge_class}", title: "{type_label}",
+                i { class: "bi {type_icon}" }
+                "{type_label}"
+            }
+        }
+    }
+}
+
+/// The paper title as a static block. Used for web search results, which have
+/// no stored record to rename.
+#[component]
+pub fn TitleField(title: String, item_type: String) -> Element {
+    rsx! {
+        div { class: "detail-field",
+            TitleLabelRow { item_type }
+            div { class: "detail-value detail-value--title", "{title}" }
+        }
+    }
+}
+
+/// The paper title as a click-to-edit field, mirroring the citation-key editor:
+/// Enter or blur commits, Escape reverts. Committing writes the title alone and
+/// patches the in-memory paper, so the card list and PDF tab retitle without a
+/// reload.
+///
+/// `external_trigger` opens the editor without a click, letting the library
+/// context menu's Rename action drive this editor from another component tree.
+#[component]
+pub fn EditableTitleField(
+    paper_id: String,
+    title: String,
+    item_type: String,
+    external_trigger: bool,
+) -> Element {
+    let mut lib_state = use_context::<Signal<LibraryState>>();
+    let db = use_context::<Database>();
+
+    let mut editing = use_signal(|| false);
+    let mut draft = use_signal(|| title.clone());
+    // The component is reused across selections rather than remounted, so the
+    // signals above keep their values when a different paper is selected. Track
+    // which paper they belong to and reset when that changes, otherwise the
+    // editor would stay open over the new paper holding the old draft.
+    let mut editing_for = use_signal(|| paper_id.clone());
+
+    {
+        let paper_id = paper_id.clone();
+        let title = title.clone();
+        use_effect(move || {
+            if *editing_for.peek() != paper_id {
+                editing_for.set(paper_id.clone());
+                editing.set(false);
+                draft.set(title.clone());
+            }
+        });
+    }
+
+    // Honour a Rename request raised elsewhere, then clear it so re-selecting
+    // this paper later doesn't reopen the editor.
+    {
+        let title = title.clone();
+        use_effect(move || {
+            if external_trigger && !*editing.peek() {
+                draft.set(title.clone());
+                editing.set(true);
+                lib_state.with_mut(|s| s.rename_paper_id = None);
+            }
+        });
+    }
+
+    // Commit the draft: blank titles are rejected, and an unchanged title skips
+    // the write entirely so a stray blur doesn't bump date_modified.
+    let commit = {
+        let db = db.clone();
+        let paper_id = paper_id.clone();
+        let original = title.clone();
+        move || {
+            let new_title = draft().trim().to_string();
+            editing.set(false);
+            if new_title.is_empty() || new_title == original {
+                return;
+            }
+            let db = db.clone();
+            let pid = paper_id.clone();
+            spawn(async move {
+                if let Err(e) = db.update_paper_title(&pid, &new_title).await {
+                    lib_state
+                        .with_mut(|s| s.report_error(format!("Could not rename the paper: {e}")));
+                    return;
+                }
+                lib_state.with_mut(|s| {
+                    if let Some(p) = s
+                        .papers
+                        .iter_mut()
+                        .find(|p| p.id.as_deref() == Some(pid.as_str()))
+                    {
+                        p.title = new_title;
+                    }
+                });
+            });
+        }
+    };
+
+    rsx! {
+        div { class: "detail-field",
+            TitleLabelRow { item_type }
+            if editing() {
+                textarea {
+                    class: "input detail-title-input",
+                    rows: 3,
+                    value: "{draft}",
+                    autofocus: true,
+                    onfocusin: crate::ui::keybindings::editable_focus_in,
+                    oninput: move |evt| draft.set(evt.value()),
+                    onkeydown: {
+                        let mut commit = commit.clone();
+                        let original = title.clone();
+                        move |evt: Event<KeyboardData>| {
+                            // Enter commits; the title is one line even though a
+                            // textarea is used to wrap long ones.
+                            if evt.key() == Key::Enter && !evt.modifiers().shift() {
+                                evt.prevent_default();
+                                commit();
+                            } else if evt.key() == Key::Escape {
+                                draft.set(original.clone());
+                                editing.set(false);
+                            }
+                        }
+                    },
+                    onfocusout: {
+                        let mut commit = commit.clone();
+                        move |evt| {
+                            crate::ui::keybindings::editable_focus_out(evt);
+                            commit();
+                        }
+                    },
+                }
+            } else {
+                div {
+                    class: "detail-value detail-value--title detail-value--editable",
+                    title: "Click to rename",
+                    onclick: {
+                        let original = title.clone();
+                        move |_| {
+                            draft.set(original.clone());
+                            editing.set(true);
+                        }
+                    },
+                    "{title}"
+                }
+            }
+        }
+    }
+}

--- a/src/ui/paper_detail/web_preview.rs
+++ b/src/ui/paper_detail/web_preview.rs
@@ -5,6 +5,7 @@ use crate::state::commands::ImportChannel;
 
 use super::DetailShell;
 use super::detail_fields::DetailFields;
+use super::title_field::TitleField;
 
 /// Read-only overview of a web search result that hasn't been imported yet.
 ///
@@ -61,6 +62,8 @@ pub fn WebPreview() -> Element {
             }
 
             div { class: "detail-web-badge", "From the web" }
+
+            TitleField { title: paper.title.clone(), item_type: paper.item_type.clone() }
 
             DetailFields { paper: paper.clone() }
 


### PR DESCRIPTION
The paper title was read-only everywhere in the UI. Every writer was
automatic — metadata enrichment, the browser connector, and the MCP
`update_paper_metadata` tool — so an AI agent could retitle a paper but the
person who owned the library could not.

## Two entry points, one editor

- **Click the title** in the detail panel. Enter or blur commits, Escape
  reverts; blank and unchanged titles skip the write.
- **Rename** in the library context menu (single selection). It selects the
  paper and sets `LibraryState::rename_paper_id`; the detail panel picks that
  up and opens the same editor, so there is one edit implementation rather
  than a second dialog.

On success the in-memory paper is patched, so the card list and PDF tab
retitle without a reload. A failed write reports through the existing toast
path.

## Why not `update_paper_metadata`

That method rewrites all 13 bibliographic columns. Driven from a stale
in-memory `Paper` it would blank fields enrichment had since filled in, and
marking every column dirty would let a rename overwrite a peer's newer DOI
when the CRR clocks merge. The new `update_paper_title` touches `title` and
`date_modified` only.

## Title extracted from `DetailFields`

`DetailFields` is shared with the web-result preview, where a search hit has
no stored record to rename. The title now lives in `src/ui/paper_detail/title_field.rs`,
which exposes a static and an editable variant over a shared label row, so
both callers still render an identical header.

## Notes

- The editor is a `textarea`, not an `input`: paper titles routinely wrap and
  an input hides most of a long title behind horizontal scroll. Enter still
  commits, so it behaves as a one-line field.
- The component is reused across selections rather than remounted (Dioxus only
  honours `key` on the first node in a block), so it tracks which paper its
  signals belong to and resets on change — switching papers mid-edit can't
  leave the editor open holding the previous draft.

## Testing

New `crates/rotero-db/tests/paper_rename_test.rs`: unrelated fields survive a
rename, only the title's sync clock advances, and the rename is reflected in
search — that last one verifies the FTS index actually follows the write
rather than asserting it in a comment.

Full workspace suite and `clippy --all-targets` are clean. Both entry points
were manually verified in the running app.
