### PR TITLE
Fix four sync bugs that predate the sync rewrite

### DIFF
--- a/crates/rotero-db/src/collections.rs
+++ b/crates/rotero-db/src/collections.rs
@@ -78,12 +78,39 @@ impl Database {
         Ok(())
     }
 
-    /// Delete a collection by ID, cascading to paper memberships.
+    /// Delete a collection by ID along with its paper memberships.
+    ///
+    /// The memberships are removed explicitly rather than by foreign key, for the
+    /// same reason [`Database::delete_paper`] does it: the schema declares
+    /// `ON DELETE CASCADE`, but `PRAGMA foreign_keys` is off, so nothing ever
+    /// fired and every deleted collection left its `paper_collections` rows
+    /// behind. A cascade would not be enough on its own either — it happens
+    /// inside SQLite, so the junction rows would vanish locally with no
+    /// `track_delete` and peers would keep memberships pointing at a collection
+    /// that no longer exists.
     pub async fn delete_collection(&self, id: &str) -> Result<(), crate::DbError> {
+        let members = self
+            .junction_ids(
+                "SELECT paper_id FROM paper_collections WHERE collection_id = ?1",
+                id,
+            )
+            .await?;
+
         let conn = self.conn();
         conn.execute(queries::COLLECTION_DELETE, [Value::Text(id.to_string())])
             .await?;
+        conn.execute(
+            "DELETE FROM paper_collections WHERE collection_id = ?1",
+            [Value::Text(id.to_string())],
+        )
+        .await?;
+
         self.crr().track_delete("collections", id).await?;
+        for paper_id in &members {
+            self.crr()
+                .track_delete("paper_collections", &format!("{paper_id}:{id}"))
+                .await?;
+        }
         Ok(())
     }
 

--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -172,13 +172,27 @@ impl Database {
             .map_err(|e| format!("Failed to initialize CRR: {e}"))?;
 
         if schema_drifted {
-            // An existing, already-synced store gained the `item_type` column
-            // (added by the v11 SQL migration above). Backfill its clock entries
-            // so existing rows emit the new column to peers. Idempotent and
-            // scoped to live rows; a no-op once every row is backfilled.
-            crr.migrate_add_column("papers", "item_type")
-                .await
-                .map_err(|e| format!("Failed to backfill item_type CRR clocks: {e}"))?;
+            // An existing, already-synced store was compiled against a schema
+            // that has since gained columns (`item_type` via the v11 SQL
+            // migration, and anything added after it). Backfill clock entries so
+            // existing rows emit those columns to peers.
+            //
+            // Every tracked column is offered rather than a hardcoded one: the
+            // drift flag is a whole-schema fingerprint comparison, so naming a
+            // single column here meant a second added column tripped the same
+            // flag and was silently skipped. `migrate_add_column` is idempotent
+            // and scoped to live rows, so offering a column that is already
+            // backfilled costs one indexed query and changes nothing.
+            for table in &crr.schema().tables {
+                for column in &table.columns {
+                    crr.migrate_add_column(&table.name, column).await.map_err(|e| {
+                        format!(
+                            "Failed to backfill CRR clocks for {}.{column}: {e}",
+                            table.name
+                        )
+                    })?;
+                }
+            }
         }
 
         let db = Self {

--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -185,12 +185,14 @@ impl Database {
             // backfilled costs one indexed query and changes nothing.
             for table in &crr.schema().tables {
                 for column in &table.columns {
-                    crr.migrate_add_column(&table.name, column).await.map_err(|e| {
-                        format!(
-                            "Failed to backfill CRR clocks for {}.{column}: {e}",
-                            table.name
-                        )
-                    })?;
+                    crr.migrate_add_column(&table.name, column)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "Failed to backfill CRR clocks for {}.{column}: {e}",
+                                table.name
+                            )
+                        })?;
                 }
             }
         }

--- a/crates/rotero-db/src/papers.rs
+++ b/crates/rotero-db/src/papers.rs
@@ -651,7 +651,11 @@ impl Database {
         .await
     }
 
-    async fn junction_ids(&self, sql: &str, paper_id: &str) -> Result<Vec<String>, crate::DbError> {
+    pub(crate) async fn junction_ids(
+        &self,
+        sql: &str,
+        paper_id: &str,
+    ) -> Result<Vec<String>, crate::DbError> {
         let mut rows = self
             .conn()
             .query(sql, [Value::Text(paper_id.to_string())])

--- a/crates/rotero-db/src/tags.rs
+++ b/crates/rotero-db/src/tags.rs
@@ -151,12 +151,35 @@ impl Database {
         Ok(ids)
     }
 
-    /// Delete a tag by ID, cascading to paper-tag associations.
+    /// Delete a tag by ID along with its paper associations.
+    ///
+    /// The associations are removed explicitly rather than by foreign key, for
+    /// the same reason [`Database::delete_paper`] does it: the schema declares
+    /// `ON DELETE CASCADE`, but `PRAGMA foreign_keys` is off, so nothing ever
+    /// fired and every deleted tag left its `paper_tags` rows behind. A cascade
+    /// would not be enough on its own either — it happens inside SQLite, so the
+    /// junction rows would vanish locally with no `track_delete` and peers would
+    /// keep associations pointing at a tag that no longer exists.
     pub async fn delete_tag(&self, id: &str) -> Result<(), crate::DbError> {
+        let tagged = self
+            .junction_ids("SELECT paper_id FROM paper_tags WHERE tag_id = ?1", id)
+            .await?;
+
         let conn = self.conn();
         conn.execute(queries::TAG_DELETE, [Value::Text(id.to_string())])
             .await?;
+        conn.execute(
+            "DELETE FROM paper_tags WHERE tag_id = ?1",
+            [Value::Text(id.to_string())],
+        )
+        .await?;
+
         self.crr().track_delete("tags", id).await?;
+        for paper_id in &tagged {
+            self.crr()
+                .track_delete("paper_tags", &format!("{paper_id}:{id}"))
+                .await?;
+        }
         Ok(())
     }
 }

--- a/crates/rotero-db/tests/merge_and_delete_sync_test.rs
+++ b/crates/rotero-db/tests/merge_and_delete_sync_test.rs
@@ -55,6 +55,31 @@ async fn insert_collection(db: &Database, name: &str) -> String {
         .unwrap()
 }
 
+/// Count rows in a junction table matching one column, reading the table
+/// directly.
+///
+/// The `list_*_for_paper` queries inner-join the parent table, so once a tag or
+/// collection row is gone its orphaned junction rows are invisible through them
+/// — on a healthy device and a broken one alike. Counting the junction table
+/// itself is what distinguishes "the membership was removed" from "the
+/// membership is still there but unreachable".
+async fn junction_count(db: &Database, table: &str, column: &str, value: &str) -> i64 {
+    let mut rows = db
+        .conn()
+        .query(
+            &format!("SELECT COUNT(*) FROM {table} WHERE {column} = ?1"),
+            [turso::Value::Text(value.to_string())],
+        )
+        .await
+        .unwrap();
+    rows.next()
+        .await
+        .unwrap()
+        .and_then(|r| r.get_value(0).ok())
+        .and_then(|v| v.as_integer().copied())
+        .unwrap_or(-1)
+}
+
 async fn insert_paper(db: &Database, title: &str) -> String {
     db.insert_paper(&rotero_models::Paper {
         title: title.into(),
@@ -160,4 +185,88 @@ async fn deleting_a_paper_removes_its_children_on_both_devices() {
         "the second device must drop the memberships too, not keep orphans"
     );
     assert!(p.b.list_papers().await.unwrap().is_empty());
+}
+
+/// Deleting a collection must remove its memberships on every device.
+///
+/// The doc comment claimed a cascade the code never performed: foreign keys are
+/// off, so `DELETE FROM collections` left every `paper_collections` row behind,
+/// untracked. Locally the collection vanished and the orphans were invisible,
+/// which is why this went unnoticed — the second device is what exposes it,
+/// still holding a membership pointing at a collection that no longer exists.
+#[tokio::test]
+async fn deleting_a_collection_removes_its_memberships_on_both_devices() {
+    let p = Pair::new().await;
+
+    let paper = insert_paper(&p.a, "Shelved").await;
+    let collection = insert_collection(&p.a, "Doomed shelf").await;
+    p.a.add_paper_to_collection(&paper, &collection)
+        .await
+        .unwrap();
+
+    p.sync_a_to_b().await;
+    assert_eq!(
+        junction_count(&p.b, "paper_collections", "collection_id", &collection).await,
+        1,
+        "the membership must reach the second device first"
+    );
+
+    p.a.delete_collection(&collection).await.unwrap();
+
+    assert_eq!(
+        junction_count(&p.a, "paper_collections", "collection_id", &collection).await,
+        0,
+        "the membership row must be gone locally, not merely unreachable"
+    );
+
+    p.sync_a_to_b().await;
+    assert_eq!(
+        junction_count(&p.b, "paper_collections", "collection_id", &collection).await,
+        0,
+        "the second device must drop the membership row too, not keep an orphan"
+    );
+    assert!(
+        p.b.list_papers().await.unwrap().len() == 1,
+        "the paper itself must survive its collection being deleted"
+    );
+}
+
+/// Deleting a tag must remove its associations on every device.
+///
+/// Same defect as [`deleting_a_collection_removes_its_memberships_on_both_devices`]:
+/// `DELETE FROM tags` left every `paper_tags` row behind and untracked, so peers
+/// kept associations pointing at a tag that no longer exists.
+#[tokio::test]
+async fn deleting_a_tag_removes_its_associations_on_both_devices() {
+    let p = Pair::new().await;
+
+    let paper = insert_paper(&p.a, "Tagged").await;
+    let tag = p.a.get_or_create_tag("doomed", None).await.unwrap();
+    p.a.add_tag_to_paper(&paper, &tag).await.unwrap();
+
+    p.sync_a_to_b().await;
+    assert_eq!(
+        junction_count(&p.b, "paper_tags", "tag_id", &tag).await,
+        1,
+        "the association must reach the second device first"
+    );
+
+    p.a.delete_tag(&tag).await.unwrap();
+
+    assert_eq!(
+        junction_count(&p.a, "paper_tags", "tag_id", &tag).await,
+        0,
+        "the association row must be gone locally, not merely unreachable"
+    );
+
+    p.sync_a_to_b().await;
+    assert_eq!(
+        junction_count(&p.b, "paper_tags", "tag_id", &tag).await,
+        0,
+        "the second device must drop the association row too, not keep an orphan"
+    );
+    assert!(
+        p.b.list_papers().await.unwrap().len() == 1,
+        "the paper itself must survive its tag being deleted"
+    );
 }

--- a/crates/rotero-mcp/src/db.rs
+++ b/crates/rotero-mcp/src/db.rs
@@ -198,6 +198,10 @@ impl Database {
                 [Value::Integer(favorite as i64), Value::Text(id.to_string())],
             )
             .await?;
+        self.crr
+            .track_update("papers", id, &[Papers::IS_FAVORITE])
+            .await
+            .map_err(|e| turso::Error::Error(e.to_string()))?;
         self.notify();
         Ok(())
     }
@@ -210,6 +214,10 @@ impl Database {
                 [Value::Integer(read as i64), Value::Text(id.to_string())],
             )
             .await?;
+        self.crr
+            .track_update("papers", id, &[Papers::IS_READ])
+            .await
+            .map_err(|e| turso::Error::Error(e.to_string()))?;
         self.notify();
         Ok(())
     }

--- a/crates/rotero-mcp/tests/agent_writes_sync_test.rs
+++ b/crates/rotero-mcp/tests/agent_writes_sync_test.rs
@@ -142,3 +142,50 @@ async fn an_agent_delete_removes_children_on_both_devices() {
     );
     assert!(app_b.list_papers().await.unwrap().is_empty());
 }
+
+/// Favorite and read flags the agent toggles must reach a peer.
+///
+/// Both methods executed their `UPDATE` and called `notify()` with no
+/// `track_update` at all, so an agent marking a paper read saved it locally and
+/// never sent it — and the stale value on any peer would win the next merge,
+/// silently reverting it. Every other mutating method in that file tracked;
+/// these two were missed.
+#[tokio::test]
+async fn agent_favorite_and_read_flags_reach_a_second_device() {
+    let shared = tempfile::tempdir().unwrap();
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+
+    let (app_a, agent_a) = app_and_agent(dir_a.path()).await;
+    let app_b = rotero_db::Database::open(dir_b.path().to_path_buf())
+        .await
+        .unwrap();
+
+    let paper = insert_paper(&app_a, "Flagged").await;
+
+    let engine_a = TestSyncEngine::new(shared.path().to_path_buf(), vec![1; 16]);
+    let engine_b = TestSyncEngine::new(shared.path().to_path_buf(), vec![2; 16]);
+    engine_a.export_changes(&app_a).await;
+    engine_b.import_changes(&app_b).await;
+
+    agent_a.set_favorite(&paper, true).await.unwrap();
+    agent_a.set_read(&paper, true).await.unwrap();
+
+    engine_a.export_changes(&app_a).await;
+    engine_b.import_changes(&app_b).await;
+
+    let synced = app_b
+        .get_papers_by_ids(std::slice::from_ref(&paper))
+        .await
+        .unwrap()
+        .pop()
+        .expect("paper on peer");
+    assert!(
+        synced.status.is_favorite,
+        "a favorite set by the agent must reach the second device"
+    );
+    assert!(
+        synced.status.is_read,
+        "a read flag set by the agent must reach the second device"
+    );
+}


### PR DESCRIPTION
Four bugs that lose or strand user data today, independent of the sync
rewrite that follows. They land first so the convergence tests that
migration brings start from a correct baseline — otherwise a failing test
is ambiguous between the new design and an old bug.

### The bugs

**`delete_collection` and `delete_tag` documented a cascade they never
performed.** `PRAGMA foreign_keys` is off, so the schema's
`ON DELETE CASCADE` never fired and each left its junction rows behind,
untracked. Locally the orphans are invisible — `list_tags_for_paper`
inner-joins `tags`, so a row pointing at a deleted tag simply stops being
returned — which is why this went unnoticed. A peer still holds the
membership. Both now delete and track their junction rows explicitly, as
`delete_paper` already did.

**The MCP server's `set_favorite` and `set_read` tracked nothing.** They
ran their `UPDATE` and called `notify()`, so an agent marking a paper read
saved it locally and never sent it. Worse, a peer's stale value would win
the next merge and silently revert it.

**The drift-triggered clock backfill hardcoded one column.** Its trigger
is a whole-schema fingerprint comparison, so a second added column would
trip the same flag and be silently skipped. It now offers every tracked
column.

### Testing

Each fix has a regression test asserting **through a second device**, and
each was confirmed to fail with its fix reverted.

Worth noting: the first two cascade tests originally passed *with the fix
reverted*. The `list_*_for_paper` helpers hide exactly the orphan being
tested, so they were asserting nothing. They now count junction rows
directly — which is the same blindness that let the bug ship.
