### PR TITLE
Key agent conversations to the subject they are about

### DIFF
--- a/assets/chat.css
+++ b/assets/chat.css
@@ -604,10 +604,22 @@
     background: var(--bg-hover);
 }
 
+/* Holds a stored summary, which is a sentence rather than a label, so it wraps
+   to a second line before being clipped. */
 .chat-session-item-title {
     font-size: var(--text-sm);
     font-weight: 500;
     color: var(--text-primary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    max-width: 100%;
+}
+
+.chat-session-item-about {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/assets/chat.css
+++ b/assets/chat.css
@@ -565,11 +565,34 @@
 
 .chat-session-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: var(--space-3);
     padding: var(--space-4) var(--space-6);
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
+}
+
+/* Takes the slack so the scope toggle sits beside the close button rather than
+   stranded in the middle of the row. */
+.chat-session-header .chat-session-title {
+    flex: 1;
+    min-width: 0;
+}
+
+.chat-session-scope {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.chat-session-scope:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
 }
 
 .chat-session-title {

--- a/assets/detail.css
+++ b/assets/detail.css
@@ -356,3 +356,50 @@
   background: var(--bg-hover);
   color: var(--text-primary);
 }
+
+/* ── Conversations ─────────────────────────────────────────────────────────
+   The agent conversations a paper belongs to, listed beside its notes. */
+
+.detail-chats-section {
+  margin-top: var(--space-4);
+}
+
+.detail-chat-card {
+  display: block;
+  width: 100%;
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.detail-chat-card:hover {
+  background: var(--bg-sidebar-hover);
+  border-color: var(--border-medium);
+}
+
+.detail-chat-summary {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  /* A summary is one sentence, but a fallback is the user's first message
+     and can run long. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.detail-chat-summary--empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.detail-chat-context {
+  margin-top: var(--space-0_5);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}

--- a/assets/graph.css
+++ b/assets/graph.css
@@ -161,3 +161,52 @@
   color: var(--text-muted);
   font-size: var(--text-base);
 }
+
+/* Floating action bar for a shift-click selection. Positioned over the canvas
+   rather than in the toolbar: it belongs to the papers being gathered, and
+   appears only while a selection of more than one exists. */
+.graph-selection-bar {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px 8px 14px;
+  border-radius: 999px;
+  background: var(--bg-elevated, #fff);
+  border: 1px solid var(--border-subtle, #e5e5e5);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 18%);
+  z-index: 5;
+}
+
+.graph-selection-count {
+  color: var(--text-secondary, #555);
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
+.graph-selection-chat {
+  white-space: nowrap;
+}
+
+.graph-selection-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-tertiary, #888);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.graph-selection-clear:hover {
+  background: var(--bg-hover, #f0f0f0);
+  color: var(--text-primary, #222);
+}

--- a/assets/graph.js
+++ b/assets/graph.js
@@ -15,6 +15,7 @@
   let isPanning = false, panStart = { x: 0, y: 0 };
   let hoverNode = null;
   let highlightIds = null;
+  let selectedIds = new Set();
   let tooltipEl = null;
   let hintEl = null;
   let animFrameId = null;
@@ -75,7 +76,7 @@
       hintEl = document.getElementById("graph-hint");
       if (hintEl) {
         const cmdKey = navigator.platform.indexOf('Mac') >= 0 ? '\u2318' : 'Ctrl';
-        hintEl.textContent = cmdKey + '+click to open';
+        hintEl.textContent = cmdKey + '+click to open \u00b7 shift+click to select';
       }
       if (!canvas) return;
       ctx = canvas.getContext("2d");
@@ -102,6 +103,12 @@
       });
       simTime = 0;
       startAnimation();
+    },
+
+    setSelection: function(ids) {
+      // No draw() here: the animation loop repaints every frame, and this can
+      // arrive before init() has a context to draw into.
+      selectedIds = new Set(ids || []);
     },
 
     highlight: function(ids) {
@@ -391,6 +398,17 @@
 
       const r = n.size;
 
+      // Selected nodes get a ring outside the circle, so the node keeps its
+      // own size and colour and the selection reads as an annotation on top.
+      if (selectedIds.has(n.id)) {
+        ctx.globalAlpha = 1.0;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, r + 3 / transform.scale, 0, Math.PI * 2);
+        ctx.strokeStyle = "#a855f7";
+        ctx.lineWidth = 2 / transform.scale;
+        ctx.stroke();
+      }
+
       // Flat filled circle — no stroke, no shadow
       ctx.globalAlpha = nodeAlpha;
       ctx.beginPath();
@@ -518,6 +536,10 @@
   function onMouseUp(e) {
     if (hoverNode && (e.metaKey || e.ctrlKey)) {
       window.__roteroGraphEvents.push({ type: "open", id: hoverNode.id });
+    } else if (hoverNode && e.shiftKey) {
+      // Add to / remove from the running selection. Cmd is already taken by
+      // "open", so shift is the accumulating click here.
+      window.__roteroGraphEvents.push({ type: "toggle", id: hoverNode.id });
     } else if (hoverNode) {
       window.__roteroGraphEvents.push({ type: "click", id: hoverNode.id });
     }

--- a/crates/rotero-db/src/chat_sessions.rs
+++ b/crates/rotero-db/src/chat_sessions.rs
@@ -162,8 +162,10 @@ impl Database {
         )
         .await?;
 
+        // These are the subject's own papers, so they define what the
+        // conversation is about.
         for paper_id in paper_ids {
-            self.link_chat_session_paper(&row.session_id, paper_id)
+            self.link_chat_session_paper(&row.session_id, paper_id, true)
                 .await?;
         }
         Ok(())
@@ -171,12 +173,19 @@ impl Database {
 
     /// Record that a conversation touched a paper. Idempotent.
     ///
+    /// `is_subject` separates the papers a conversation is *about* from the ones
+    /// it merely read: an agent answering a question runs searches, and every
+    /// result would otherwise claim the conversation as its own. A paper already
+    /// recorded as a subject stays one — a later incidental mention must not
+    /// demote it.
+    ///
     /// Unknown ids are dropped rather than inserted: foreign keys are not
     /// enforced, and the agent can name a paper that isn't in the library.
     pub async fn link_chat_session_paper(
         &self,
         session_id: &str,
         paper_id: &str,
+        is_subject: bool,
     ) -> Result<(), crate::DbError> {
         let conn = self.conn();
         let mut existing = conn
@@ -189,10 +198,14 @@ impl Database {
             return Ok(());
         }
         conn.execute(
-            "INSERT OR IGNORE INTO chat_session_papers (session_id, paper_id) VALUES (?1, ?2)",
+            "INSERT INTO chat_session_papers (session_id, paper_id, is_subject) \
+             VALUES (?1, ?2, ?3) \
+             ON CONFLICT(session_id, paper_id) DO UPDATE SET \
+                 is_subject = MAX(chat_session_papers.is_subject, excluded.is_subject)",
             [
                 Value::Text(session_id.to_string()),
                 Value::Text(paper_id.to_string()),
+                Value::Integer(i64::from(is_subject)),
             ],
         )
         .await?;
@@ -249,7 +262,14 @@ impl Database {
         Ok(())
     }
 
-    /// Every live conversation that touched a paper, most recently used first.
+    /// Every live conversation *about* a paper, most recently used first.
+    ///
+    /// Deliberately narrower than "touched this paper": an agent answering a
+    /// question runs searches, and every result it reads is linked to the
+    /// conversation. Listing those would put one chat about one paper on the
+    /// panel of every paper it happened to look at. A conversation belongs to a
+    /// paper when the paper is its subject, or when it is a member of the group
+    /// or collection the conversation is about.
     pub async fn chat_sessions_for_paper(
         &self,
         paper_id: &str,
@@ -268,7 +288,7 @@ impl Database {
             "SELECT {cols} FROM chat_sessions s \
              JOIN chat_session_papers p ON p.session_id = s.session_id \
              JOIN papers_live lp ON lp.id = p.paper_id \
-             WHERE p.paper_id = ?1 AND s.is_dead = 0 \
+             WHERE p.paper_id = ?1 AND p.is_subject = 1 AND s.is_dead = 0 \
              ORDER BY s.last_used_at DESC"
         );
         let mut rows = conn

--- a/crates/rotero-db/src/chat_sessions.rs
+++ b/crates/rotero-db/src/chat_sessions.rs
@@ -219,11 +219,20 @@ impl Database {
         summary: &str,
     ) -> Result<(), crate::DbError> {
         let conn = self.conn();
+        // Inserts rather than only updating: the row is created when the agent
+        // announces the session, and both writes are spawned independently, so
+        // a label written first would update nothing and be lost. The
+        // placeholder columns are all overwritten by the upsert that follows.
         conn.execute(
-            "UPDATE chat_sessions SET summary = ?1 WHERE session_id = ?2",
+            "INSERT INTO chat_sessions \
+                 (session_id, provider_id, subject_kind, subject_id, summary, \
+                  created_at, last_used_at, is_dead) \
+             VALUES (?1, '', 'general', NULL, ?2, ?3, ?3, 0) \
+             ON CONFLICT(session_id) DO UPDATE SET summary = excluded.summary",
             [
-                Value::Text(summary.to_string()),
                 Value::Text(session_id.to_string()),
+                Value::Text(summary.to_string()),
+                Value::Text(chrono::Utc::now().to_rfc3339()),
             ],
         )
         .await?;

--- a/crates/rotero-db/src/chat_sessions.rs
+++ b/crates/rotero-db/src/chat_sessions.rs
@@ -301,6 +301,40 @@ impl Database {
         Ok(out)
     }
 
+    /// Every conversation on record, keyed by session id.
+    ///
+    /// For joining against a list the agent reports: the agent titles a session
+    /// after its first user message, which for these is a synthetic startup
+    /// entry, so its titles are uninformative and ours are not.
+    pub async fn all_chat_sessions(&self) -> Result<Vec<ChatSessionRow>, crate::DbError> {
+        let conn = self.conn();
+        let sql = format!("SELECT {SELECT_COLS} FROM chat_sessions");
+        let mut rows = conn.query(&sql, ()).await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            out.push(row_to_session(&row));
+        }
+        Ok(out)
+    }
+
+    /// The subject papers of every conversation, as `(session_id, paper_id)`.
+    pub async fn all_chat_session_subjects(&self) -> Result<Vec<(String, String)>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn
+            .query(
+                "SELECT p.session_id, p.paper_id FROM chat_session_papers p \
+                 JOIN papers_live lp ON lp.id = p.paper_id \
+                 WHERE p.is_subject = 1",
+                (),
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            out.push((crate::get_text(&row, 0), crate::get_text(&row, 1)));
+        }
+        Ok(out)
+    }
+
     /// The papers a conversation covers, excluding any since deleted.
     pub async fn chat_session_paper_ids(
         &self,

--- a/crates/rotero-db/src/chat_sessions.rs
+++ b/crates/rotero-db/src/chat_sessions.rs
@@ -1,0 +1,304 @@
+//! The agent conversation belonging to each subject.
+//!
+//! A chat is an attribute of what it is about — a paper, a collection, or an
+//! ad-hoc set of papers — not an entry in a chronological log. This module owns
+//! that mapping so opening a paper can resume its conversation.
+//!
+//! Local-only, and deliberately so: session ids are minted by the agent binary
+//! on this machine, so a row synced to another device would name a session that
+//! resolves to nothing there. These tables are therefore absent from
+//! [`crate::sync_schema::SYNCED_TABLES`], carry none of the `updated_at` /
+//! `updated_by` / `deleted` bookkeeping columns, and have no `_live` view.
+//! **Never call [`Database::touch`] for them** — every synced table's write path
+//! does, and it would fail here for want of those columns.
+
+use turso::Value;
+
+use crate::Database;
+
+/// What a conversation is about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatSubject {
+    /// One paper.
+    Paper(String),
+    /// A collection, by id.
+    Collection(String),
+    /// An ad-hoc set of papers, identified by its members rather than by a name.
+    Group(Vec<String>),
+}
+
+impl ChatSubject {
+    /// The `subject_kind` column value.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Paper(_) => "paper",
+            Self::Collection(_) => "collection",
+            Self::Group(_) => "group",
+        }
+    }
+
+    /// The `subject_id` column value.
+    ///
+    /// A group has no name to key on, so it is identified by its members: the
+    /// ids sorted and joined, which makes the lookup insensitive to the order
+    /// they happened to be selected in. Selecting a *different* set yields a
+    /// different key, which is correct — it is a different subject.
+    pub fn id(&self) -> String {
+        match self {
+            Self::Paper(id) | Self::Collection(id) => id.clone(),
+            Self::Group(ids) => {
+                let mut sorted = ids.clone();
+                sorted.sort();
+                sorted.dedup();
+                sorted.join(":")
+            }
+        }
+    }
+
+    /// The papers this subject covers, for the `chat_session_papers` rows.
+    /// A collection's membership is resolved by the caller, so it contributes
+    /// nothing here on its own.
+    pub fn paper_ids(&self) -> Vec<String> {
+        match self {
+            Self::Paper(id) => vec![id.clone()],
+            Self::Collection(_) => Vec::new(),
+            Self::Group(ids) => ids.clone(),
+        }
+    }
+}
+
+/// One conversation's index row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChatSessionRow {
+    /// The agent's session id — the key used to resume it.
+    pub session_id: String,
+    pub provider_id: String,
+    pub subject_kind: String,
+    pub subject_id: Option<String>,
+    /// A one-line description, shown where the subject's own name isn't enough.
+    pub summary: Option<String>,
+    pub created_at: String,
+    pub last_used_at: String,
+    /// The agent no longer has this session, so a fresh one should replace it.
+    pub is_dead: bool,
+}
+
+const SELECT_COLS: &str = "session_id, provider_id, subject_kind, subject_id, summary, \
+                           created_at, last_used_at, is_dead";
+
+fn row_to_session(row: &turso::Row) -> ChatSessionRow {
+    ChatSessionRow {
+        session_id: crate::get_text(row, 0),
+        provider_id: crate::get_text(row, 1),
+        subject_kind: crate::get_text(row, 2),
+        subject_id: crate::get_opt_text(row, 3),
+        summary: crate::get_opt_text(row, 4),
+        created_at: crate::get_text(row, 5),
+        last_used_at: crate::get_text(row, 6),
+        is_dead: crate::get_bool(row, 7),
+    }
+}
+
+impl Database {
+    /// The live conversation for a subject, if one exists.
+    ///
+    /// Dead sessions are filtered out, so a subject whose conversation the agent
+    /// has forgotten reads as having none and a fresh one takes its place.
+    pub async fn chat_session_for_subject(
+        &self,
+        subject: &ChatSubject,
+    ) -> Result<Option<ChatSessionRow>, crate::DbError> {
+        let conn = self.conn();
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM chat_sessions \
+             WHERE subject_kind = ?1 AND subject_id = ?2 AND is_dead = 0 \
+             ORDER BY last_used_at DESC LIMIT 1"
+        );
+        let mut rows = conn
+            .query(
+                &sql,
+                [
+                    Value::Text(subject.kind().to_string()),
+                    Value::Text(subject.id()),
+                ],
+            )
+            .await?;
+        Ok(rows.next().await?.map(|row| row_to_session(&row)))
+    }
+
+    /// Record a conversation and the papers it covers.
+    ///
+    /// `created_at` survives a repeat call so the row keeps its original age;
+    /// `summary` is only overwritten by a non-null value, so a later upsert that
+    /// doesn't know the summary can't erase one already learned.
+    pub async fn upsert_chat_session(
+        &self,
+        row: &ChatSessionRow,
+        paper_ids: &[String],
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO chat_sessions \
+                 (session_id, provider_id, subject_kind, subject_id, summary, \
+                  created_at, last_used_at, is_dead) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+             ON CONFLICT(session_id) DO UPDATE SET \
+                 provider_id  = excluded.provider_id, \
+                 subject_kind = excluded.subject_kind, \
+                 subject_id   = excluded.subject_id, \
+                 summary      = COALESCE(excluded.summary, chat_sessions.summary), \
+                 last_used_at = excluded.last_used_at, \
+                 is_dead      = excluded.is_dead",
+            turso::params::Params::Positional(vec![
+                Value::Text(row.session_id.clone()),
+                Value::Text(row.provider_id.clone()),
+                Value::Text(row.subject_kind.clone()),
+                crate::opt_text(row.subject_id.as_ref()),
+                crate::opt_text(row.summary.as_ref()),
+                Value::Text(row.created_at.clone()),
+                Value::Text(row.last_used_at.clone()),
+                Value::Integer(i64::from(row.is_dead)),
+            ]),
+        )
+        .await?;
+
+        for paper_id in paper_ids {
+            self.link_chat_session_paper(&row.session_id, paper_id)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Record that a conversation touched a paper. Idempotent.
+    ///
+    /// Unknown ids are dropped rather than inserted: foreign keys are not
+    /// enforced, and the agent can name a paper that isn't in the library.
+    pub async fn link_chat_session_paper(
+        &self,
+        session_id: &str,
+        paper_id: &str,
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        let mut existing = conn
+            .query(
+                "SELECT 1 FROM papers_live WHERE id = ?1",
+                [Value::Text(paper_id.to_string())],
+            )
+            .await?;
+        if existing.next().await?.is_none() {
+            return Ok(());
+        }
+        conn.execute(
+            "INSERT OR IGNORE INTO chat_session_papers (session_id, paper_id) VALUES (?1, ?2)",
+            [
+                Value::Text(session_id.to_string()),
+                Value::Text(paper_id.to_string()),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Attach a one-line description to a conversation.
+    pub async fn set_chat_session_summary(
+        &self,
+        session_id: &str,
+        summary: &str,
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "UPDATE chat_sessions SET summary = ?1 WHERE session_id = ?2",
+            [
+                Value::Text(summary.to_string()),
+                Value::Text(session_id.to_string()),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Note that a conversation was just used, so it sorts as the most recent.
+    pub async fn touch_chat_session(
+        &self,
+        session_id: &str,
+        when: &str,
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "UPDATE chat_sessions SET last_used_at = ?1 WHERE session_id = ?2",
+            [
+                Value::Text(when.to_string()),
+                Value::Text(session_id.to_string()),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Mark a conversation the agent can no longer load.
+    ///
+    /// The row is kept rather than deleted so the papers it covered stay on
+    /// record; it simply stops being offered for resumption.
+    pub async fn mark_chat_session_dead(&self, session_id: &str) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "UPDATE chat_sessions SET is_dead = 1 WHERE session_id = ?1",
+            [Value::Text(session_id.to_string())],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Every live conversation that touched a paper, most recently used first.
+    pub async fn chat_sessions_for_paper(
+        &self,
+        paper_id: &str,
+    ) -> Result<Vec<ChatSessionRow>, crate::DbError> {
+        let conn = self.conn();
+        // Joined against `papers_live`: a deleted paper is tombstoned rather
+        // than removed, so the cascade never fires and the link outlives it.
+        // Columns are qualified: `session_id` names a column on both joined
+        // tables, so an unqualified list is ambiguous.
+        let cols = SELECT_COLS
+            .split(", ")
+            .map(|c| format!("s.{c}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT {cols} FROM chat_sessions s \
+             JOIN chat_session_papers p ON p.session_id = s.session_id \
+             JOIN papers_live lp ON lp.id = p.paper_id \
+             WHERE p.paper_id = ?1 AND s.is_dead = 0 \
+             ORDER BY s.last_used_at DESC"
+        );
+        let mut rows = conn
+            .query(&sql, [Value::Text(paper_id.to_string())])
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            out.push(row_to_session(&row));
+        }
+        Ok(out)
+    }
+
+    /// The papers a conversation covers, excluding any since deleted.
+    pub async fn chat_session_paper_ids(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<String>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn
+            .query(
+                "SELECT p.paper_id FROM chat_session_papers p \
+                 JOIN papers_live lp ON lp.id = p.paper_id \
+                 WHERE p.session_id = ?1",
+                [Value::Text(session_id.to_string())],
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            out.push(crate::get_text(&row, 0));
+        }
+        Ok(out)
+    }
+}

--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -6,6 +6,8 @@
 /// PDF annotation CRUD operations.
 pub mod annotations;
 /// Test utilities for simulating multi-device sync round-trips.
+/// The agent conversation belonging to each subject. Local-only, not synced.
+pub mod chat_sessions;
 /// Stamping local writes so they can win a merge.
 pub mod clock;
 /// One-time repair for libraries written without CRR change tracking.

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_LIVE_VIEWS, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub const SCHEMA_VERSION: i64 = 16;
+pub const SCHEMA_VERSION: i64 = 17;
 
 /// Why a database could not be prepared for use.
 #[derive(Debug, thiserror::Error)]
@@ -366,6 +366,21 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
             (),
         )
         .await;
+
+    if current_version < 17 {
+        // Clear out conversations that never happened. An earlier build filed a
+        // row when the agent opened a session, which it does on connect — so
+        // every launch left one behind whether or not anything was said. They
+        // are identifiable by having neither a label nor a linked paper.
+        let _ = conn
+            .execute(
+                "DELETE FROM chat_sessions \
+                 WHERE (summary IS NULL OR summary = '') \
+                   AND session_id NOT IN (SELECT session_id FROM chat_session_papers)",
+                (),
+            )
+            .await;
+    }
 
     if current_version < SCHEMA_VERSION {
         conn.execute("UPDATE schema_version SET version = ?1", [SCHEMA_VERSION])

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_LIVE_VIEWS, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub const SCHEMA_VERSION: i64 = 15;
+pub const SCHEMA_VERSION: i64 = 16;
 
 /// Why a database could not be prepared for use.
 #[derive(Debug, thiserror::Error)]
@@ -323,8 +323,16 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
                 "CREATE TABLE IF NOT EXISTS chat_session_papers (
                     session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
                     paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+                    is_subject INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (session_id, paper_id)
                 )",
+                (),
+            )
+            .await;
+        // Idempotent: adds the column to a v15 library, no-op once present.
+        let _ = conn
+            .execute(
+                "ALTER TABLE chat_session_papers ADD COLUMN is_subject INTEGER NOT NULL DEFAULT 0",
                 (),
             )
             .await;

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -352,6 +352,21 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
             .await;
     }
 
+    // Unconditional, not guarded on the version: an earlier build stamped 16
+    // without ever running this, stranding the column in a library that then
+    // reported itself up to date. Attempting it every open costs one failed
+    // statement and repairs those libraries; a version check cannot.
+    //
+    // Separates the papers a conversation is about from the ones the agent
+    // merely read. A library created at 15 already has the table, so the CREATE
+    // above is a no-op for it and only this ALTER adds the column.
+    let _ = conn
+        .execute(
+            "ALTER TABLE chat_session_papers ADD COLUMN is_subject INTEGER NOT NULL DEFAULT 0",
+            (),
+        )
+        .await;
+
     if current_version < SCHEMA_VERSION {
         conn.execute("UPDATE schema_version SET version = ?1", [SCHEMA_VERSION])
             .await?;

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_LIVE_VIEWS, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub const SCHEMA_VERSION: i64 = 14;
+pub const SCHEMA_VERSION: i64 = 15;
 
 /// Why a database could not be prepared for use.
 #[derive(Debug, thiserror::Error)]
@@ -297,6 +297,51 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
 
     if current_version < 14 {
         migrate_to_lww(conn).await?;
+    }
+
+    if current_version < 15 {
+        // Chat-session index, keyed by the subject a conversation is about.
+        // Created here for existing DBs; CREATE_TABLES handles fresh ones.
+        // Local-only, so no sync columns and no _live view — see tables.rs.
+        let _ = conn
+            .execute(
+                "CREATE TABLE IF NOT EXISTS chat_sessions (
+                    session_id   TEXT PRIMARY KEY,
+                    provider_id  TEXT NOT NULL DEFAULT '',
+                    subject_kind TEXT NOT NULL,
+                    subject_id   TEXT,
+                    summary      TEXT,
+                    created_at   TEXT NOT NULL,
+                    last_used_at TEXT NOT NULL,
+                    is_dead      INTEGER NOT NULL DEFAULT 0
+                )",
+                (),
+            )
+            .await;
+        let _ = conn
+            .execute(
+                "CREATE TABLE IF NOT EXISTS chat_session_papers (
+                    session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+                    paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+                    PRIMARY KEY (session_id, paper_id)
+                )",
+                (),
+            )
+            .await;
+        let _ = conn
+            .execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_sessions_subject \
+                 ON chat_sessions (subject_kind, subject_id)",
+                (),
+            )
+            .await;
+        let _ = conn
+            .execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_session_papers_paper \
+                 ON chat_session_papers (paper_id)",
+                (),
+            )
+            .await;
     }
 
     if current_version < SCHEMA_VERSION {

--- a/crates/rotero-db/src/schema/tables.rs
+++ b/crates/rotero-db/src/schema/tables.rs
@@ -97,6 +97,36 @@ CREATE TABLE IF NOT EXISTS app_flags (
     value TEXT
 );
 
+-- The agent conversation for one subject: a paper, a collection, or an ad-hoc
+-- set of papers. Local-only for the same reason as app_flags, and a stronger
+-- one: session ids are minted by the agent binary on THIS machine, so a synced
+-- row would name a session that resolves to nothing on the other device. Hence
+-- no updated_at/updated_by/deleted columns and no _live view.
+--
+-- subject_id is deliberately not a foreign key: deleting a paper should leave
+-- the conversation on record rather than erase it.
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    session_id   TEXT PRIMARY KEY,
+    provider_id  TEXT NOT NULL DEFAULT '',
+    subject_kind TEXT NOT NULL,
+    subject_id   TEXT,
+    summary      TEXT,
+    created_at   TEXT NOT NULL,
+    last_used_at TEXT NOT NULL,
+    is_dead      INTEGER NOT NULL DEFAULT 0
+);
+
+-- Papers a conversation is about: the single anchor for a 'paper' subject, the
+-- whole member set for 'collection' and 'group'.
+CREATE TABLE IF NOT EXISTS chat_session_papers (
+    session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+    paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    PRIMARY KEY (session_id, paper_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_subject ON chat_sessions (subject_kind, subject_id);
+CREATE INDEX IF NOT EXISTS idx_chat_session_papers_paper ON chat_session_papers (paper_id);
+
 CREATE TABLE IF NOT EXISTS annotations (
     id          TEXT PRIMARY KEY,
     paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,

--- a/crates/rotero-db/src/schema/tables.rs
+++ b/crates/rotero-db/src/schema/tables.rs
@@ -116,11 +116,14 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
     is_dead      INTEGER NOT NULL DEFAULT 0
 );
 
--- Papers a conversation is about: the single anchor for a 'paper' subject, the
--- whole member set for 'collection' and 'group'.
+-- Papers a conversation touched. `is_subject` marks the ones it is actually
+-- about — the single anchor for a 'paper' subject, the whole member set for
+-- 'collection' and 'group'. The rest are papers the agent read while answering,
+-- recorded so the conversation can be traced, but not claiming to be about them.
 CREATE TABLE IF NOT EXISTS chat_session_papers (
     session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
     paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    is_subject INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (session_id, paper_id)
 );
 

--- a/crates/rotero-db/tests/chat_sessions_test.rs
+++ b/crates/rotero-db/tests/chat_sessions_test.rs
@@ -119,10 +119,14 @@ async fn linking_is_idempotent_and_ignores_unknown_papers() {
         .await
         .unwrap();
 
-    db.link_chat_session_paper("sess-1", &paper).await.unwrap();
-    db.link_chat_session_paper("sess-1", &paper).await.unwrap();
+    db.link_chat_session_paper("sess-1", &paper, false)
+        .await
+        .unwrap();
+    db.link_chat_session_paper("sess-1", &paper, false)
+        .await
+        .unwrap();
     // An id the agent invented is not a library paper, so it is dropped.
-    db.link_chat_session_paper("sess-1", "not-a-real-paper")
+    db.link_chat_session_paper("sess-1", "not-a-real-paper", false)
         .await
         .unwrap();
 
@@ -130,6 +134,58 @@ async fn linking_is_idempotent_and_ignores_unknown_papers() {
         db.chat_session_paper_ids("sess-1").await.unwrap(),
         vec![paper]
     );
+}
+
+/// The bug this guards: an agent answering a question searches the library, and
+/// every paper it reads used to be linked as though the conversation were about
+/// it — so one chat about one paper appeared on the detail panel of every paper
+/// the search happened to return.
+#[tokio::test]
+async fn a_paper_the_agent_merely_read_does_not_claim_the_conversation() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let discussed = insert(&db, "The paper being read").await;
+    let stumbled_on = insert(&db, "A search result").await;
+
+    let subject = ChatSubject::Paper(discussed.clone());
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+    db.link_chat_session_paper("sess-1", &stumbled_on, false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        db.chat_sessions_for_paper(&discussed).await.unwrap().len(),
+        1
+    );
+    assert!(
+        db.chat_sessions_for_paper(&stumbled_on)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    // Both are still on record, so the conversation can be traced.
+    assert_eq!(db.chat_session_paper_ids("sess-1").await.unwrap().len(), 2);
+}
+
+/// A paper that is the subject stays the subject: the agent re-reading it
+/// mid-conversation must not demote it to an incidental mention.
+#[tokio::test]
+async fn an_incidental_mention_cannot_demote_a_subject() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "A").await;
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+
+    db.link_chat_session_paper("sess-1", &paper, false)
+        .await
+        .unwrap();
+
+    assert_eq!(db.chat_sessions_for_paper(&paper).await.unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/rotero-db/tests/chat_sessions_test.rs
+++ b/crates/rotero-db/tests/chat_sessions_test.rs
@@ -1,0 +1,199 @@
+//! The subject→conversation mapping, and its deliberate absence from sync.
+
+mod common;
+
+use rotero_db::Database;
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
+use rotero_models::Paper;
+
+async fn insert(db: &Database, title: &str) -> String {
+    let paper = Paper {
+        title: title.to_string(),
+        ..Default::default()
+    };
+    db.insert_paper(&paper).await.unwrap()
+}
+
+fn row(session_id: &str, subject: &ChatSubject) -> ChatSessionRow {
+    ChatSessionRow {
+        session_id: session_id.to_string(),
+        provider_id: "claude".into(),
+        subject_kind: subject.kind().to_string(),
+        subject_id: Some(subject.id()),
+        summary: None,
+        created_at: "2026-01-01T00:00:00Z".into(),
+        last_used_at: "2026-01-01T00:00:00Z".into(),
+        is_dead: false,
+    }
+}
+
+#[tokio::test]
+async fn a_paper_subject_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "Attention Is All You Need").await;
+    let subject = ChatSubject::Paper(paper.clone());
+
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+
+    let found = db.chat_session_for_subject(&subject).await.unwrap();
+    assert_eq!(found.map(|r| r.session_id), Some("sess-1".to_string()));
+    assert_eq!(
+        db.chat_session_paper_ids("sess-1").await.unwrap(),
+        vec![paper]
+    );
+}
+
+#[tokio::test]
+async fn a_group_is_identified_by_its_members_not_their_order() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let a = insert(&db, "A").await;
+    let b = insert(&db, "B").await;
+    let c = insert(&db, "C").await;
+
+    let selected = ChatSubject::Group(vec![a.clone(), b.clone(), c.clone()]);
+    db.upsert_chat_session(&row("sess-group", &selected), &selected.paper_ids())
+        .await
+        .unwrap();
+
+    // Re-selecting the same papers in a different order is the same subject.
+    let reselected = ChatSubject::Group(vec![c.clone(), a.clone(), b.clone()]);
+    assert_eq!(selected.id(), reselected.id());
+    let found = db.chat_session_for_subject(&reselected).await.unwrap();
+    assert_eq!(found.map(|r| r.session_id), Some("sess-group".to_string()));
+
+    // A different set is a different subject, and has no conversation yet.
+    let narrower = ChatSubject::Group(vec![a, b]);
+    assert!(
+        db.chat_session_for_subject(&narrower)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn upsert_keeps_the_original_age_and_never_erases_a_summary() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "A").await;
+    let subject = ChatSubject::Paper(paper);
+
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+    db.set_chat_session_summary("sess-1", "Explains the attention mechanism")
+        .await
+        .unwrap();
+
+    // A later upsert that doesn't know the summary must not clear it.
+    let mut later = row("sess-1", &subject);
+    later.last_used_at = "2026-06-01T00:00:00Z".into();
+    db.upsert_chat_session(&later, &subject.paper_ids())
+        .await
+        .unwrap();
+
+    let found = db
+        .chat_session_for_subject(&subject)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        found.summary.as_deref(),
+        Some("Explains the attention mechanism")
+    );
+    assert_eq!(found.created_at, "2026-01-01T00:00:00Z");
+    assert_eq!(found.last_used_at, "2026-06-01T00:00:00Z");
+}
+
+#[tokio::test]
+async fn linking_is_idempotent_and_ignores_unknown_papers() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "A").await;
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(&row("sess-1", &subject), &[])
+        .await
+        .unwrap();
+
+    db.link_chat_session_paper("sess-1", &paper).await.unwrap();
+    db.link_chat_session_paper("sess-1", &paper).await.unwrap();
+    // An id the agent invented is not a library paper, so it is dropped.
+    db.link_chat_session_paper("sess-1", "not-a-real-paper")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        db.chat_session_paper_ids("sess-1").await.unwrap(),
+        vec![paper]
+    );
+}
+
+#[tokio::test]
+async fn a_dead_session_stops_being_offered_but_stays_on_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "A").await;
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+
+    db.mark_chat_session_dead("sess-1").await.unwrap();
+
+    assert!(
+        db.chat_session_for_subject(&subject)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(db.chat_sessions_for_paper(&paper).await.unwrap().is_empty());
+    // The link survives, so the conversation is still inspectable.
+    assert_eq!(
+        db.chat_session_paper_ids("sess-1").await.unwrap(),
+        vec![paper]
+    );
+}
+
+#[tokio::test]
+async fn a_deleted_paper_drops_out_of_its_conversations() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let kept = insert(&db, "Kept").await;
+    let removed = insert(&db, "Removed").await;
+    let subject = ChatSubject::Group(vec![kept.clone(), removed.clone()]);
+    db.upsert_chat_session(&row("sess-group", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+
+    // Papers are tombstoned rather than removed, so the cascade never fires —
+    // the reads have to exclude dead papers themselves.
+    db.delete_paper(&removed).await.unwrap();
+
+    assert_eq!(
+        db.chat_session_paper_ids("sess-group").await.unwrap(),
+        vec![kept.clone()]
+    );
+    assert!(
+        db.chat_sessions_for_paper(&removed)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    // The conversation is still reachable from the paper that remains.
+    assert_eq!(db.chat_sessions_for_paper(&kept).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn chat_tables_are_not_synced() {
+    // The whole point of keeping these local: a session id minted by the agent
+    // on this machine means nothing on another device, so a synced row would
+    // name a conversation that cannot be resumed.
+    for table in rotero_db::sync_schema::SYNCED_TABLES {
+        assert_ne!(table.name, "chat_sessions");
+        assert_ne!(table.name, "chat_session_papers");
+    }
+}

--- a/crates/rotero-db/tests/chat_sessions_test.rs
+++ b/crates/rotero-db/tests/chat_sessions_test.rs
@@ -253,3 +253,38 @@ async fn chat_tables_are_not_synced() {
         assert_ne!(table.name, "chat_session_papers");
     }
 }
+
+/// The bug this guards: the row is created when the agent announces the session
+/// and the label is written when the user sends a message, and both writes are
+/// spawned independently. An UPDATE that lost the race updated nothing, so every
+/// stored summary stayed null and the chat list fell back to the agent's own
+/// uninformative title.
+#[tokio::test]
+async fn a_summary_written_before_its_row_exists_is_not_lost() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "A").await;
+    let subject = ChatSubject::Paper(paper);
+
+    // The label lands first, with no row to update.
+    db.set_chat_session_summary("sess-1", "What does this paper claim?")
+        .await
+        .unwrap();
+    // The session announcement follows, and must not erase it.
+    db.upsert_chat_session(&row("sess-1", &subject), &subject.paper_ids())
+        .await
+        .unwrap();
+
+    let found = db
+        .chat_session_for_subject(&subject)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        found.summary.as_deref(),
+        Some("What does this paper claim?")
+    );
+    // The placeholder columns must not survive the real upsert.
+    assert_eq!(found.subject_kind, "paper");
+    assert_eq!(found.provider_id, "claude");
+}

--- a/crates/rotero-db/tests/migration_v15_test.rs
+++ b/crates/rotero-db/tests/migration_v15_test.rs
@@ -1,0 +1,100 @@
+//! The v15 migration must add the chat tables to a library that predates them.
+//!
+//! `CREATE_TABLES` covers a fresh database, so a bug in the migration block is
+//! invisible to every other test — they all start from a new library. This one
+//! rewinds a real library to v14 and reopens it, which is the upgrade path an
+//! existing user actually takes.
+
+mod common;
+
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
+use rotero_models::Paper;
+
+/// Drop the chat tables and rewind the version, as a genuinely pre-v15 library is.
+async fn rewind_to_v14(dir: &std::path::Path) {
+    let db_path = dir.join("rotero.db");
+    let raw = turso::Builder::new_local(db_path.to_str().unwrap())
+        .experimental_index_method(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = raw.connect().unwrap();
+    conn.execute("DROP TABLE IF EXISTS chat_session_papers", ())
+        .await
+        .unwrap();
+    conn.execute("DROP TABLE IF EXISTS chat_sessions", ())
+        .await
+        .unwrap();
+    conn.execute(
+        "UPDATE schema_version SET version = ?1",
+        [turso::Value::Integer(14)],
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn reopening_a_v14_library_creates_the_chat_tables() {
+    let dir = tempfile::tempdir().unwrap();
+    let paper = {
+        let db = common::open_test_db(dir.path()).await;
+        db.insert_paper(&Paper {
+            title: "A".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+    };
+    rewind_to_v14(dir.path()).await;
+
+    let db = common::open_test_db(dir.path()).await;
+
+    // The tables exist and are usable, not merely present.
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(
+        &ChatSessionRow {
+            session_id: "sess-1".into(),
+            provider_id: "claude".into(),
+            subject_kind: subject.kind().to_string(),
+            subject_id: Some(subject.id()),
+            summary: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            last_used_at: "2026-01-01T00:00:00Z".into(),
+            is_dead: false,
+        },
+        &subject.paper_ids(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        db.chat_session_for_subject(&subject)
+            .await
+            .unwrap()
+            .map(|r| r.session_id),
+        Some("sess-1".to_string())
+    );
+    assert_eq!(db.chat_sessions_for_paper(&paper).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn the_upgrade_leaves_the_library_healthy() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = common::open_test_db(dir.path()).await;
+        db.insert_paper(&Paper {
+            title: "A".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    }
+    rewind_to_v14(dir.path()).await;
+
+    let db = common::open_test_db(dir.path()).await;
+
+    // The new tables are local-only, so they must not register as a sync
+    // problem — health derives its expectations from SYNCED_TABLES.
+    let problems = rotero_db::health::verify_database_health(&db).await;
+    assert!(problems.is_empty(), "unexpected problems: {problems:?}");
+}

--- a/crates/rotero-db/tests/migration_v16_test.rs
+++ b/crates/rotero-db/tests/migration_v16_test.rs
@@ -1,0 +1,139 @@
+//! The v16 migration must add `is_subject` to a library created at v15.
+//!
+//! The column is declared in `CREATE_TABLES` and in the v15 block's
+//! `CREATE TABLE IF NOT EXISTS`, so a fresh library and a pre-v15 upgrade both
+//! get it — and every other test starts from one of those. A library created
+//! *at* v15 already has the table, so both statements are no-ops for it and
+//! only the ALTER can add the column. That is the path a real user was on, and
+//! the version stamped to 16 without the column ever arriving.
+
+mod common;
+
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
+use rotero_models::Paper;
+
+/// Rebuild `chat_session_papers` without `is_subject` and rewind to 15, which is
+/// exactly the shape a library created by the v15 build has.
+async fn rewind_to_v15(dir: &std::path::Path) {
+    let db_path = dir.join("rotero.db");
+    let raw = turso::Builder::new_local(db_path.to_str().unwrap())
+        .experimental_index_method(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = raw.connect().unwrap();
+    conn.execute("DROP TABLE IF EXISTS chat_session_papers", ())
+        .await
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE chat_session_papers (
+            session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+            paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+            PRIMARY KEY (session_id, paper_id)
+        )",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "UPDATE schema_version SET version = ?1",
+        [turso::Value::Integer(15)],
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn reopening_a_v15_library_adds_the_is_subject_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let paper = {
+        let db = common::open_test_db(dir.path()).await;
+        db.insert_paper(&Paper {
+            title: "A".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+    };
+    rewind_to_v15(dir.path()).await;
+
+    // Reopening runs the migrations, as launching the app does.
+    let db = common::open_test_db(dir.path()).await;
+
+    // The column is what every subject query filters on, so a conversation is
+    // only findable by its paper if the ALTER landed.
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(
+        &ChatSessionRow {
+            session_id: "sess-1".into(),
+            provider_id: "claude".into(),
+            subject_kind: subject.kind().to_string(),
+            subject_id: Some(subject.id()),
+            summary: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            last_used_at: "2026-01-01T00:00:00Z".into(),
+            is_dead: false,
+        },
+        &subject.paper_ids(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(db.chat_sessions_for_paper(&paper).await.unwrap().len(), 1);
+}
+
+/// A library an earlier build stamped 16 without adding the column reports
+/// itself up to date, so a version-guarded migration would skip it forever.
+/// Reopening has to repair it regardless of what the version says.
+#[tokio::test]
+async fn a_library_stamped_16_without_the_column_still_gets_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let paper = {
+        let db = common::open_test_db(dir.path()).await;
+        db.insert_paper(&Paper {
+            title: "A".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+    };
+
+    // The exact broken state: table without the column, version already at 16.
+    rewind_to_v15(dir.path()).await;
+    {
+        let db_path = dir.path().join("rotero.db");
+        let raw = turso::Builder::new_local(db_path.to_str().unwrap())
+            .experimental_index_method(true)
+            .build()
+            .await
+            .unwrap();
+        let conn = raw.connect().unwrap();
+        conn.execute(
+            "UPDATE schema_version SET version = ?1",
+            [turso::Value::Integer(16)],
+        )
+        .await
+        .unwrap();
+    }
+
+    let db = common::open_test_db(dir.path()).await;
+
+    let subject = ChatSubject::Paper(paper.clone());
+    db.upsert_chat_session(
+        &ChatSessionRow {
+            session_id: "sess-1".into(),
+            provider_id: "claude".into(),
+            subject_kind: subject.kind().to_string(),
+            subject_id: Some(subject.id()),
+            summary: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            last_used_at: "2026-01-01T00:00:00Z".into(),
+            is_dead: false,
+        },
+        &subject.paper_ids(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(db.chat_sessions_for_paper(&paper).await.unwrap().len(), 1);
+}

--- a/crates/rotero-db/tests/migration_v17_test.rs
+++ b/crates/rotero-db/tests/migration_v17_test.rs
@@ -1,0 +1,94 @@
+//! The v17 migration clears out conversations that never happened.
+//!
+//! An earlier build filed a row when the agent opened a session, which it does
+//! on connect — so every launch left one behind whether or not anything was
+//! said. The cleanup has to remove those without touching a real conversation.
+
+mod common;
+
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
+use rotero_models::Paper;
+
+fn row(session_id: &str, subject: &ChatSubject) -> ChatSessionRow {
+    ChatSessionRow {
+        session_id: session_id.to_string(),
+        provider_id: "claude".into(),
+        subject_kind: subject.kind().to_string(),
+        subject_id: Some(subject.id()),
+        summary: None,
+        created_at: "2026-01-01T00:00:00Z".into(),
+        last_used_at: "2026-01-01T00:00:00Z".into(),
+        is_dead: false,
+    }
+}
+
+/// Rewind so reopening runs the v17 block.
+async fn rewind_to_v16(dir: &std::path::Path) {
+    let db_path = dir.join("rotero.db");
+    let raw = turso::Builder::new_local(db_path.to_str().unwrap())
+        .experimental_index_method(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = raw.connect().unwrap();
+    conn.execute(
+        "UPDATE schema_version SET version = ?1",
+        [turso::Value::Integer(16)],
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn empty_sessions_are_cleared_and_real_ones_kept() {
+    let dir = tempfile::tempdir().unwrap();
+    let paper = {
+        let db = common::open_test_db(dir.path()).await;
+        let paper = db
+            .insert_paper(&Paper {
+                title: "A".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let subject = ChatSubject::Paper(paper.clone());
+
+        // A real conversation: has a subject paper linked.
+        db.upsert_chat_session(&row("real", &subject), &subject.paper_ids())
+            .await
+            .unwrap();
+        // A conversation with a label but no papers is still real.
+        db.upsert_chat_session(&row("labelled", &subject), &[])
+            .await
+            .unwrap();
+        db.set_chat_session_summary("labelled", "Explain this")
+            .await
+            .unwrap();
+        // The shells: no label, no papers.
+        db.upsert_chat_session(&row("empty-1", &subject), &[])
+            .await
+            .unwrap();
+        db.upsert_chat_session(&row("empty-2", &subject), &[])
+            .await
+            .unwrap();
+        paper
+    };
+    rewind_to_v16(dir.path()).await;
+
+    let db = common::open_test_db(dir.path()).await;
+
+    let ids: Vec<String> = db
+        .all_chat_sessions()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| r.session_id)
+        .collect();
+    assert!(ids.contains(&"real".to_string()), "got {ids:?}");
+    assert!(ids.contains(&"labelled".to_string()), "got {ids:?}");
+    assert!(!ids.contains(&"empty-1".to_string()), "got {ids:?}");
+    assert!(!ids.contains(&"empty-2".to_string()), "got {ids:?}");
+
+    // The surviving conversation is still reachable from its paper.
+    assert_eq!(db.chat_sessions_for_paper(&paper).await.unwrap().len(), 1);
+}

--- a/crates/rotero-graph/src/data.rs
+++ b/crates/rotero-graph/src/data.rs
@@ -11,6 +11,10 @@ pub struct GraphNode {
     pub color: String,
     pub is_read: bool,
     pub is_favorite: bool,
+    /// Whether any agent conversation is about this paper. Drives the node's
+    /// own appearance, so a paper discussed on its own still stands out in
+    /// conversation mode, where it has no one to share an edge with.
+    pub is_discussed: bool,
 }
 
 /// The kind of relationship that connects two papers.
@@ -27,6 +31,8 @@ pub enum EdgeType {
     Journal,
     /// The source paper cites the target paper (directed A → B).
     Citation,
+    /// Papers were discussed together in one agent conversation.
+    Conversation,
 }
 
 /// A weighted, typed edge between two paper nodes.
@@ -46,6 +52,24 @@ pub struct GraphData {
     pub links: Vec<GraphEdge>,
 }
 
+/// The library relationships edges are computed from.
+///
+/// Grouped into a struct rather than passed positionally: four of these are
+/// `&[(String, String)]`, so transposing two at a call site would compile
+/// cleanly and quietly draw the wrong graph.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Relations<'a> {
+    /// `(paper_id, tag_id)`.
+    pub paper_tags: &'a [(String, String)],
+    /// `(paper_id, collection_id)`.
+    pub paper_collections: &'a [(String, String)],
+    /// `(citing_paper_id, cited_paper_id)`, directed.
+    pub citations: &'a [(String, String)],
+    /// `(session_id, paper_id)`, listing only the papers a conversation is
+    /// *about* — not every paper the agent happened to read.
+    pub conversations: &'a [(String, String)],
+}
+
 /// Controls which edge types are included and caps edge density.
 #[derive(Debug, Clone)]
 pub struct GraphFilter {
@@ -54,6 +78,7 @@ pub struct GraphFilter {
     pub show_author_edges: bool,
     pub show_journal_edges: bool,
     pub show_citation_edges: bool,
+    pub show_conversation_edges: bool,
     pub max_edges_per_node: usize,
     pub max_author_group_size: usize,
 }
@@ -66,6 +91,7 @@ impl Default for GraphFilter {
             show_author_edges: true,
             show_journal_edges: false,
             show_citation_edges: false,
+            show_conversation_edges: false,
             max_edges_per_node: 15,
             max_author_group_size: 20,
         }

--- a/crates/rotero-graph/src/edges.rs
+++ b/crates/rotero-graph/src/edges.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use rotero_models::{Paper, Tag};
 
-use crate::data::{EdgeType, GraphFilter};
+use crate::data::{EdgeType, GraphFilter, Relations};
 
 /// A raw edge before deduplication.
 #[derive(Debug)]
@@ -28,11 +28,16 @@ pub struct MergedEdge {
 pub fn compute_edges(
     papers: &[Paper],
     tags: &[Tag],
-    paper_tag_pairs: &[(String, String)],
-    paper_collection_pairs: &[(String, String)],
-    citation_pairs: &[(String, String)],
+    relations: Relations<'_>,
     filter: &GraphFilter,
 ) -> Vec<MergedEdge> {
+    let Relations {
+        paper_tags: paper_tag_pairs,
+        paper_collections: paper_collection_pairs,
+        citations: citation_pairs,
+        conversations: conversation_pairs,
+    } = relations;
+
     let tag_name_map: HashMap<&str, &str> = tags
         .iter()
         .filter_map(|t| Some((t.id.as_deref()?, t.name.as_str())))
@@ -136,6 +141,31 @@ pub fn compute_edges(
         }
     }
 
+    // Papers discussed together in one conversation. Grouped like shared tags:
+    // the pairs arrive as (session_id, paper_id), so every paper a single
+    // conversation is *about* links to every other. Papers the agent merely
+    // read are not in this list — only subjects are — so a library search the
+    // agent ran does not wire its results together.
+    if filter.show_conversation_edges {
+        let mut session_to_papers: HashMap<&str, Vec<&str>> = HashMap::new();
+        for (session_id, paper_id) in conversation_pairs {
+            if paper_ids.contains(paper_id.as_str()) {
+                session_to_papers
+                    .entry(session_id.as_str())
+                    .or_default()
+                    .push(paper_id.as_str());
+            }
+        }
+        for pids in session_to_papers.values() {
+            add_pairwise_edges(
+                &mut raw_edges,
+                pids,
+                EdgeType::Conversation,
+                "discussed together",
+            );
+        }
+    }
+
     merge_edges(raw_edges, filter.max_edges_per_node)
 }
 
@@ -216,7 +246,10 @@ fn merge_edges(raw: Vec<RawEdge>, max_per_node: usize) -> Vec<MergedEdge> {
 
 fn edge_type_priority(t: EdgeType) -> u8 {
     match t {
-        // Citations are the strongest signal — an explicit A→B reference — so if
+        // A conversation outranks everything: the user chose these papers and
+        // discussed them together, which no derived metadata match can beat.
+        EdgeType::Conversation => 5,
+        // Citations are the next strongest — an explicit A→B reference — so if
         // a pair also shares metadata, the citation label wins.
         EdgeType::Citation => 4,
         EdgeType::Tag => 3,
@@ -238,6 +271,159 @@ mod tests {
         }
     }
 
+    fn conversation_only_filter() -> GraphFilter {
+        GraphFilter {
+            show_tag_edges: false,
+            show_collection_edges: false,
+            show_author_edges: false,
+            show_journal_edges: false,
+            show_conversation_edges: true,
+            ..Default::default()
+        }
+    }
+
+    /// `(session_id, paper_id)`, the shape `all_chat_session_subjects` returns.
+    fn chat(session: &str, paper: &str) -> (String, String) {
+        (session.to_string(), paper.to_string())
+    }
+
+    #[test]
+    fn papers_discussed_in_one_conversation_are_linked() {
+        let papers = [paper("a"), paper("b"), paper("c")];
+        let chats = [chat("s1", "a"), chat("s1", "b"), chat("s1", "c")];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &conversation_only_filter(),
+        );
+        // A three-paper conversation is a triangle, not a star.
+        assert_eq!(edges.len(), 3);
+        assert!(edges.iter().all(|e| e.rel_type == EdgeType::Conversation));
+    }
+
+    /// The point of the mode: a conversation about one paper is real history,
+    /// but it has no second paper to link to and so draws no edge. The node
+    /// marker is what carries it — see `is_discussed` in the crate root.
+    #[test]
+    fn a_conversation_about_one_paper_draws_no_edge() {
+        let papers = [paper("a"), paper("b")];
+        let chats = [chat("s1", "a")];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &conversation_only_filter(),
+        );
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn separate_conversations_do_not_link_their_papers() {
+        let papers = [paper("a"), paper("b")];
+        let chats = [chat("s1", "a"), chat("s2", "b")];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &conversation_only_filter(),
+        );
+        assert!(edges.is_empty());
+    }
+
+    /// Two conversations covering the same pair are one edge, weighted heavier.
+    #[test]
+    fn discussing_a_pair_twice_strengthens_one_edge() {
+        let papers = [paper("a"), paper("b")];
+        let chats = [
+            chat("s1", "a"),
+            chat("s1", "b"),
+            chat("s2", "a"),
+            chat("s2", "b"),
+        ];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &conversation_only_filter(),
+        );
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].weight, 2.0);
+    }
+
+    #[test]
+    fn a_deleted_paper_drops_out_of_conversation_edges() {
+        let papers = [paper("a")];
+        let chats = [chat("s1", "a"), chat("s1", "gone")];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &conversation_only_filter(),
+        );
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn conversations_hidden_when_filter_off() {
+        let papers = [paper("a"), paper("b")];
+        let chats = [chat("s1", "a"), chat("s1", "b")];
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                conversations: &chats,
+                ..Default::default()
+            },
+            &GraphFilter::default(),
+        );
+        assert!(edges.is_empty());
+    }
+
+    /// A pair that both shares a tag and was discussed together is labelled by
+    /// the conversation: the user's own grouping outranks derived metadata.
+    #[test]
+    fn a_conversation_outranks_a_shared_tag() {
+        let papers = [paper("a"), paper("b")];
+        let tag_pairs = [
+            ("a".to_string(), "t1".to_string()),
+            ("b".to_string(), "t1".to_string()),
+        ];
+        let chats = [chat("s1", "a"), chat("s1", "b")];
+        let filter = GraphFilter {
+            show_tag_edges: true,
+            show_conversation_edges: true,
+            ..conversation_only_filter()
+        };
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                paper_tags: &tag_pairs,
+                conversations: &chats,
+                ..Default::default()
+            },
+            &filter,
+        );
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].rel_type, EdgeType::Conversation);
+    }
+
     fn citation_only_filter() -> GraphFilter {
         GraphFilter {
             show_tag_edges: false,
@@ -253,7 +439,15 @@ mod tests {
     fn citation_edges_are_directed() {
         let papers = [paper("a"), paper("b")];
         let cites = [("a".to_string(), "b".to_string())];
-        let edges = compute_edges(&papers, &[], &[], &[], &cites, &citation_only_filter());
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                citations: &cites,
+                ..Default::default()
+            },
+            &citation_only_filter(),
+        );
         assert_eq!(edges.len(), 1);
         // Preserved as citing → cited, NOT normalized by id order.
         assert_eq!(edges[0].source, "a");
@@ -268,7 +462,15 @@ mod tests {
             ("a".to_string(), "b".to_string()),
             ("b".to_string(), "a".to_string()),
         ];
-        let edges = compute_edges(&papers, &[], &[], &[], &cites, &citation_only_filter());
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                citations: &cites,
+                ..Default::default()
+            },
+            &citation_only_filter(),
+        );
         assert_eq!(edges.len(), 2);
     }
 
@@ -276,7 +478,15 @@ mod tests {
     fn citations_hidden_when_filter_off() {
         let papers = [paper("a"), paper("b")];
         let cites = [("a".to_string(), "b".to_string())];
-        let edges = compute_edges(&papers, &[], &[], &[], &cites, &GraphFilter::default());
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                citations: &cites,
+                ..Default::default()
+            },
+            &GraphFilter::default(),
+        );
         assert!(edges.is_empty());
     }
 
@@ -287,7 +497,15 @@ mod tests {
             ("a".to_string(), "a".to_string()),       // self-citation
             ("a".to_string(), "missing".to_string()), // target not in library
         ];
-        let edges = compute_edges(&papers, &[], &[], &[], &cites, &citation_only_filter());
+        let edges = compute_edges(
+            &papers,
+            &[],
+            Relations {
+                citations: &cites,
+                ..Default::default()
+            },
+            &citation_only_filter(),
+        );
         assert!(edges.is_empty());
     }
 }

--- a/crates/rotero-graph/src/lib.rs
+++ b/crates/rotero-graph/src/lib.rs
@@ -11,27 +11,32 @@ use std::collections::HashMap;
 
 use rotero_models::{Paper, Tag};
 
-pub use data::{EdgeType, GraphData, GraphEdge, GraphFilter, GraphNode};
+pub use data::{EdgeType, GraphData, GraphEdge, GraphFilter, GraphNode, Relations};
 pub use edges::MergedEdge;
 
 /// Build the full graph and run force simulation.
 pub fn build_and_simulate(
     papers: &[Paper],
     tags: &[Tag],
-    paper_tag_pairs: &[(String, String)],
-    paper_collection_pairs: &[(String, String)],
-    citation_pairs: &[(String, String)],
+    relations: Relations<'_>,
     filter: &GraphFilter,
     iterations: usize,
 ) -> GraphData {
-    let merged_edges = edges::compute_edges(
-        papers,
-        tags,
-        paper_tag_pairs,
-        paper_collection_pairs,
-        citation_pairs,
-        filter,
-    );
+    let Relations {
+        paper_tags: paper_tag_pairs,
+        conversations: conversation_pairs,
+        ..
+    } = relations;
+    let merged_edges = edges::compute_edges(papers, tags, relations, filter);
+
+    // Every paper any conversation is about. A node carries this regardless of
+    // whether it shares an edge: a paper discussed on its own has no partner to
+    // link to, and would otherwise be indistinguishable from one never
+    // discussed at all.
+    let discussed: std::collections::HashSet<&str> = conversation_pairs
+        .iter()
+        .map(|(_, paper_id)| paper_id.as_str())
+        .collect();
 
     let tag_colors: HashMap<&str, &str> = tags
         .iter()
@@ -195,6 +200,7 @@ pub fn build_and_simulate(
                 color,
                 is_read: paper.status.is_read,
                 is_favorite: paper.status.is_favorite,
+                is_discussed: discussed.contains(pid),
             })
         })
         .collect();

--- a/crates/rotero-mcp/src/server/tools.rs
+++ b/crates/rotero-mcp/src/server/tools.rs
@@ -717,9 +717,14 @@ impl RoteroMcp {
         let edges = rotero_graph::edges::compute_edges(
             &papers,
             &tags,
-            &paper_tags,
-            &paper_colls,
-            &citations,
+            rotero_graph::data::Relations {
+                paper_tags: &paper_tags,
+                paper_collections: &paper_colls,
+                citations: &citations,
+                // Deliberately empty: these tools describe the library to the
+                // agent, and its own past chats are not a property of it.
+                conversations: &[],
+            },
             &filter,
         );
 
@@ -781,9 +786,14 @@ impl RoteroMcp {
         let mut edges = rotero_graph::edges::compute_edges(
             &papers,
             &tags,
-            &paper_tags,
-            &paper_colls,
-            &citations,
+            rotero_graph::data::Relations {
+                paper_tags: &paper_tags,
+                paper_collections: &paper_colls,
+                citations: &citations,
+                // Deliberately empty: these tools describe the library to the
+                // agent, and its own past chats are not a property of it.
+                conversations: &[],
+            },
             &filter,
         );
         edges.truncate(max_edges);

--- a/src/agent/helpers.rs
+++ b/src/agent/helpers.rs
@@ -137,11 +137,18 @@ pub(crate) fn handle_notification(
                         .and_then(|c| c.get("text"))
                         .and_then(|t| t.as_str())
                     {
+                        // Read the context block before stripping it: on a
+                        // replayed transcript this is the only record of which
+                        // paper the conversation was about.
+                        let context_paper_ids = paper_ids_from_context_block(text);
                         // A user chunk is a whole message, so the padding
                         // left behind by tag removal can go.
                         let cleaned = strip_protocol_tags(text).trim().to_string();
-                        if !cleaned.is_empty() {
-                            let _ = evt_tx.send(ChatEvent::UserMessage(cleaned));
+                        if !cleaned.is_empty() || !context_paper_ids.is_empty() {
+                            let _ = evt_tx.send(ChatEvent::UserMessage {
+                                text: cleaned,
+                                context_paper_ids,
+                            });
                         }
                     }
                 }
@@ -353,6 +360,39 @@ pub(crate) fn strip_protocol_tags(text: &str) -> String {
     result
 }
 
+/// Paper ids named in a message's `<rotero-context>` blocks, in order.
+///
+/// Runs here rather than in the app layer because [`strip_protocol_tags`]
+/// removes the block before a message is ever emitted: the agent's stored
+/// transcript is the only record of which paper a past conversation was about,
+/// and it is readable exactly once, as the transcript replays on `session/load`.
+pub(crate) fn paper_ids_from_context_block(raw: &str) -> Vec<String> {
+    const OPEN: &str = "<rotero-context";
+    const CLOSE: &str = "</rotero-context>";
+    const KEY: &str = "Paper ID:";
+
+    let mut ids = Vec::new();
+    let mut rest = raw;
+    while let Some(start) = rest.find(OPEN) {
+        let after_open = &rest[start..];
+        // An unterminated block still carries a usable id, so scan to the end.
+        let (block, consumed) = match after_open.find(CLOSE) {
+            Some(end) => (&after_open[..end], start + end + CLOSE.len()),
+            None => (after_open, rest.len()),
+        };
+        for line in block.lines() {
+            if let Some(value) = line.trim().strip_prefix(KEY) {
+                let id = value.trim();
+                if !id.is_empty() && !ids.iter().any(|seen| seen == id) {
+                    ids.push(id.to_string());
+                }
+            }
+        }
+        rest = &rest[consumed..];
+    }
+    ids
+}
+
 pub(crate) fn extract_models_event(models: &serde_json::Value) -> ChatEvent {
     let available = models
         .get("availableModels")
@@ -455,6 +495,47 @@ pub(crate) fn extract_auth_methods(init_result: &serde_json::Value) -> Vec<Agent
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The exact shape `build_paper_context` produces.
+    #[test]
+    fn reads_the_paper_id_the_app_sends() {
+        let raw = "<rotero-context>\nWhen finding papers, prefer the rotero MCP tools.\n\
+                   I'm currently looking at this paper in my library:\n\
+                   Title: Attention Is All You Need\nAuthors: Vaswani\nYear: 2017\n\
+                   DOI: 10.5555/1\nPaper ID: abc-123\n\
+                   You can use the rotero MCP tools.\n</rotero-context>\n\nWhat is this about?";
+        assert_eq!(paper_ids_from_context_block(raw), vec!["abc-123"]);
+    }
+
+    /// The variant the paper detail panel sends when asking for an OA PDF.
+    #[test]
+    fn reads_the_shorter_block_from_the_detail_panel() {
+        let raw = "<rotero-context>\nPaper ID: xyz-789\nTitle: A\n</rotero-context>";
+        assert_eq!(paper_ids_from_context_block(raw), vec!["xyz-789"]);
+    }
+
+    #[test]
+    fn a_message_without_a_block_names_no_papers() {
+        assert!(paper_ids_from_context_block("Just a question.").is_empty());
+        assert!(paper_ids_from_context_block("").is_empty());
+    }
+
+    #[test]
+    fn reads_every_block_and_records_each_paper_once() {
+        let raw = "<rotero-context>\nPaper ID: a\n</rotero-context>\
+                   <rotero-context>\nPaper ID: b\n</rotero-context>\
+                   <rotero-context>\nPaper ID: a\n</rotero-context>";
+        assert_eq!(paper_ids_from_context_block(raw), vec!["a", "b"]);
+    }
+
+    /// A block cut off mid-stream still names the paper it was about.
+    #[test]
+    fn an_unterminated_block_still_yields_its_id() {
+        assert_eq!(
+            paper_ids_from_context_block("<rotero-context>\nPaper ID: a\n"),
+            vec!["a"]
+        );
+    }
 
     #[test]
     fn recognises_windows_batch_extensions() {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -96,7 +96,9 @@ pub(crate) fn connect_and_run(
                 .unwrap_or("")
                 .to_string();
             tracing::info!("ACP: session created: {session_id}");
-            let _ = evt_tx.send(ChatEvent::SessionCreated);
+            let _ = evt_tx.send(ChatEvent::SessionCreated {
+                session_id: session_id.clone(),
+            });
 
             if let Some(models) = r.get("models") {
                 let _ = evt_tx.send(extract_models_event(models));
@@ -317,10 +319,18 @@ pub(crate) fn connect_and_run(
                 });
                 match conn.send_request("session/load", params, Some(evt_tx)) {
                     Ok(result) => {
-                        if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str()) {
-                            session_id = sid.to_string();
-                        }
-                        let _ = evt_tx.send(ChatEvent::SessionCreated);
+                        // Fall back to the id we asked for: an agent that omits
+                        // `sessionId` from the reply would otherwise leave the
+                        // previous session's id in place, and the loaded chat
+                        // would be recorded against the wrong subject.
+                        session_id = result
+                            .get("sessionId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(load_id.as_str())
+                            .to_string();
+                        let _ = evt_tx.send(ChatEvent::SessionCreated {
+                            session_id: session_id.clone(),
+                        });
                     }
                     Err(e) => {
                         let _ = evt_tx.send(ChatEvent::Error(format!("Load session failed: {e}")));
@@ -398,7 +408,14 @@ pub(crate) fn connect_and_run(
                                         {
                                             session_id = sid.to_string();
                                         }
-                                        let _ = evt_tx.send(ChatEvent::SessionCreated);
+                                        // No requested id to fall back on here, so
+                                        // stay silent rather than announce a session
+                                        // keyed on an empty string.
+                                        if !session_id.is_empty() {
+                                            let _ = evt_tx.send(ChatEvent::SessionCreated {
+                                                session_id: session_id.clone(),
+                                            });
+                                        }
                                     }
                                     Err(e) if is_auth_error(&e) => {
                                         let _ = evt_tx.send(ChatEvent::AuthRequired {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -6,7 +6,7 @@ use super::connection::RawAcpConnection;
 use super::helpers::{
     agent_working_dir, build_mcp_servers_json, extract_auth_methods, extract_models_event,
     extract_permission_options, first_allow_option_id, handle_notification, is_auth_error,
-    wait_for_switch_or_shutdown,
+    strip_protocol_tags, wait_for_switch_or_shutdown,
 };
 use super::install::ensure_agent_installed;
 use super::types::{AgentProvider, ChatEvent, ChatRequest, PastSession};
@@ -122,6 +122,9 @@ pub(crate) fn connect_and_run(
         }
     }
 
+    // A summary request that arrived while a turn was streaming, run once it
+    // completes so it describes a conversation that has actually happened.
+    let mut deferred_summary: Option<String> = None;
     let mut pending_auth_id: Option<u64> = None;
     let mut pending_auth_start: Option<std::time::Instant> = None;
     const AUTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -174,6 +177,13 @@ pub(crate) fn connect_and_run(
                                 "session/cancel",
                                 serde_json::json!({ "sessionId": session_id }),
                             );
+                        }
+                        // A summary asked for while the turn it describes is
+                        // still streaming: hold it until the turn finishes
+                        // rather than dropping it, which is what `_ => {}` did
+                        // to every other request that arrived mid-turn.
+                        Ok(ChatRequest::SummarizeSession { session_id: sid }) => {
+                            deferred_summary = Some(sid);
                         }
                         _ => {}
                     }
@@ -237,6 +247,18 @@ pub(crate) fn connect_and_run(
                             }
                         }
                     }
+                }
+
+                // The turn is over, so a summary asked for mid-stream can now
+                // describe it.
+                if let Some(sid) = deferred_summary.take()
+                    && sid == session_id
+                    && let Some(summary) = request_session_summary(&mut conn, &session_id)
+                {
+                    let _ = evt_tx.send(ChatEvent::SessionSummary {
+                        session_id: sid,
+                        summary,
+                    });
                 }
             }
             Ok(ChatRequest::Cancel) => {
@@ -335,6 +357,20 @@ pub(crate) fn connect_and_run(
                     Err(e) => {
                         let _ = evt_tx.send(ChatEvent::Error(format!("Load session failed: {e}")));
                     }
+                }
+            }
+            Ok(ChatRequest::SummarizeSession {
+                session_id: summarize_id,
+            }) => {
+                // Summarizing a session other than the live one would describe
+                // the wrong conversation.
+                if summarize_id == session_id
+                    && let Some(summary) = request_session_summary(&mut conn, &session_id)
+                {
+                    let _ = evt_tx.send(ChatEvent::SessionSummary {
+                        session_id: summarize_id,
+                        summary,
+                    });
                 }
             }
             Ok(ChatRequest::SwitchAgent { provider_id }) => {
@@ -463,4 +499,94 @@ pub(crate) fn connect_and_run(
 
     conn.kill();
     result
+}
+
+/// Ask the agent to describe the conversation, returning the reply text.
+///
+/// Deliberately does not go through `handle_notification`: routing the reply
+/// here rather than filtering it downstream means the summary turn emits no
+/// events at all, so there is no window in which a stray delta could land in
+/// the visible transcript. Correlation is by JSON-RPC id, which is exact.
+///
+/// Returns `None` if the agent declines, errors, or says nothing.
+fn request_session_summary(conn: &mut RawAcpConnection, session_id: &str) -> Option<String> {
+    const PROMPT: &str = "<rotero-context>\nIn one sentence of at most 120 characters, describe \
+what this conversation has been about. Name the specific paper or topic. Reply with the sentence \
+only — no preamble, no markdown, no quotes.\n</rotero-context>";
+    /// A summary must never wedge the loop the user's own messages run through.
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+    let prompt_id = conn.next_id;
+    conn.next_id += 1;
+    let msg = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": prompt_id,
+        "method": "session/prompt",
+        "params": {
+            "sessionId": session_id,
+            "prompt": [{ "type": "text", "text": PROMPT }],
+        },
+    });
+    conn.write_message(&msg).ok()?;
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    let mut buf = String::new();
+    loop {
+        match conn.incoming.try_recv() {
+            Ok(line) => {
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+                    continue;
+                };
+                if v.get("id").and_then(|i| i.as_u64()) == Some(prompt_id) {
+                    if v.get("error").is_some() {
+                        return None;
+                    }
+                    break;
+                }
+                // Auto-allow: a summary should never raise a dialog, and a
+                // pending permission would otherwise stall until the timeout.
+                if v.get("method").and_then(|m| m.as_str()) == Some("session/request_permission") {
+                    if let Some(req_id) = v.get("id") {
+                        let option_id = first_allow_option_id(&v);
+                        let response = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "result": { "outcome": { "outcome": "selected", "optionId": option_id } }
+                        });
+                        let _ = conn.write_message(&response);
+                    }
+                    continue;
+                }
+                // Everything else this turn produces is dropped on purpose.
+                if v.pointer("/params/update/sessionUpdate")
+                    .and_then(|s| s.as_str())
+                    == Some("agent_message_chunk")
+                    && let Some(text) = v
+                        .pointer("/params/update/content/text")
+                        .and_then(|t| t.as_str())
+                {
+                    buf.push_str(text);
+                }
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                if std::time::Instant::now() > deadline {
+                    tracing::debug!("ACP: session summary timed out");
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(mpsc::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    let summary: String = strip_protocol_tags(&buf)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+        .trim_matches('"')
+        .chars()
+        .take(200)
+        .collect();
+    (!summary.is_empty()).then_some(summary)
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -355,7 +355,14 @@ pub(crate) fn connect_and_run(
                         });
                     }
                     Err(e) => {
-                        let _ = evt_tx.send(ChatEvent::Error(format!("Load session failed: {e}")));
+                        // The agent has forgotten this conversation — it was
+                        // pruned, or belongs to another machine. Not the user's
+                        // problem to solve, so report it as a lost session
+                        // rather than an error and let a fresh one take over.
+                        tracing::info!("ACP: session {load_id} could not be loaded: {e}");
+                        let _ = evt_tx.send(ChatEvent::SessionLoadFailed {
+                            session_id: load_id,
+                        });
                     }
                 }
             }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -181,6 +181,12 @@ pub struct ChatState {
     /// A subject the user declined to switch to, so the offer is not repeated
     /// until they move somewhere else.
     pub declined_subject: Option<rotero_db::chat_sessions::ChatSubject>,
+    /// A conversation's first message, held until the agent reports a session
+    /// id to attach it to.
+    ///
+    /// The id does not exist yet when the message is sent, so a label written
+    /// at send time would have nothing to key on and be dropped.
+    pub pending_summary: Option<String>,
 }
 
 /// A subject switch the user has been asked about but not yet answered.
@@ -282,4 +288,28 @@ pub enum ChatEvent {
         provider_name: String,
     },
     Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this guards: a conversation's first message is sent before the
+    /// agent reports a session id, so a label written at send time had nothing
+    /// to key on and was dropped — leaving every stored summary null.
+    #[test]
+    fn a_first_message_label_survives_until_a_session_id_arrives() {
+        let mut state = ChatState {
+            pending_summary: Some("What does this paper claim?".into()),
+            ..Default::default()
+        };
+        assert!(state.current_session_id.is_none());
+
+        // What ChatEvent::SessionCreated does once the agent answers.
+        let held = state.pending_summary.take();
+        state.current_session_id = Some("sess-1".into());
+
+        assert_eq!(held.as_deref(), Some("What does this paper claim?"));
+        assert!(state.pending_summary.is_none(), "must not be written twice");
+    }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -169,6 +169,9 @@ pub struct ChatState {
     pub current_model: String,
     /// The agent session backing the visible transcript, once one exists.
     pub current_session_id: Option<String>,
+    /// What the next session created will be about. Set when a message is sent,
+    /// since the subject is known then but the session id is not yet.
+    pub pending_subject: Option<rotero_db::chat_sessions::ChatSubject>,
 }
 
 pub enum ChatRequest {
@@ -212,7 +215,12 @@ pub enum ChatEvent {
     SessionCreated {
         session_id: String,
     },
-    UserMessage(String),
+    UserMessage {
+        text: String,
+        /// Papers named in the message's `<rotero-context>` block, recovered
+        /// before the block was stripped for display.
+        context_paper_ids: Vec<String>,
+    },
     TextDelta(String),
     ToolCallStarted {
         id: String,

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -172,6 +172,23 @@ pub struct ChatState {
     /// What the next session created will be about. Set when a message is sent,
     /// since the subject is known then but the session id is not yet.
     pub pending_subject: Option<rotero_db::chat_sessions::ChatSubject>,
+    /// What the visible conversation is about, once it has been resumed or
+    /// started for a subject.
+    pub current_subject: Option<rotero_db::chat_sessions::ChatSubject>,
+    /// A subject the panel would switch to, waiting on the user's answer
+    /// because switching now would abandon a conversation in progress.
+    pub pending_switch: Option<PendingSwitch>,
+    /// A subject the user declined to switch to, so the offer is not repeated
+    /// until they move somewhere else.
+    pub declined_subject: Option<rotero_db::chat_sessions::ChatSubject>,
+}
+
+/// A subject switch the user has been asked about but not yet answered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingSwitch {
+    pub subject: rotero_db::chat_sessions::ChatSubject,
+    /// What to call it in the prompt.
+    pub label: String,
 }
 
 pub enum ChatRequest {
@@ -255,6 +272,11 @@ pub enum ChatEvent {
     SessionSummary {
         session_id: String,
         summary: String,
+    },
+    /// The agent could not load a conversation, so it no longer exists as far
+    /// as this device is concerned.
+    SessionLoadFailed {
+        session_id: String,
     },
     AuthRequired {
         provider_name: String,

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -181,12 +181,6 @@ pub struct ChatState {
     /// A subject the user declined to switch to, so the offer is not repeated
     /// until they move somewhere else.
     pub declined_subject: Option<rotero_db::chat_sessions::ChatSubject>,
-    /// A conversation's first message, held until the agent reports a session
-    /// id to attach it to.
-    ///
-    /// The id does not exist yet when the message is sent, so a label written
-    /// at send time would have nothing to key on and be dropped.
-    pub pending_summary: Option<String>,
 }
 
 /// A subject switch the user has been asked about but not yet answered.
@@ -288,28 +282,4 @@ pub enum ChatEvent {
         provider_name: String,
     },
     Error(String),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The bug this guards: a conversation's first message is sent before the
-    /// agent reports a session id, so a label written at send time had nothing
-    /// to key on and was dropped — leaving every stored summary null.
-    #[test]
-    fn a_first_message_label_survives_until_a_session_id_arrives() {
-        let mut state = ChatState {
-            pending_summary: Some("What does this paper claim?".into()),
-            ..Default::default()
-        };
-        assert!(state.current_session_id.is_none());
-
-        // What ChatEvent::SessionCreated does once the agent answers.
-        let held = state.pending_summary.take();
-        state.current_session_id = Some("sess-1".into());
-
-        assert_eq!(held.as_deref(), Some("What does this paper claim?"));
-        assert!(state.pending_summary.is_none(), "must not be written twice");
-    }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -167,6 +167,8 @@ pub struct ChatState {
     pub supports_list_sessions: bool,
     pub available_models: Vec<AgentModel>,
     pub current_model: String,
+    /// The agent session backing the visible transcript, once one exists.
+    pub current_session_id: Option<String>,
 }
 
 pub enum ChatRequest {
@@ -207,7 +209,9 @@ pub enum ChatEvent {
         provider_id: String,
         supports_list_sessions: bool,
     },
-    SessionCreated,
+    SessionCreated {
+        session_id: String,
+    },
     UserMessage(String),
     TextDelta(String),
     ToolCallStarted {

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -195,6 +195,13 @@ pub enum ChatRequest {
         session_id: String,
         cwd: String,
     },
+    /// Ask for a one-line description of the conversation so far.
+    ///
+    /// The reply is routed to [`ChatEvent::SessionSummary`] and never reaches
+    /// the transcript.
+    SummarizeSession {
+        session_id: String,
+    },
     SwitchAgent {
         provider_id: String,
     },
@@ -243,6 +250,12 @@ pub enum ChatEvent {
         current: String,
     },
     SessionList(Vec<PastSession>),
+    /// A one-line description of a conversation, for surfaces that show it
+    /// without its transcript. Carries no visible message.
+    SessionSummary {
+        session_id: String,
+        summary: String,
+    },
     AuthRequired {
         provider_name: String,
     },

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -181,6 +181,12 @@ pub struct ChatState {
     /// A subject the user declined to switch to, so the offer is not repeated
     /// until they move somewhere else.
     pub declined_subject: Option<rotero_db::chat_sessions::ChatSubject>,
+    /// Show every past chat rather than only the current subject's.
+    ///
+    /// The list is about what is open, so it filters by default; this widens it
+    /// to reach a conversation about something else — including the ones that
+    /// belong to no paper at all.
+    pub browse_all_sessions: bool,
 }
 
 /// A subject switch the user has been asked about but not yet answered.

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -115,24 +115,11 @@ pub fn handle_chat_event(
         }
         ChatEvent::SessionCreated { session_id } => {
             let subject = chat_state.read().pending_subject.clone();
-            // A first message is sent before any session id exists, so its label
-            // waits here for one to attach to.
-            let held_summary = chat_state.read().pending_summary.clone();
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 s.session_active = true;
                 s.current_session_id = Some(session_id.clone());
-                s.pending_summary = None;
             });
-            if let Some(summary) = held_summary {
-                let db = db.clone();
-                let sid = session_id.clone();
-                spawn(async move {
-                    if let Err(e) = db.set_chat_session_summary(&sid, &summary).await {
-                        tracing::debug!("chat: labelling {sid} failed: {e}");
-                    }
-                });
-            }
 
             // Without a subject the conversation is a general one; it is still
             // worth recording, so it can be found once a subject is inferred

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -255,6 +255,19 @@ pub fn handle_chat_event(
         ChatEvent::CommandsAvailable(commands) => {
             chat_state.with_mut(|s| s.commands = commands);
         }
+        ChatEvent::SessionSummary {
+            session_id,
+            summary,
+        } => {
+            // Deliberately does not touch `messages`: the summary describes the
+            // conversation from outside it.
+            let db = db.clone();
+            spawn(async move {
+                if let Err(e) = db.set_chat_session_summary(&session_id, &summary).await {
+                    tracing::debug!("chat: recording summary failed: {e}");
+                }
+            });
+        }
         ChatEvent::SessionList(sessions) => {
             chat_state.with_mut(|s| {
                 s.past_sessions = sessions;

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -28,10 +28,11 @@ pub fn handle_chat_event(chat_state: &mut Signal<ChatState>, event: ChatEvent) {
                 s.supports_list_sessions = supports_list_sessions;
             });
         }
-        ChatEvent::SessionCreated => {
+        ChatEvent::SessionCreated { session_id } => {
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 s.session_active = true;
+                s.current_session_id = Some(session_id);
             });
         }
         ChatEvent::UserMessage(text) => {

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -268,6 +268,21 @@ pub fn handle_chat_event(
                 }
             });
         }
+        ChatEvent::SessionLoadFailed { session_id } => {
+            // Nothing to tell the user: they asked for this subject's
+            // conversation and they get one, it just starts empty.
+            chat_state.with_mut(|s| {
+                s.status = AgentStatus::Idle;
+                s.messages.clear();
+                s.current_session_id = None;
+            });
+            let db = db.clone();
+            spawn(async move {
+                if let Err(e) = db.mark_chat_session_dead(&session_id).await {
+                    tracing::debug!("chat: retiring a lost session failed: {e}");
+                }
+            });
+        }
         ChatEvent::SessionList(sessions) => {
             chat_state.with_mut(|s| {
                 s.past_sessions = sessions;

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -84,6 +84,49 @@ fn link_papers(
     });
 }
 
+/// File the conversation now that it has something in it.
+///
+/// Called when a message is sent rather than when the session opens: the agent
+/// creates a session on connect, so recording there filed an empty row every
+/// time the app started one.
+///
+/// Idempotent — later messages in the same conversation refresh `last_used_at`
+/// and leave the rest alone.
+pub fn record_session(
+    chat_state: &Signal<ChatState>,
+    db: &Database,
+    subject: Option<rotero_db::chat_sessions::ChatSubject>,
+) {
+    let Some(session_id) = chat_state.read().current_session_id.clone() else {
+        return;
+    };
+    let provider_id = chat_state.read().active_provider_id.clone();
+    let now = chrono::Utc::now().to_rfc3339();
+    let paper_ids = subject.as_ref().map(|s| s.paper_ids()).unwrap_or_default();
+    // Without a subject the conversation is a general one; it is still worth
+    // recording, so it can be found once a subject is inferred from the papers
+    // it goes on to touch.
+    let row = ChatSessionRow {
+        session_id,
+        provider_id,
+        subject_kind: subject
+            .as_ref()
+            .map(|s| s.kind().to_string())
+            .unwrap_or_else(|| "general".into()),
+        subject_id: subject.as_ref().map(|s| s.id()),
+        summary: None,
+        created_at: now.clone(),
+        last_used_at: now,
+        is_dead: false,
+    };
+    let db = db.clone();
+    spawn(async move {
+        if let Err(e) = db.upsert_chat_session(&row, &paper_ids).await {
+            tracing::debug!("chat: recording session failed: {e}");
+        }
+    });
+}
+
 pub fn handle_chat_event(
     chat_state: &mut Signal<ChatState>,
     lib_state: &Signal<LibraryState>,
@@ -114,37 +157,14 @@ pub fn handle_chat_event(
             });
         }
         ChatEvent::SessionCreated { session_id } => {
-            let subject = chat_state.read().pending_subject.clone();
+            // Deliberately does not record the conversation: the agent opens a
+            // session when it connects, so recording here filed a row for every
+            // launch, whether or not the user ever said anything. A conversation
+            // earns its row by carrying a message — see `record_session`.
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 s.session_active = true;
-                s.current_session_id = Some(session_id.clone());
-            });
-
-            // Without a subject the conversation is a general one; it is still
-            // worth recording, so it can be found once a subject is inferred
-            // from the papers it goes on to touch.
-            let provider_id = chat_state.read().active_provider_id.clone();
-            let now = chrono::Utc::now().to_rfc3339();
-            let paper_ids = subject.as_ref().map(|s| s.paper_ids()).unwrap_or_default();
-            let row = ChatSessionRow {
-                session_id,
-                provider_id,
-                subject_kind: subject
-                    .as_ref()
-                    .map(|s| s.kind().to_string())
-                    .unwrap_or_else(|| "general".into()),
-                subject_id: subject.as_ref().map(|s| s.id()),
-                summary: None,
-                created_at: now.clone(),
-                last_used_at: now,
-                is_dead: false,
-            };
-            let db = db.clone();
-            spawn(async move {
-                if let Err(e) = db.upsert_chat_session(&row, &paper_ids).await {
-                    tracing::debug!("chat: recording session failed: {e}");
-                }
+                s.current_session_id = Some(session_id);
             });
         }
         ChatEvent::UserMessage {

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -1,10 +1,91 @@
 use dioxus::prelude::*;
+use rotero_db::Database;
+use rotero_db::chat_sessions::ChatSessionRow;
 
+use super::chat_papers::paper_ids_from_tool_output;
 use crate::agent::types::{
     AgentStatus, ChatEvent, ChatMessage, ChatRole, ChatState, MessageContent,
 };
+use crate::state::app_state::LibraryState;
 
-pub fn handle_chat_event(chat_state: &mut Signal<ChatState>, event: ChatEvent) {
+/// The agent thread's event receiver, handed to [`ChatEventPump`].
+///
+/// Held in a signal so the pump can take ownership once, on first render.
+#[derive(Clone, Copy)]
+pub struct AgentEvents {
+    pub inner: Signal<Option<tokio::sync::mpsc::UnboundedReceiver<ChatEvent>>>,
+}
+
+/// Drains the agent thread's events into [`ChatState`].
+///
+/// A component rather than a bare future so it can reach the `Database`, which
+/// only exists once the library is open: recording which papers a conversation
+/// touched is part of handling those events.
+#[component]
+pub fn ChatEventPump() -> Element {
+    let db = use_context::<Database>();
+    let mut chat_state = use_context::<Signal<ChatState>>();
+    let lib_state = use_context::<Signal<LibraryState>>();
+    let events = use_context::<AgentEvents>();
+
+    use_future(move || {
+        let db = db.clone();
+        let mut rx_sig = events.inner;
+        async move {
+            let Some(mut rx) = rx_sig.write().take() else {
+                return;
+            };
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                while let Ok(event) = rx.try_recv() {
+                    handle_chat_event(&mut chat_state, &lib_state, &db, event);
+                }
+            }
+        }
+    });
+
+    rsx! {}
+}
+
+/// Record papers a conversation touched, keeping only ids the library knows.
+///
+/// Best-effort: chat bookkeeping must never interrupt the stream, so failures
+/// are logged and dropped rather than surfaced.
+fn link_papers(
+    chat_state: &Signal<ChatState>,
+    lib_state: &Signal<LibraryState>,
+    db: &Database,
+    paper_ids: Vec<String>,
+) {
+    let Some(session_id) = chat_state.read().current_session_id.clone() else {
+        return;
+    };
+    let known: Vec<String> = {
+        let lib = lib_state.read();
+        paper_ids
+            .into_iter()
+            .filter(|id| lib.papers.iter().any(|p| p.id.as_deref() == Some(id)))
+            .collect()
+    };
+    if known.is_empty() {
+        return;
+    }
+    let db = db.clone();
+    spawn(async move {
+        for paper_id in known {
+            if let Err(e) = db.link_chat_session_paper(&session_id, &paper_id).await {
+                tracing::debug!("chat: linking {paper_id} failed: {e}");
+            }
+        }
+    });
+}
+
+pub fn handle_chat_event(
+    chat_state: &mut Signal<ChatState>,
+    lib_state: &Signal<LibraryState>,
+    db: &Database,
+    event: ChatEvent,
+) {
     match event {
         ChatEvent::Switching { provider_id } => {
             chat_state.with_mut(|s| {
@@ -29,19 +110,54 @@ pub fn handle_chat_event(chat_state: &mut Signal<ChatState>, event: ChatEvent) {
             });
         }
         ChatEvent::SessionCreated { session_id } => {
+            let subject = chat_state.read().pending_subject.clone();
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 s.session_active = true;
-                s.current_session_id = Some(session_id);
+                s.current_session_id = Some(session_id.clone());
+            });
+
+            // Without a subject the conversation is a general one; it is still
+            // worth recording, so it can be found once a subject is inferred
+            // from the papers it goes on to touch.
+            let provider_id = chat_state.read().active_provider_id.clone();
+            let now = chrono::Utc::now().to_rfc3339();
+            let paper_ids = subject.as_ref().map(|s| s.paper_ids()).unwrap_or_default();
+            let row = ChatSessionRow {
+                session_id,
+                provider_id,
+                subject_kind: subject
+                    .as_ref()
+                    .map(|s| s.kind().to_string())
+                    .unwrap_or_else(|| "general".into()),
+                subject_id: subject.as_ref().map(|s| s.id()),
+                summary: None,
+                created_at: now.clone(),
+                last_used_at: now,
+                is_dead: false,
+            };
+            let db = db.clone();
+            spawn(async move {
+                if let Err(e) = db.upsert_chat_session(&row, &paper_ids).await {
+                    tracing::debug!("chat: recording session failed: {e}");
+                }
             });
         }
-        ChatEvent::UserMessage(text) => {
-            chat_state.with_mut(|s| {
-                s.messages.push(ChatMessage::new(
-                    ChatRole::User,
-                    vec![MessageContent::Text(text)],
-                ));
-            });
+        ChatEvent::UserMessage {
+            text,
+            context_paper_ids,
+        } => {
+            // A replayed transcript is the only place an older conversation's
+            // subject survives, so capture before rendering.
+            link_papers(chat_state, lib_state, db, context_paper_ids);
+            if !text.is_empty() {
+                chat_state.with_mut(|s| {
+                    s.messages.push(ChatMessage::new(
+                        ChatRole::User,
+                        vec![MessageContent::Text(text)],
+                    ));
+                });
+            }
         }
         ChatEvent::TextDelta(text) => {
             chat_state.with_mut(|s| {
@@ -77,6 +193,13 @@ pub fn handle_chat_event(chat_state: &mut Signal<ChatState>, event: ChatEvent) {
             });
         }
         ChatEvent::ToolCallUpdated { id, status, output } => {
+            // Only once the call has finished: an in-progress update repeats,
+            // and the papers it names are not settled until it completes.
+            if status == crate::agent::types::ToolStatus::Completed
+                && let Some(text) = output.as_deref()
+            {
+                link_papers(chat_state, lib_state, db, paper_ids_from_tool_output(text));
+            }
             chat_state.with_mut(|s| {
                 if let Some(last) = s.messages.last_mut() {
                     for content in &mut last.content {
@@ -99,6 +222,13 @@ pub fn handle_chat_event(chat_state: &mut Signal<ChatState>, event: ChatEvent) {
             });
         }
         ChatEvent::TurnCompleted => {
+            if let Some(session_id) = chat_state.read().current_session_id.clone() {
+                let db = db.clone();
+                let now = chrono::Utc::now().to_rfc3339();
+                spawn(async move {
+                    let _ = db.touch_chat_session(&session_id, &now).await;
+                });
+            }
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 for msg in &mut s.messages {

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -56,6 +56,7 @@ fn link_papers(
     lib_state: &Signal<LibraryState>,
     db: &Database,
     paper_ids: Vec<String>,
+    is_subject: bool,
 ) {
     let Some(session_id) = chat_state.read().current_session_id.clone() else {
         return;
@@ -73,7 +74,10 @@ fn link_papers(
     let db = db.clone();
     spawn(async move {
         for paper_id in known {
-            if let Err(e) = db.link_chat_session_paper(&session_id, &paper_id).await {
+            if let Err(e) = db
+                .link_chat_session_paper(&session_id, &paper_id, is_subject)
+                .await
+            {
                 tracing::debug!("chat: linking {paper_id} failed: {e}");
             }
         }
@@ -148,8 +152,9 @@ pub fn handle_chat_event(
             context_paper_ids,
         } => {
             // A replayed transcript is the only place an older conversation's
-            // subject survives, so capture before rendering.
-            link_papers(chat_state, lib_state, db, context_paper_ids);
+            // subject survives, so capture before rendering. The context block
+            // names the paper the user was reading — the subject itself.
+            link_papers(chat_state, lib_state, db, context_paper_ids, true);
             if !text.is_empty() {
                 chat_state.with_mut(|s| {
                     s.messages.push(ChatMessage::new(
@@ -198,7 +203,16 @@ pub fn handle_chat_event(
             if status == crate::agent::types::ToolStatus::Completed
                 && let Some(text) = output.as_deref()
             {
-                link_papers(chat_state, lib_state, db, paper_ids_from_tool_output(text));
+                // Papers the agent read while answering, not what the
+                // conversation is about: a search returns dozens, and each
+                // would otherwise claim this chat on its own detail panel.
+                link_papers(
+                    chat_state,
+                    lib_state,
+                    db,
+                    paper_ids_from_tool_output(text),
+                    false,
+                );
             }
             chat_state.with_mut(|s| {
                 if let Some(last) = s.messages.last_mut() {

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -115,11 +115,24 @@ pub fn handle_chat_event(
         }
         ChatEvent::SessionCreated { session_id } => {
             let subject = chat_state.read().pending_subject.clone();
+            // A first message is sent before any session id exists, so its label
+            // waits here for one to attach to.
+            let held_summary = chat_state.read().pending_summary.clone();
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
                 s.session_active = true;
                 s.current_session_id = Some(session_id.clone());
+                s.pending_summary = None;
             });
+            if let Some(summary) = held_summary {
+                let db = db.clone();
+                let sid = session_id.clone();
+                spawn(async move {
+                    if let Err(e) = db.set_chat_session_summary(&sid, &summary).await {
+                        tracing::debug!("chat: labelling {sid} failed: {e}");
+                    }
+                });
+            }
 
             // Without a subject the conversation is a general one; it is still
             // worth recording, so it can be found once a subject is inferred

--- a/src/app/chat_papers.rs
+++ b/src/app/chat_papers.rs
@@ -1,0 +1,148 @@
+//! Recovering which library papers a conversation touched.
+//!
+//! The agent names papers in two places: the `<rotero-context>` block the app
+//! prepends to every prompt (read in `agent::helpers`, before the block is
+//! stripped for display), and the results of the rotero MCP tools it calls.
+//! This module reads the second.
+
+/// Library paper ids appearing in an MCP tool result.
+///
+/// Tool results are pretty-printed JSON from the rotero MCP server, so a paper
+/// arrives either as a serialized `Paper` (carrying `id`) or as a mutation
+/// acknowledgement (carrying `paper_id`). Tags, collections, and notes also have
+/// uuid `id` fields, so a bare `id` is only believed when its object also has the
+/// `title` and `creators` that identify a `Paper` — which makes that struct's
+/// serialized shape load-bearing here, hence the round-trip test below.
+///
+/// Ids are returned in the order found, deduplicated. Callers must still filter
+/// against the library: the agent can name a paper that was never imported.
+pub fn paper_ids_from_tool_output(output: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        walk(&value, &mut ids);
+    }
+    ids
+}
+
+fn walk(value: &serde_json::Value, ids: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(id) = map.get("paper_id").and_then(|v| v.as_str()) {
+                push_unique(ids, id);
+            }
+            let looks_like_paper = map.contains_key("title") && map.contains_key("creators");
+            if looks_like_paper && let Some(id) = map.get("id").and_then(|v| v.as_str()) {
+                push_unique(ids, id);
+            }
+            for nested in map.values() {
+                walk(nested, ids);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                walk(item, ids);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_unique(ids: &mut Vec<String>, id: &str) {
+    if !id.is_empty() && !ids.iter().any(|seen| seen == id) {
+        ids.push(id.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rotero_models::Paper;
+
+    fn paper(id: &str, title: &str) -> Paper {
+        Paper {
+            id: Some(id.to_string()),
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn reads_ids_from_serialized_papers() {
+        let json = serde_json::to_string_pretty(&vec![
+            paper("11111111-1111-7111-8111-111111111111", "A"),
+            paper("22222222-2222-7222-8222-222222222222", "B"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            paper_ids_from_tool_output(&json),
+            vec![
+                "11111111-1111-7111-8111-111111111111",
+                "22222222-2222-7222-8222-222222222222"
+            ]
+        );
+    }
+
+    /// The discriminator depends on `Paper` serializing `title` and `creators`
+    /// under those names. Renaming either silently stops paper capture, so the
+    /// coupling is asserted rather than assumed.
+    #[test]
+    fn a_paper_serializes_the_fields_the_discriminator_relies_on() {
+        let json = serde_json::to_value(paper("id-1", "A")).unwrap();
+        let map = json.as_object().unwrap();
+        assert!(map.contains_key("title"));
+        assert!(map.contains_key("creators"));
+        assert!(map.contains_key("id"));
+    }
+
+    #[test]
+    fn reads_the_id_from_a_mutation_acknowledgement() {
+        let json = r#"{"success": true, "paper_id": "33333333-3333-7333-8333-333333333333"}"#;
+        assert_eq!(
+            paper_ids_from_tool_output(json),
+            vec!["33333333-3333-7333-8333-333333333333"]
+        );
+    }
+
+    /// Tags, collections, and notes have uuid ids too. Treating those as papers
+    /// would attach a conversation to whatever paper happened to share the id.
+    #[test]
+    fn ignores_ids_belonging_to_other_kinds_of_record() {
+        let tags = r#"[{"id": "44444444-4444-7444-8444-444444444444", "name": "diffusion"}]"#;
+        assert!(paper_ids_from_tool_output(tags).is_empty());
+
+        let collections = r#"[{"id": "55555555-5555-7555-8555-555555555555", "name": "Reading"}]"#;
+        assert!(paper_ids_from_tool_output(collections).is_empty());
+    }
+
+    #[test]
+    fn finds_papers_nested_inside_an_envelope() {
+        let json = format!(
+            r#"{{"results": [{{"paper": {}}}], "total": 1}}"#,
+            serde_json::to_string(&paper("66666666-6666-7666-8666-666666666666", "A")).unwrap()
+        );
+        assert_eq!(
+            paper_ids_from_tool_output(&json),
+            vec!["66666666-6666-7666-8666-666666666666"]
+        );
+    }
+
+    #[test]
+    fn a_repeated_paper_is_recorded_once() {
+        let json = serde_json::to_string(&vec![
+            paper("77777777-7777-7777-8777-777777777777", "A"),
+            paper("77777777-7777-7777-8777-777777777777", "A"),
+        ])
+        .unwrap();
+        assert_eq!(paper_ids_from_tool_output(&json).len(), 1);
+    }
+
+    /// Output can be truncated or be plain prose ("No paper found with ID ..."),
+    /// which must read as no papers rather than panicking.
+    #[test]
+    fn unparseable_output_yields_nothing() {
+        assert!(paper_ids_from_tool_output("").is_empty());
+        assert!(paper_ids_from_tool_output("No paper found with ID abc").is_empty());
+        assert!(paper_ids_from_tool_output(r#"[{"id": "trunc"#).is_empty());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 mod chat_handler;
+mod chat_papers;
 mod library_loader;
 // Poses the UI for documentation screenshots. Debug builds only.
 #[cfg(all(feature = "desktop", debug_assertions))]
@@ -17,7 +18,7 @@ use crate::ui::chat_panel::AgentChannel;
 use crate::ui::layout::Layout;
 use rotero_db::Database;
 
-use chat_handler::handle_chat_event;
+use chat_handler::{AgentEvents, ChatEventPump};
 use library_loader::LoadLibraryData;
 use sync_loop::SyncLoop;
 #[cfg(feature = "desktop")]
@@ -134,8 +135,7 @@ pub fn App() -> Element {
         crate::init::preflight::check_pdf_engine().await;
     });
 
-    let mut chat_state: Signal<ChatState> =
-        use_context_provider(|| Signal::new(ChatState::default()));
+    let _chat_state: Signal<ChatState> = use_context_provider(|| Signal::new(ChatState::default()));
     let (agent_tx, agent_rx) = use_hook(|| {
         let (req_tx, evt_rx) = crate::agent::spawn_agent_thread();
         (Signal::new(Some(req_tx)), Signal::new(Some(evt_rx)))
@@ -143,20 +143,10 @@ pub fn App() -> Element {
     let agent_channel: AgentChannel = use_context_provider(|| AgentChannel { inner: agent_tx });
     let _ = agent_channel;
 
-    use_future(move || {
-        let mut rx_sig = agent_rx;
-        async move {
-            let Some(mut rx) = rx_sig.write().take() else {
-                return;
-            };
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                while let Ok(event) = rx.try_recv() {
-                    handle_chat_event(&mut chat_state, event);
-                }
-            }
-        }
-    });
+    // The receiver is drained by `ChatEventPump`, which renders once the
+    // database is open: recording which papers a conversation touched needs a
+    // `Database`, and this scope is above the one that provides it.
+    use_context_provider(|| AgentEvents { inner: agent_rx });
 
     let db_gen = *db_generation.read();
     let db_resource = use_resource(move || async move {
@@ -208,6 +198,7 @@ pub fn App() -> Element {
                 document::Script { {GRAPH_JS} }
                 {longpress_script()}
                 LoadLibraryData {}
+                ChatEventPump {}
                 SyncLoop {}
                 {update_checker_element()}
                 {shot_driver_element()}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-mod chat_handler;
+pub mod chat_handler;
 mod chat_papers;
 mod library_loader;
 // Poses the UI for documentation screenshots. Debug builds only.

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -870,6 +870,39 @@ mod tests {
         }
     }
 
+    /// Shift-clicking papers in the graph gathers them into one selection,
+    /// which is what the "Chat About These" action takes as its subject.
+    #[test]
+    fn toggling_gathers_papers_and_toggling_again_drops_them() {
+        let mut state = LibraryState::default();
+
+        state.toggle_select("p1");
+        state.toggle_select("p2");
+        state.toggle_select("p3");
+        assert_eq!(state.selection_count(), 3);
+
+        // The same click again removes it, leaving the rest gathered.
+        state.toggle_select("p2");
+        assert_eq!(state.selection_count(), 2);
+        assert!(state.is_selected("p1"));
+        assert!(!state.is_selected("p2"));
+        assert!(state.is_selected("p3"));
+    }
+
+    /// A plain click is not an accumulating one: it replaces whatever was
+    /// gathered, so the graph's ordinary click still means "look at this paper".
+    #[test]
+    fn a_plain_click_replaces_a_gathered_selection() {
+        let mut state = LibraryState::default();
+        state.toggle_select("p1");
+        state.toggle_select("p2");
+
+        state.select_one("p3".to_string());
+
+        assert_eq!(state.selection_count(), 1);
+        assert!(state.is_selected("p3"));
+    }
+
     /// Search results are a snapshot taken when the query ran, and no mutation
     /// path updates it. Reading through to `papers` is what stops a favourite
     /// toggled during a search from appearing to revert.

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -9,6 +9,7 @@ use crate::agent::types::{
     AgentStatus, ChatMessage, ChatRequest, ChatRole, ChatState, MessageContent,
 };
 use crate::state::app_state::{LibraryState, LibraryView, PdfTabManager};
+use rotero_db::Database;
 use rotero_db::chat_sessions::ChatSubject;
 
 pub use panel::ChatPanel;
@@ -123,6 +124,7 @@ fn do_send(
     agent_channel: &AgentChannel,
     lib_state: &Signal<LibraryState>,
     tab_mgr: &Signal<PdfTabManager>,
+    db: &Database,
 ) {
     let input = chat_state.read().input_text.trim().to_string();
     if input.is_empty() {
@@ -146,10 +148,35 @@ fn do_send(
         }
     });
 
+    // A cheap label immediately, so a conversation is never nameless: the agent
+    // summary is better but costs a round trip, and may not arrive at all.
+    let first_message = chat_state
+        .read()
+        .messages
+        .iter()
+        .filter(|m| m.role == ChatRole::User)
+        .count()
+        == 1;
+    let session_id = chat_state.read().current_session_id.clone();
+    if first_message && let Some(session_id) = session_id.clone() {
+        let fallback: String = input.chars().take(120).collect();
+        let db = db.clone();
+        spawn(async move {
+            let _ = db.set_chat_session_summary(&session_id, &fallback).await;
+        });
+    }
+
     let paper_context = build_paper_context(&lib_state.read(), &tab_mgr.read());
 
     agent_channel.send(ChatRequest::SendMessage {
         prompt: input,
         paper_context,
     });
+
+    // Queued behind the message above: the agent thread handles requests in
+    // order, so asking first would summarize a conversation that hasn't
+    // happened yet.
+    if first_message && let Some(session_id) = session_id {
+        agent_channel.send(ChatRequest::SummarizeSession { session_id });
+    }
 }

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -169,119 +169,6 @@ pub(crate) fn current_subject(
     None
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::state::app_state::PdfTab;
-    use rotero_models::Paper;
-
-    fn paper(id: &str, title: &str) -> Paper {
-        Paper {
-            id: Some(id.to_string()),
-            title: title.to_string(),
-            ..Default::default()
-        }
-    }
-
-    fn library() -> LibraryState {
-        LibraryState {
-            papers: vec![paper("p1", "First"), paper("p2", "Second")],
-            ..Default::default()
-        }
-    }
-
-    /// An open PDF is what the user is reading, whatever the list has selected.
-    #[test]
-    fn an_open_pdf_wins_over_the_selection() {
-        let mut lib = library();
-        lib.select_one("p2".into());
-        let mut tabs = PdfTabManager::default();
-        let id = tabs.next_id();
-        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
-        tab.paper_id = Some("p1".into());
-        tabs.open_tab(tab);
-
-        assert_eq!(
-            current_subject(&lib, &tabs),
-            Some(ChatSubject::Paper("p1".into()))
-        );
-    }
-
-    /// Several papers selected is one conversation about the group, not one
-    /// conversation per paper.
-    #[test]
-    fn a_multi_selection_is_a_single_group_subject() {
-        let mut lib = library();
-        lib.select_one("p1".into());
-        lib.toggle_select("p2".into());
-
-        let subject = current_subject(&lib, &PdfTabManager::default()).unwrap();
-        assert!(matches!(subject, ChatSubject::Group(ref ids) if ids.len() == 2));
-    }
-
-    #[test]
-    fn a_browsed_collection_is_the_subject_when_nothing_is_selected() {
-        let mut lib = library();
-        lib.view = LibraryView::Collection("c1".into());
-
-        assert_eq!(
-            current_subject(&lib, &PdfTabManager::default()),
-            Some(ChatSubject::Collection("c1".into()))
-        );
-    }
-
-    /// Nothing open and nothing selected is a general chat, not a subject.
-    #[test]
-    fn browsing_the_whole_library_has_no_subject() {
-        assert_eq!(current_subject(&library(), &PdfTabManager::default()), None);
-    }
-
-    /// The agent only ever sees the paper that happens to be open unless the
-    /// group names them all.
-    #[test]
-    fn a_group_context_names_every_paper() {
-        let block = group_context(&library(), &["p1".to_string(), "p2".to_string()]);
-        assert!(block.contains("Paper ID: p1"));
-        assert!(block.contains("Paper ID: p2"));
-        assert!(block.contains("First"));
-        assert!(block.contains("Second"));
-    }
-
-    /// A large selection must not crowd out the conversation itself.
-    #[test]
-    fn a_large_group_is_capped_and_says_so() {
-        let mut lib = LibraryState::default();
-        let ids: Vec<String> = (0..GROUP_CONTEXT_LIMIT + 5)
-            .map(|i| {
-                let id = format!("p{i}");
-                lib.papers.push(paper(&id, &format!("Paper {i}")));
-                id
-            })
-            .collect();
-
-        let block = group_context(&lib, &ids);
-        assert_eq!(block.matches("Paper ID:").count(), GROUP_CONTEXT_LIMIT);
-        assert!(block.contains("and 5 more"));
-    }
-
-    /// A group conversation stays about its group even while one of its papers
-    /// is open, or the agent would silently narrow to that paper.
-    #[test]
-    fn the_subject_beats_the_open_pdf_when_building_context() {
-        let lib = library();
-        let mut tabs = PdfTabManager::default();
-        let id = tabs.next_id();
-        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
-        tab.paper_id = Some("p1".into());
-        tabs.open_tab(tab);
-
-        let group = ChatSubject::Group(vec!["p1".into(), "p2".into()]);
-        let context = build_paper_context(&lib, &tabs, Some(&group)).unwrap();
-        assert!(context.contains("Paper ID: p2"));
-        assert!(context.contains("asking about these papers together"));
-    }
-}
-
 fn do_send(
     chat_state: &mut Signal<ChatState>,
     agent_channel: &AgentChannel,
@@ -354,5 +241,118 @@ fn do_send(
     // happened yet.
     if first_message && let Some(session_id) = session_id {
         agent_channel.send(ChatRequest::SummarizeSession { session_id });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::app_state::PdfTab;
+    use rotero_models::Paper;
+
+    fn paper(id: &str, title: &str) -> Paper {
+        Paper {
+            id: Some(id.to_string()),
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn library() -> LibraryState {
+        LibraryState {
+            papers: vec![paper("p1", "First"), paper("p2", "Second")],
+            ..Default::default()
+        }
+    }
+
+    /// An open PDF is what the user is reading, whatever the list has selected.
+    #[test]
+    fn an_open_pdf_wins_over_the_selection() {
+        let mut lib = library();
+        lib.select_one("p2".into());
+        let mut tabs = PdfTabManager::default();
+        let id = tabs.next_id();
+        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
+        tab.paper_id = Some("p1".into());
+        tabs.open_tab(tab);
+
+        assert_eq!(
+            current_subject(&lib, &tabs),
+            Some(ChatSubject::Paper("p1".into()))
+        );
+    }
+
+    /// Several papers selected is one conversation about the group, not one
+    /// conversation per paper.
+    #[test]
+    fn a_multi_selection_is_a_single_group_subject() {
+        let mut lib = library();
+        lib.select_one("p1".into());
+        lib.toggle_select("p2");
+
+        let subject = current_subject(&lib, &PdfTabManager::default()).unwrap();
+        assert!(matches!(subject, ChatSubject::Group(ref ids) if ids.len() == 2));
+    }
+
+    #[test]
+    fn a_browsed_collection_is_the_subject_when_nothing_is_selected() {
+        let mut lib = library();
+        lib.view = LibraryView::Collection("c1".into());
+
+        assert_eq!(
+            current_subject(&lib, &PdfTabManager::default()),
+            Some(ChatSubject::Collection("c1".into()))
+        );
+    }
+
+    /// Nothing open and nothing selected is a general chat, not a subject.
+    #[test]
+    fn browsing_the_whole_library_has_no_subject() {
+        assert_eq!(current_subject(&library(), &PdfTabManager::default()), None);
+    }
+
+    /// The agent only ever sees the paper that happens to be open unless the
+    /// group names them all.
+    #[test]
+    fn a_group_context_names_every_paper() {
+        let block = group_context(&library(), &["p1".to_string(), "p2".to_string()]);
+        assert!(block.contains("Paper ID: p1"));
+        assert!(block.contains("Paper ID: p2"));
+        assert!(block.contains("First"));
+        assert!(block.contains("Second"));
+    }
+
+    /// A large selection must not crowd out the conversation itself.
+    #[test]
+    fn a_large_group_is_capped_and_says_so() {
+        let mut lib = LibraryState::default();
+        let ids: Vec<String> = (0..GROUP_CONTEXT_LIMIT + 5)
+            .map(|i| {
+                let id = format!("p{i}");
+                lib.papers.push(paper(&id, &format!("Paper {i}")));
+                id
+            })
+            .collect();
+
+        let block = group_context(&lib, &ids);
+        assert_eq!(block.matches("Paper ID:").count(), GROUP_CONTEXT_LIMIT);
+        assert!(block.contains("and 5 more"));
+    }
+
+    /// A group conversation stays about its group even while one of its papers
+    /// is open, or the agent would silently narrow to that paper.
+    #[test]
+    fn the_subject_beats_the_open_pdf_when_building_context() {
+        let lib = library();
+        let mut tabs = PdfTabManager::default();
+        let id = tabs.next_id();
+        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
+        tab.paper_id = Some("p1".into());
+        tabs.open_tab(tab);
+
+        let group = ChatSubject::Group(vec!["p1".into(), "p2".into()]);
+        let context = build_paper_context(&lib, &tabs, Some(&group)).unwrap();
+        assert!(context.contains("Paper ID: p2"));
+        assert!(context.contains("asking about these papers together"));
     }
 }

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -8,7 +8,8 @@ use dioxus::prelude::*;
 use crate::agent::types::{
     AgentStatus, ChatMessage, ChatRequest, ChatRole, ChatState, MessageContent,
 };
-use crate::state::app_state::{LibraryState, PdfTabManager};
+use crate::state::app_state::{LibraryState, LibraryView, PdfTabManager};
+use rotero_db::chat_sessions::ChatSubject;
 
 pub use panel::ChatPanel;
 pub use resize_handle::ResizeHandle;
@@ -77,6 +78,37 @@ fn build_paper_context(lib_state: &LibraryState, tab_mgr: &PdfTabManager) -> Opt
     ))
 }
 
+/// What a conversation started right now would be about.
+///
+/// An open PDF wins: it is the paper being read, whatever the library list
+/// happens to have selected. Several papers selected is one subject — a group —
+/// rather than several conversations, and a collection being browsed with
+/// nothing selected is the collection itself.
+pub(crate) fn current_subject(
+    lib_state: &LibraryState,
+    tab_mgr: &PdfTabManager,
+) -> Option<ChatSubject> {
+    if let Some(paper_id) = tab_mgr
+        .active_tab_id
+        .and_then(|tid| tab_mgr.tabs.iter().find(|t| t.id == tid))
+        .and_then(|t| t.paper_id.clone())
+    {
+        return Some(ChatSubject::Paper(paper_id));
+    }
+    if lib_state.selection_count() > 1 {
+        return Some(ChatSubject::Group(
+            lib_state.selected_paper_ids.iter().cloned().collect(),
+        ));
+    }
+    if let Some(paper_id) = lib_state.single_selected_id() {
+        return Some(ChatSubject::Paper(paper_id.clone()));
+    }
+    if let LibraryView::Collection(id) = &lib_state.view {
+        return Some(ChatSubject::Collection(id.clone()));
+    }
+    None
+}
+
 fn get_context_paper_title(lib_state: &LibraryState, tab_mgr: &PdfTabManager) -> Option<String> {
     let paper_id = get_active_paper_id(lib_state, tab_mgr)?;
     lib_state
@@ -97,6 +129,10 @@ fn do_send(
         return;
     }
 
+    // The subject is known now but the session id is not, so hold it until
+    // `SessionCreated` arrives with something to key it to.
+    let subject = current_subject(&lib_state.read(), &tab_mgr.read());
+
     chat_state.with_mut(|s| {
         s.messages.push(ChatMessage::new(
             ChatRole::User,
@@ -105,6 +141,9 @@ fn do_send(
         s.input_text.clear();
         s.status = AgentStatus::Streaming;
         s.show_command_picker = false;
+        if s.pending_subject.is_none() {
+            s.pending_subject = subject;
+        }
     });
 
     let paper_context = build_paper_context(&lib_state.read(), &tab_mgr.read());

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -15,7 +15,7 @@ use rotero_db::chat_sessions::ChatSubject;
 
 pub use panel::ChatPanel;
 pub use resize_handle::ResizeHandle;
-pub use resume::{SubjectFollower, subject_label, switch_to};
+pub use resume::{SubjectFollower, subject_label, subject_of_row, switch_to};
 pub use toggle::ChatToggleButton;
 
 #[derive(Clone, Copy)]

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -15,7 +15,7 @@ use rotero_db::chat_sessions::ChatSubject;
 
 pub use panel::ChatPanel;
 pub use resize_handle::ResizeHandle;
-pub use resume::{SubjectFollower, subject_label, subject_of_row, switch_to};
+pub use resume::{SubjectFollower, subject_label, subject_of_row, switch_to, unlabelled_title};
 pub use toggle::ChatToggleButton;
 
 #[derive(Clone, Copy)]
@@ -311,6 +311,18 @@ fn do_send(
         }
     });
 
+    // The conversation's own subject wins over what is on screen: a group chat
+    // stays about its group even while one of its papers is open.
+    let context_subject = chat_state
+        .read()
+        .current_subject
+        .clone()
+        .or_else(|| chat_state.read().pending_subject.clone());
+
+    // It has a message now, so it earns its row. Must precede the label write
+    // below, which needs a row to attach to.
+    crate::app::chat_handler::record_session(&chat_state, &db, context_subject.clone());
+
     // A cheap label immediately, so a conversation is never nameless: the agent
     // summary is better but costs a round trip, and may not arrive at all.
     let first_message = chat_state
@@ -329,13 +341,6 @@ fn do_send(
         });
     }
 
-    // The conversation's own subject wins over what is on screen: a group chat
-    // stays about its group even while one of its papers is open.
-    let context_subject = chat_state
-        .read()
-        .current_subject
-        .clone()
-        .or_else(|| chat_state.read().pending_subject.clone());
     let paper_context =
         build_paper_context(&lib_state.read(), &tab_mgr.read(), context_subject.as_ref());
 

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -1,6 +1,7 @@
 mod message;
 mod panel;
 mod resize_handle;
+mod resume;
 mod toggle;
 
 use dioxus::prelude::*;
@@ -14,6 +15,7 @@ use rotero_db::chat_sessions::ChatSubject;
 
 pub use panel::ChatPanel;
 pub use resize_handle::ResizeHandle;
+pub use resume::{SubjectFollower, subject_label, switch_to};
 pub use toggle::ChatToggleButton;
 
 #[derive(Clone, Copy)]
@@ -50,7 +52,64 @@ returns papers in the library's format), `find_pdf` (locates an open-access PDF 
 URL), `download_pdf`, and `add_paper` to import a result into my library. \
 Use `search_papers` to search papers already in my library.";
 
-fn build_paper_context(lib_state: &LibraryState, tab_mgr: &PdfTabManager) -> Option<String> {
+/// How many papers a group conversation names in its context block.
+///
+/// A large selection would otherwise crowd out the conversation itself; the
+/// agent can look the rest up by id through the MCP tools.
+const GROUP_CONTEXT_LIMIT: usize = 25;
+
+/// The papers of a multi-paper subject, as a compact list for the prompt.
+fn group_context(lib_state: &LibraryState, paper_ids: &[String]) -> String {
+    let listed: Vec<String> = paper_ids
+        .iter()
+        .filter_map(|id| {
+            lib_state
+                .papers
+                .iter()
+                .find(|p| p.id.as_deref() == Some(id.as_str()))
+        })
+        .take(GROUP_CONTEXT_LIMIT)
+        .map(|p| {
+            format!(
+                "- {} ({}) — {} [Paper ID: {}]",
+                p.title,
+                p.year
+                    .map(|y| y.to_string())
+                    .unwrap_or_else(|| "n.d.".into()),
+                p.formatted_authors(),
+                p.id.as_deref().unwrap_or(""),
+            )
+        })
+        .collect();
+    if listed.is_empty() {
+        return String::new();
+    }
+    let omitted = paper_ids.len().saturating_sub(listed.len());
+    let note = if omitted > 0 {
+        format!("\n(and {omitted} more — use the rotero MCP tools to list them)")
+    } else {
+        String::new()
+    };
+    format!(
+        "\nI'm asking about these papers together:\n{}{note}",
+        listed.join("\n")
+    )
+}
+
+fn build_paper_context(
+    lib_state: &LibraryState,
+    tab_mgr: &PdfTabManager,
+    subject: Option<&ChatSubject>,
+) -> Option<String> {
+    // A conversation about several papers has to name them all, or the agent
+    // only ever sees whichever one happens to be open.
+    if let Some(ChatSubject::Group(ids)) = subject {
+        let block = group_context(lib_state, ids);
+        return Some(format!(
+            "<rotero-context>\n{SEARCH_GUIDANCE}{block}\n</rotero-context>"
+        ));
+    }
+
     let paper_block = get_active_paper_id(lib_state, tab_mgr)
         .and_then(|paper_id| {
             lib_state
@@ -110,13 +169,117 @@ pub(crate) fn current_subject(
     None
 }
 
-fn get_context_paper_title(lib_state: &LibraryState, tab_mgr: &PdfTabManager) -> Option<String> {
-    let paper_id = get_active_paper_id(lib_state, tab_mgr)?;
-    lib_state
-        .papers
-        .iter()
-        .find(|p| p.id.as_deref() == Some(paper_id.as_str()))
-        .map(|p| p.title.clone())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::app_state::PdfTab;
+    use rotero_models::Paper;
+
+    fn paper(id: &str, title: &str) -> Paper {
+        Paper {
+            id: Some(id.to_string()),
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn library() -> LibraryState {
+        LibraryState {
+            papers: vec![paper("p1", "First"), paper("p2", "Second")],
+            ..Default::default()
+        }
+    }
+
+    /// An open PDF is what the user is reading, whatever the list has selected.
+    #[test]
+    fn an_open_pdf_wins_over_the_selection() {
+        let mut lib = library();
+        lib.select_one("p2".into());
+        let mut tabs = PdfTabManager::default();
+        let id = tabs.next_id();
+        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
+        tab.paper_id = Some("p1".into());
+        tabs.open_tab(tab);
+
+        assert_eq!(
+            current_subject(&lib, &tabs),
+            Some(ChatSubject::Paper("p1".into()))
+        );
+    }
+
+    /// Several papers selected is one conversation about the group, not one
+    /// conversation per paper.
+    #[test]
+    fn a_multi_selection_is_a_single_group_subject() {
+        let mut lib = library();
+        lib.select_one("p1".into());
+        lib.toggle_select("p2".into());
+
+        let subject = current_subject(&lib, &PdfTabManager::default()).unwrap();
+        assert!(matches!(subject, ChatSubject::Group(ref ids) if ids.len() == 2));
+    }
+
+    #[test]
+    fn a_browsed_collection_is_the_subject_when_nothing_is_selected() {
+        let mut lib = library();
+        lib.view = LibraryView::Collection("c1".into());
+
+        assert_eq!(
+            current_subject(&lib, &PdfTabManager::default()),
+            Some(ChatSubject::Collection("c1".into()))
+        );
+    }
+
+    /// Nothing open and nothing selected is a general chat, not a subject.
+    #[test]
+    fn browsing_the_whole_library_has_no_subject() {
+        assert_eq!(current_subject(&library(), &PdfTabManager::default()), None);
+    }
+
+    /// The agent only ever sees the paper that happens to be open unless the
+    /// group names them all.
+    #[test]
+    fn a_group_context_names_every_paper() {
+        let block = group_context(&library(), &["p1".to_string(), "p2".to_string()]);
+        assert!(block.contains("Paper ID: p1"));
+        assert!(block.contains("Paper ID: p2"));
+        assert!(block.contains("First"));
+        assert!(block.contains("Second"));
+    }
+
+    /// A large selection must not crowd out the conversation itself.
+    #[test]
+    fn a_large_group_is_capped_and_says_so() {
+        let mut lib = LibraryState::default();
+        let ids: Vec<String> = (0..GROUP_CONTEXT_LIMIT + 5)
+            .map(|i| {
+                let id = format!("p{i}");
+                lib.papers.push(paper(&id, &format!("Paper {i}")));
+                id
+            })
+            .collect();
+
+        let block = group_context(&lib, &ids);
+        assert_eq!(block.matches("Paper ID:").count(), GROUP_CONTEXT_LIMIT);
+        assert!(block.contains("and 5 more"));
+    }
+
+    /// A group conversation stays about its group even while one of its papers
+    /// is open, or the agent would silently narrow to that paper.
+    #[test]
+    fn the_subject_beats_the_open_pdf_when_building_context() {
+        let lib = library();
+        let mut tabs = PdfTabManager::default();
+        let id = tabs.next_id();
+        let mut tab = PdfTab::new(id, "/tmp/a.pdf".into(), "First".into(), 1.0, 4, 1.0);
+        tab.paper_id = Some("p1".into());
+        tabs.open_tab(tab);
+
+        let group = ChatSubject::Group(vec!["p1".into(), "p2".into()]);
+        let context = build_paper_context(&lib, &tabs, Some(&group)).unwrap();
+        assert!(context.contains("Paper ID: p2"));
+        assert!(context.contains("asking about these papers together"));
+    }
 }
 
 fn do_send(
@@ -166,7 +329,15 @@ fn do_send(
         });
     }
 
-    let paper_context = build_paper_context(&lib_state.read(), &tab_mgr.read());
+    // The conversation's own subject wins over what is on screen: a group chat
+    // stays about its group even while one of its papers is open.
+    let context_subject = chat_state
+        .read()
+        .current_subject
+        .clone()
+        .or_else(|| chat_state.read().pending_subject.clone());
+    let paper_context =
+        build_paper_context(&lib_state.read(), &tab_mgr.read(), context_subject.as_ref());
 
     agent_channel.send(ChatRequest::SendMessage {
         prompt: input,

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -321,7 +321,7 @@ fn do_send(
 
     // It has a message now, so it earns its row. Must precede the label write
     // below, which needs a row to attach to.
-    crate::app::chat_handler::record_session(&chat_state, &db, context_subject.clone());
+    crate::app::chat_handler::record_session(chat_state, db, context_subject.clone());
 
     // A cheap label immediately, so a conversation is never nameless: the agent
     // summary is better but costs a round trip, and may not arrive at all.

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -311,12 +311,8 @@ fn do_send(
         }
     });
 
-    // A cheap label, so a conversation is never nameless: the agent summary is
-    // better but costs a round trip, and may not arrive at all.
-    //
-    // A new conversation has no session id yet — the agent reports one only
-    // after this message is sent — so hold the label until it does rather than
-    // writing it against nothing.
+    // A cheap label immediately, so a conversation is never nameless: the agent
+    // summary is better but costs a round trip, and may not arrive at all.
     let first_message = chat_state
         .read()
         .messages
@@ -324,18 +320,13 @@ fn do_send(
         .filter(|m| m.role == ChatRole::User)
         .count()
         == 1;
-    if first_message {
+    let session_id = chat_state.read().current_session_id.clone();
+    if first_message && let Some(session_id) = session_id.clone() {
         let fallback: String = input.chars().take(120).collect();
-        let existing = chat_state.read().current_session_id.clone();
-        match existing {
-            Some(session_id) => {
-                let db = db.clone();
-                spawn(async move {
-                    let _ = db.set_chat_session_summary(&session_id, &fallback).await;
-                });
-            }
-            None => chat_state.with_mut(|s| s.pending_summary = Some(fallback)),
-        }
+        let db = db.clone();
+        spawn(async move {
+            let _ = db.set_chat_session_summary(&session_id, &fallback).await;
+        });
     }
 
     // The conversation's own subject wins over what is on screen: a group chat
@@ -356,11 +347,7 @@ fn do_send(
     // Queued behind the message above: the agent thread handles requests in
     // order, so asking first would summarize a conversation that hasn't
     // happened yet.
-    //
-    // Only for a conversation that already has a session id. A brand new one
-    // gets its label from `pending_summary` instead, since there is nothing to
-    // address the request to yet.
-    if first_message && let Some(session_id) = chat_state.read().current_session_id.clone() {
+    if first_message && let Some(session_id) = session_id {
         agent_channel.send(ChatRequest::SummarizeSession { session_id });
     }
 }

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -311,8 +311,12 @@ fn do_send(
         }
     });
 
-    // A cheap label immediately, so a conversation is never nameless: the agent
-    // summary is better but costs a round trip, and may not arrive at all.
+    // A cheap label, so a conversation is never nameless: the agent summary is
+    // better but costs a round trip, and may not arrive at all.
+    //
+    // A new conversation has no session id yet — the agent reports one only
+    // after this message is sent — so hold the label until it does rather than
+    // writing it against nothing.
     let first_message = chat_state
         .read()
         .messages
@@ -320,13 +324,18 @@ fn do_send(
         .filter(|m| m.role == ChatRole::User)
         .count()
         == 1;
-    let session_id = chat_state.read().current_session_id.clone();
-    if first_message && let Some(session_id) = session_id.clone() {
+    if first_message {
         let fallback: String = input.chars().take(120).collect();
-        let db = db.clone();
-        spawn(async move {
-            let _ = db.set_chat_session_summary(&session_id, &fallback).await;
-        });
+        let existing = chat_state.read().current_session_id.clone();
+        match existing {
+            Some(session_id) => {
+                let db = db.clone();
+                spawn(async move {
+                    let _ = db.set_chat_session_summary(&session_id, &fallback).await;
+                });
+            }
+            None => chat_state.with_mut(|s| s.pending_summary = Some(fallback)),
+        }
     }
 
     // The conversation's own subject wins over what is on screen: a group chat
@@ -347,7 +356,11 @@ fn do_send(
     // Queued behind the message above: the agent thread handles requests in
     // order, so asking first would summarize a conversation that hasn't
     // happened yet.
-    if first_message && let Some(session_id) = session_id {
+    //
+    // Only for a conversation that already has a session id. A brand new one
+    // gets its label from `pending_summary` instead, since there is nothing to
+    // address the request to yet.
+    if first_message && let Some(session_id) = chat_state.read().current_session_id.clone() {
         agent_channel.send(ChatRequest::SummarizeSession { session_id });
     }
 }

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -61,6 +61,36 @@ pub fn ChatPanel() -> Element {
     let show_sessions = chat_state.read().show_session_browser;
     let past_sessions = chat_state.read().past_sessions.clone();
 
+    // The agent titles a session after its first user message, which for these
+    // is a synthetic startup entry — so every one reads "/model". Our own record
+    // knows what each conversation is about, so label them from that and fall
+    // back to the agent's title only where we have no record.
+    let described = use_resource({
+        let db = db.clone();
+        let sessions = past_sessions.clone();
+        move || {
+            let db = db.clone();
+            let sessions = sessions.clone();
+            let lib = lib_state;
+            async move {
+                let rows = db.all_chat_sessions().await.unwrap_or_default();
+                let subjects = db.all_chat_session_subjects().await.unwrap_or_default();
+                sessions
+                    .iter()
+                    .map(|s| {
+                        let known = rows.iter().find(|r| r.session_id == s.session_id);
+                        let summary = known.and_then(|r| r.summary.clone());
+                        let about = known.and_then(|r| {
+                            super::subject_of_row(r, &subjects)
+                                .map(|subj| super::subject_label(&subj, &lib.read()))
+                        });
+                        (s.session_id.clone(), summary, about)
+                    })
+                    .collect::<Vec<_>>()
+            }
+        }
+    });
+
     let status_text = match &status {
         AgentStatus::Idle => "Ready",
         AgentStatus::Connecting => "Connecting...",
@@ -185,7 +215,21 @@ pub fn ChatPanel() -> Element {
                                 {
                                     let sid = session.session_id.clone();
                                     let session_cwd = session.cwd.clone();
-                                    let title = session.title.clone().unwrap_or_else(|| "Untitled".into());
+                                    let known = described
+                                        .read()
+                                        .as_ref()
+                                        .and_then(|rows: &Vec<(String, Option<String>, Option<String>)>| {
+                                            rows.iter().find(|(id, _, _)| *id == sid).cloned()
+                                        });
+                                    let (summary, about) = known
+                                        .map(|(_, s, a)| (s, a))
+                                        .unwrap_or((None, None));
+                                    // Only fall back to the agent's title where
+                                    // we have nothing: it is the transcript's
+                                    // first message, which is a startup command.
+                                    let title = summary
+                                        .or_else(|| session.title.clone())
+                                        .unwrap_or_else(|| "Untitled".into());
                                     let updated = session.updated_at.clone().unwrap_or_default();
                                     rsx! {
                                         button {
@@ -203,6 +247,9 @@ pub fn ChatPanel() -> Element {
                                                 });
                                             },
                                             div { class: "chat-session-item-title", "{title}" }
+                                            if let Some(about) = about {
+                                                div { class: "chat-session-item-about", "About: {about}" }
+                                            }
                                             div { class: "chat-session-item-date", "{updated}" }
                                         }
                                     }

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -61,10 +61,9 @@ pub fn ChatPanel() -> Element {
     let show_sessions = chat_state.read().show_session_browser;
     let past_sessions = chat_state.read().past_sessions.clone();
 
-    // The agent titles a session after its first user message, which for these
-    // is a synthetic startup entry — so every one reads "/model". Our own record
-    // knows what each conversation is about, so label them from that and fall
-    // back to the agent's title only where we have no record.
+    // Labelled from our own record rather than the agent's. The agent titles a
+    // session after its first user message, which for these is a synthetic
+    // startup entry — so every one of its titles reads "/model".
     let described = use_resource({
         let db = db.clone();
         let sessions = past_sessions.clone();
@@ -84,7 +83,17 @@ pub fn ChatPanel() -> Element {
                             super::subject_of_row(r, &subjects)
                                 .map(|subj| super::subject_label(&subj, &lib.read()))
                         });
-                        (s.session_id.clone(), summary, about)
+                        // Named by subject and time when nothing was stored:
+                        // the agent's own title is the transcript's first
+                        // message, which is a startup command.
+                        let title = summary.unwrap_or_else(|| {
+                            let when = known
+                                .map(|r| r.last_used_at.as_str())
+                                .or(s.updated_at.as_deref())
+                                .unwrap_or_default();
+                            super::unlabelled_title(about.as_deref(), when)
+                        });
+                        (s.session_id.clone(), title, about)
                     })
                     .collect::<Vec<_>>()
             }
@@ -218,18 +227,12 @@ pub fn ChatPanel() -> Element {
                                     let known = described
                                         .read()
                                         .as_ref()
-                                        .and_then(|rows: &Vec<(String, Option<String>, Option<String>)>| {
+                                        .and_then(|rows: &Vec<(String, String, Option<String>)>| {
                                             rows.iter().find(|(id, _, _)| *id == sid).cloned()
                                         });
-                                    let (summary, about) = known
-                                        .map(|(_, s, a)| (s, a))
-                                        .unwrap_or((None, None));
-                                    // Only fall back to the agent's title where
-                                    // we have nothing: it is the transcript's
-                                    // first message, which is a startup command.
-                                    let title = summary
-                                        .or_else(|| session.title.clone())
-                                        .unwrap_or_else(|| "Untitled".into());
+                                    let (title, about) = known
+                                        .map(|(_, t, a)| (t, a))
+                                        .unwrap_or_else(|| ("Untitled chat".into(), None));
                                     let updated = session.updated_at.clone().unwrap_or_default();
                                     rsx! {
                                         button {

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -5,7 +5,7 @@ use crate::state::app_state::{LibraryState, PdfTabManager};
 
 use super::message::ChatMessageBubble;
 use super::resize_handle::ResizeHandle;
-use super::{AgentChannel, do_send, get_context_paper_title};
+use super::{AgentChannel, do_send};
 
 #[component]
 pub fn ChatPanel() -> Element {
@@ -35,9 +35,19 @@ pub fn ChatPanel() -> Element {
             );
         });
     });
-    let paper_title = get_context_paper_title(&lib_state.read(), &tab_mgr.read());
-    let has_context = paper_title.is_some();
-    let paper_title_display = paper_title.unwrap_or_default();
+    // What the conversation is about, falling back to what the next message
+    // would be about before one has started.
+    let subject = chat_state
+        .read()
+        .current_subject
+        .clone()
+        .or_else(|| super::current_subject(&lib_state.read(), &tab_mgr.read()));
+    let subject_name = subject
+        .as_ref()
+        .map(|s| super::subject_label(s, &lib_state.read()));
+    let has_context = subject_name.is_some();
+    let paper_title_display = subject_name.unwrap_or_default();
+    let pending_switch = chat_state.read().pending_switch.clone();
     let active_provider = chat_state.read().active_provider_id.clone();
     let provider_name = crate::agent::types::AGENT_PROVIDERS
         .iter()
@@ -79,6 +89,36 @@ pub fn ChatPanel() -> Element {
     };
 
     rsx! {
+        super::SubjectFollower {}
+
+        if let Some(switch) = pending_switch {
+            {
+                let subject = switch.subject.clone();
+                let db_switch = db.clone();
+                rsx! {
+                    crate::ui::components::confirm_dialog::ConfirmDialog {
+                        title: "Switch conversation?".to_string(),
+                        message: format!(
+                            "Continue the conversation about {}? This chat stays saved.",
+                            switch.label,
+                        ),
+                        confirm_label: "Switch".to_string(),
+                        on_confirm: move |_| {
+                            super::switch_to(&mut chat_state, &agent_channel, &db_switch, subject.clone());
+                        },
+                        on_cancel: move |_| {
+                            chat_state.with_mut(|s| {
+                                // Remembered as declined so the follower does
+                                // not re-ask about the same subject on every
+                                // render; a different subject asks afresh.
+                                s.declined_subject = s.pending_switch.take().map(|p| p.subject);
+                            });
+                        },
+                    }
+                }
+            }
+        }
+
         div { class: "chat-panel",
             ResizeHandle { target: "chat" }
 
@@ -195,7 +235,7 @@ pub fn ChatPanel() -> Element {
 
             if has_context {
                 div { class: "chat-context-badge",
-                    span { class: "chat-context-text", "Discussing: {paper_title_display}" }
+                    span { class: "chat-context-text", "About: {paper_title_display}" }
                 }
             }
 

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -64,38 +64,18 @@ pub fn ChatPanel() -> Element {
     // Labelled from our own record rather than the agent's. The agent titles a
     // session after its first user message, which for these is a synthetic
     // startup entry — so every one of its titles reads "/model".
+    // Only the database read is deferred. Resolving a subject to its title reads
+    // the library, which is reactive state: doing that inside the future would
+    // not register as a dependency, so the labels would never refresh.
     let described = use_resource({
         let db = db.clone();
-        let sessions = past_sessions.clone();
         move || {
             let db = db.clone();
-            let sessions = sessions.clone();
-            let lib = lib_state;
             async move {
-                let rows = db.all_chat_sessions().await.unwrap_or_default();
-                let subjects = db.all_chat_session_subjects().await.unwrap_or_default();
-                sessions
-                    .iter()
-                    .map(|s| {
-                        let known = rows.iter().find(|r| r.session_id == s.session_id);
-                        let summary = known.and_then(|r| r.summary.clone());
-                        let about = known.and_then(|r| {
-                            super::subject_of_row(r, &subjects)
-                                .map(|subj| super::subject_label(&subj, &lib.read()))
-                        });
-                        // Named by subject and time when nothing was stored:
-                        // the agent's own title is the transcript's first
-                        // message, which is a startup command.
-                        let title = summary.unwrap_or_else(|| {
-                            let when = known
-                                .map(|r| r.last_used_at.as_str())
-                                .or(s.updated_at.as_deref())
-                                .unwrap_or_default();
-                            super::unlabelled_title(about.as_deref(), when)
-                        });
-                        (s.session_id.clone(), title, about)
-                    })
-                    .collect::<Vec<_>>()
+                (
+                    db.all_chat_sessions().await.unwrap_or_default(),
+                    db.all_chat_session_subjects().await.unwrap_or_default(),
+                )
             }
         }
     });
@@ -224,15 +204,37 @@ pub fn ChatPanel() -> Element {
                                 {
                                     let sid = session.session_id.clone();
                                     let session_cwd = session.cwd.clone();
-                                    let known = described
-                                        .read()
-                                        .as_ref()
-                                        .and_then(|rows: &Vec<(String, String, Option<String>)>| {
-                                            rows.iter().find(|(id, _, _)| *id == sid).cloned()
-                                        });
-                                    let (title, about) = known
-                                        .map(|(_, t, a)| (t, a))
-                                        .unwrap_or_else(|| ("Untitled chat".into(), None));
+                                    // Falls back to the agent's own title only
+                                    // until the record loads; ours is better
+                                    // but arrives a frame later.
+                                    let (title, about) = match &*described.read() {
+                                        Some((rows, subjects)) => {
+                                            let known =
+                                                rows.iter().find(|r| r.session_id == sid);
+                                            let about = known.and_then(|r| {
+                                                super::subject_of_row(r, subjects).map(|subj| {
+                                                    super::subject_label(&subj, &lib_state.read())
+                                                })
+                                            });
+                                            let title = known
+                                                .and_then(|r| r.summary.clone())
+                                                .unwrap_or_else(|| {
+                                                    let when = known
+                                                        .map(|r| r.last_used_at.as_str())
+                                                        .or(session.updated_at.as_deref())
+                                                        .unwrap_or_default();
+                                                    super::unlabelled_title(about.as_deref(), when)
+                                                });
+                                            (title, about)
+                                        }
+                                        None => (
+                                            session
+                                                .title
+                                                .clone()
+                                                .unwrap_or_else(|| "Loading…".into()),
+                                            None,
+                                        ),
+                                    };
                                     let updated = session.updated_at.clone().unwrap_or_default();
                                     rsx! {
                                         button {

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -60,6 +60,7 @@ pub fn ChatPanel() -> Element {
     let commands = chat_state.read().commands.clone();
     let show_sessions = chat_state.read().show_session_browser;
     let past_sessions = chat_state.read().past_sessions.clone();
+    let browse_all = chat_state.read().browse_all_sessions;
 
     // Labelled from our own record rather than the agent's. The agent titles a
     // session after its first user message, which for these is a synthetic
@@ -79,6 +80,25 @@ pub fn ChatPanel() -> Element {
             }
         }
     });
+
+    // The list is about what is open, so it shows that subject's conversations
+    // unless widened. Filtering waits for the record to load: without it every
+    // row would be hidden for the frame before it arrives.
+    let visible_sessions: Vec<_> = match (&*described.read(), browse_all, subject.as_ref()) {
+        (Some((rows, subjects)), false, Some(current)) => past_sessions
+            .iter()
+            .filter(|s| {
+                rows.iter()
+                    .find(|r| r.session_id == s.session_id)
+                    .and_then(|r| super::subject_of_row(r, subjects))
+                    .is_some_and(|subj| subj == *current)
+            })
+            .cloned()
+            .collect(),
+        _ => past_sessions.clone(),
+    };
+
+    let hidden_count = past_sessions.len().saturating_sub(visible_sessions.len());
 
     let status_text = match &status {
         AgentStatus::Idle => "Ready",
@@ -185,7 +205,25 @@ pub fn ChatPanel() -> Element {
             if show_sessions {
                 div { class: "chat-session-browser",
                     div { class: "chat-session-header",
-                        span { class: "chat-session-title", "Past chats" }
+                        span { class: "chat-session-title",
+                            if browse_all { "All chats" } else { "Chats about this" }
+                        }
+                        // Only worth offering when it would change the list.
+                        if hidden_count > 0 || browse_all {
+                            button {
+                                class: "chat-session-scope",
+                                onclick: move |_| {
+                                    chat_state.with_mut(|s| {
+                                        s.browse_all_sessions = !s.browse_all_sessions;
+                                    });
+                                },
+                                if browse_all {
+                                    "Only this"
+                                } else {
+                                    "Show all ({hidden_count})"
+                                }
+                            }
+                        }
                         button {
                             class: "chat-header-btn",
                             onclick: move |_| {
@@ -195,12 +233,18 @@ pub fn ChatPanel() -> Element {
                         }
                     }
                     div { class: "chat-session-list",
-                        if past_sessions.is_empty() {
+                        if visible_sessions.is_empty() {
                             div { class: "chat-empty",
-                                p { "No past chats found." }
+                                p {
+                                    if past_sessions.is_empty() {
+                                        "No past chats found."
+                                    } else {
+                                        "No past chats about this yet."
+                                    }
+                                }
                             }
                         } else {
-                            for session in past_sessions.iter() {
+                            for session in visible_sessions.iter() {
                                 {
                                     let sid = session.session_id.clone();
                                     let session_cwd = session.cwd.clone();

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -11,6 +11,8 @@ use super::{AgentChannel, do_send, get_context_paper_title};
 pub fn ChatPanel() -> Element {
     let mut chat_state = use_context::<Signal<ChatState>>();
     let agent_channel = use_context::<AgentChannel>();
+    let db = use_context::<rotero_db::Database>();
+    let db_key = db.clone();
     let lib_state = use_context::<Signal<LibraryState>>();
     let tab_mgr = use_context::<Signal<PdfTabManager>>();
 
@@ -262,7 +264,7 @@ pub fn ChatPanel() -> Element {
                     onkeydown: move |e| {
                         if e.key() == Key::Enter && !e.modifiers().shift() {
                             e.prevent_default();
-                            do_send(&mut chat_state, &agent_channel, &lib_state, &tab_mgr);
+                            do_send(&mut chat_state, &agent_channel, &lib_state, &tab_mgr, &db_key);
                         }
                         if e.key() == Key::Escape {
                             chat_state.with_mut(|s| s.show_command_picker = false);
@@ -277,7 +279,7 @@ pub fn ChatPanel() -> Element {
                             agent_channel.send(ChatRequest::Cancel);
                             chat_state.with_mut(|s| s.status = AgentStatus::Idle);
                         } else {
-                            do_send(&mut chat_state, &agent_channel, &lib_state, &tab_mgr);
+                            do_send(&mut chat_state, &agent_channel, &lib_state, &tab_mgr, &db);
                         }
                     },
                     if is_busy {

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -1,0 +1,125 @@
+//! Keeping the panel's conversation pointed at what the user is reading.
+//!
+//! A chat belongs to its subject, so opening a paper should continue that
+//! paper's conversation rather than whatever was last on screen. Switching is
+//! automatic only while the panel is idle: doing it mid-reply would abandon a
+//! conversation the user is still waiting on, so that case asks first.
+
+use dioxus::prelude::*;
+use rotero_db::Database;
+use rotero_db::chat_sessions::ChatSubject;
+
+use crate::agent::types::{AgentStatus, ChatRequest, ChatState, PendingSwitch};
+use crate::state::app_state::{LibraryState, PdfTabManager};
+
+use super::{AgentChannel, current_subject};
+
+/// How to name a subject in the UI.
+pub fn subject_label(subject: &ChatSubject, lib: &LibraryState) -> String {
+    match subject {
+        ChatSubject::Paper(id) => lib
+            .papers
+            .iter()
+            .find(|p| p.id.as_deref() == Some(id.as_str()))
+            .map(|p| p.title.clone())
+            .unwrap_or_else(|| "this paper".into()),
+        ChatSubject::Collection(id) => lib
+            .collections
+            .iter()
+            .find(|c| c.id.as_deref() == Some(id.as_str()))
+            .map(|c| c.name.clone())
+            .unwrap_or_else(|| "this collection".into()),
+        ChatSubject::Group(ids) => format!("{} papers", ids.len()),
+    }
+}
+
+/// Whether the panel can switch conversations without losing anything.
+fn is_idle(state: &ChatState) -> bool {
+    matches!(state.status, AgentStatus::Idle) && state.input_text.trim().is_empty()
+}
+
+/// Point the panel at `subject`, resuming its conversation or starting one.
+pub fn switch_to(
+    chat_state: &mut Signal<ChatState>,
+    agent_channel: &AgentChannel,
+    db: &Database,
+    subject: ChatSubject,
+) {
+    chat_state.with_mut(|s| {
+        s.messages.clear();
+        s.current_subject = Some(subject.clone());
+        s.pending_subject = Some(subject.clone());
+        s.pending_switch = None;
+        s.declined_subject = None;
+        s.current_session_id = None;
+    });
+
+    let db = db.clone();
+    let agent_channel = *agent_channel;
+    let mut chat_state = *chat_state;
+    spawn(async move {
+        match db.chat_session_for_subject(&subject).await {
+            Ok(Some(existing)) => {
+                chat_state.with_mut(|s| s.status = AgentStatus::Connecting);
+                agent_channel.send(ChatRequest::LoadSession {
+                    session_id: existing.session_id,
+                    cwd: String::new(),
+                });
+            }
+            // Nothing to resume: the next message starts this subject's
+            // conversation, and `pending_subject` already says what it is about.
+            Ok(None) => {}
+            Err(e) => tracing::debug!("chat: looking up a conversation failed: {e}"),
+        }
+    });
+}
+
+/// Follows the active subject, switching the panel's conversation to match.
+#[component]
+pub fn SubjectFollower() -> Element {
+    let mut chat_state = use_context::<Signal<ChatState>>();
+    let lib_state = use_context::<Signal<LibraryState>>();
+    let tab_mgr = use_context::<Signal<PdfTabManager>>();
+    let agent_channel = use_context::<AgentChannel>();
+    let db = use_context::<Database>();
+
+    use_effect(move || {
+        // Read outside any spawn so the effect actually subscribes to these.
+        let panel_open = chat_state.read().panel_open;
+        let subject = current_subject(&lib_state.read(), &tab_mgr.read());
+
+        if !panel_open {
+            return;
+        }
+        let Some(subject) = subject else {
+            // No subject — a general chat. Leave whatever is on screen alone
+            // rather than clearing it for nothing.
+            return;
+        };
+        if chat_state.read().current_subject.as_ref() == Some(&subject) {
+            return;
+        }
+        // Asking twice about the same subject would nag on every render, and a
+        // subject already declined should stay declined.
+        if chat_state
+            .read()
+            .pending_switch
+            .as_ref()
+            .is_some_and(|p| p.subject == subject)
+            || chat_state.read().declined_subject.as_ref() == Some(&subject)
+        {
+            return;
+        }
+
+        if is_idle(&chat_state.read()) {
+            switch_to(&mut chat_state, &agent_channel, &db, subject);
+        } else {
+            let label = subject_label(&subject, &lib_state.read());
+            chat_state.with_mut(|s| {
+                s.pending_switch = Some(PendingSwitch { subject, label });
+            });
+        }
+    });
+
+    rsx! {}
+}

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -246,4 +246,34 @@ mod tests {
     fn a_conversation_with_nothing_known_still_has_a_name() {
         assert_eq!(unlabelled_title(None, "not-a-date"), "Untitled chat");
     }
+
+    /// The list renders before the stored record loads. A row must not settle on
+    /// "Untitled chat" in that gap — the subject and time are there, one frame
+    /// later, and that is what the row should end up saying.
+    #[test]
+    fn a_row_with_a_record_is_named_from_it_not_from_the_empty_fallback() {
+        let lib = LibraryState {
+            papers: vec![rotero_models::Paper {
+                id: Some("p1".into()),
+                title: "Attention Is All You Need".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut r = row("paper", Some("p1"));
+        r.last_used_at = "2026-08-27T07:54:10Z".into();
+
+        // What the render path does once the resource has resolved.
+        let about = subject_of_row(&r, &[]).map(|s| subject_label(&s, &lib));
+        let title = r
+            .summary
+            .clone()
+            .unwrap_or_else(|| unlabelled_title(about.as_deref(), &r.last_used_at));
+
+        assert_ne!(title, "Untitled chat");
+        assert!(
+            title.starts_with("Attention Is All You Need — "),
+            "got {title}"
+        );
+    }
 }

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -33,6 +33,32 @@ pub fn subject_label(subject: &ChatSubject, lib: &LibraryState) -> String {
     }
 }
 
+/// When a conversation was last used, as a short human date.
+///
+/// Same-subject conversations are otherwise indistinguishable in a list, so the
+/// time is what tells them apart.
+pub fn short_time(rfc3339: &str) -> Option<String> {
+    chrono::DateTime::parse_from_rfc3339(rfc3339).ok().map(|t| {
+        t.with_timezone(&chrono::Local)
+            .format("%-d %b, %H:%M")
+            .to_string()
+    })
+}
+
+/// What to call a conversation with no stored summary.
+///
+/// The agent's own title is useless here — it names the transcript's first
+/// message, which is a startup command — so name the conversation by what it is
+/// about and when it was last used instead.
+pub fn unlabelled_title(about: Option<&str>, last_used_at: &str) -> String {
+    match (about, short_time(last_used_at)) {
+        (Some(a), Some(t)) => format!("{a} — {t}"),
+        (Some(a), None) => a.to_string(),
+        (None, Some(t)) => format!("Chat — {t}"),
+        (None, None) => "Untitled chat".into(),
+    }
+}
+
 /// Rebuild the subject a stored conversation is about.
 ///
 /// A group is identified by its members rather than by `subject_id`, which
@@ -192,5 +218,32 @@ mod tests {
     #[test]
     fn a_group_with_no_surviving_members_has_no_subject() {
         assert_eq!(subject_of_row(&row("group", Some("hash")), &[]), None);
+    }
+
+    /// The agent's own title is a startup command, so an unlabelled conversation
+    /// is named by what it is about instead.
+    #[test]
+    fn an_unlabelled_conversation_is_named_by_subject_and_time() {
+        let title = unlabelled_title(Some("Attention Is All You Need"), "2026-08-27T07:54:10Z");
+        assert!(
+            title.starts_with("Attention Is All You Need — "),
+            "got {title}"
+        );
+    }
+
+    /// Two conversations about the same paper are otherwise identical in a
+    /// list, so the time has to be what separates them.
+    #[test]
+    fn same_subject_conversations_differ_by_time() {
+        let a = unlabelled_title(Some("A paper"), "2026-08-27T07:54:10Z");
+        let b = unlabelled_title(Some("A paper"), "2026-08-27T09:31:00Z");
+        assert_ne!(a, b);
+    }
+
+    /// A conversation about nothing in particular, with an unreadable date,
+    /// still needs a name.
+    #[test]
+    fn a_conversation_with_nothing_known_still_has_a_name() {
+        assert_eq!(unlabelled_title(None, "not-a-date"), "Untitled chat");
     }
 }

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -7,7 +7,7 @@
 
 use dioxus::prelude::*;
 use rotero_db::Database;
-use rotero_db::chat_sessions::ChatSubject;
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
 
 use crate::agent::types::{AgentStatus, ChatRequest, ChatState, PendingSwitch};
 use crate::state::app_state::{LibraryState, PdfTabManager};
@@ -30,6 +30,27 @@ pub fn subject_label(subject: &ChatSubject, lib: &LibraryState) -> String {
             .map(|c| c.name.clone())
             .unwrap_or_else(|| "this collection".into()),
         ChatSubject::Group(ids) => format!("{} papers", ids.len()),
+    }
+}
+
+/// Rebuild the subject a stored conversation is about.
+///
+/// A group is identified by its members rather than by `subject_id`, which
+/// holds only their hash, so the members are looked up from the supplied
+/// `(session_id, paper_id)` pairs.
+pub fn subject_of_row(row: &ChatSessionRow, subjects: &[(String, String)]) -> Option<ChatSubject> {
+    match row.subject_kind.as_str() {
+        "paper" => row.subject_id.clone().map(ChatSubject::Paper),
+        "collection" => row.subject_id.clone().map(ChatSubject::Collection),
+        "group" => {
+            let members: Vec<String> = subjects
+                .iter()
+                .filter(|(sid, _)| *sid == row.session_id)
+                .map(|(_, pid)| pid.clone())
+                .collect();
+            (!members.is_empty()).then_some(ChatSubject::Group(members))
+        }
+        _ => None,
     }
 }
 
@@ -122,4 +143,54 @@ pub fn SubjectFollower() -> Element {
     });
 
     rsx! {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(kind: &str, subject_id: Option<&str>) -> ChatSessionRow {
+        ChatSessionRow {
+            session_id: "sess-1".into(),
+            provider_id: "claude".into(),
+            subject_kind: kind.into(),
+            subject_id: subject_id.map(String::from),
+            summary: None,
+            created_at: String::new(),
+            last_used_at: String::new(),
+            is_dead: false,
+        }
+    }
+
+    #[test]
+    fn a_paper_row_rebuilds_its_subject() {
+        assert_eq!(
+            subject_of_row(&row("paper", Some("p1")), &[]),
+            Some(ChatSubject::Paper("p1".into()))
+        );
+    }
+
+    /// A group's `subject_id` is a hash of its members, so the members
+    /// themselves have to come from the link rows.
+    #[test]
+    fn a_group_row_rebuilds_from_its_member_links() {
+        let links = vec![
+            ("sess-1".to_string(), "p1".to_string()),
+            ("sess-1".to_string(), "p2".to_string()),
+            ("sess-other".to_string(), "p3".to_string()),
+        ];
+
+        let subject = subject_of_row(&row("group", Some("hash")), &links).unwrap();
+
+        match subject {
+            ChatSubject::Group(ids) => assert_eq!(ids, vec!["p1", "p2"]),
+            other => panic!("expected a group, got {other:?}"),
+        }
+    }
+
+    /// Every member deleted leaves nothing to describe the conversation by.
+    #[test]
+    fn a_group_with_no_surviving_members_has_no_subject() {
+        assert_eq!(subject_of_row(&row("group", Some("hash")), &[]), None);
+    }
 }

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -247,6 +247,27 @@ mod tests {
         assert_eq!(unlabelled_title(None, "not-a-date"), "Untitled chat");
     }
 
+    /// The clock list shows the open subject's conversations, so a chat about a
+    /// different paper has to drop out — and a group is matched by its members,
+    /// not by the order they were selected in.
+    #[test]
+    fn only_the_current_subjects_conversations_match() {
+        let here = ChatSubject::Paper("p1".into());
+
+        let mine = row("paper", Some("p1"));
+        let theirs = row("paper", Some("p2"));
+
+        assert_eq!(subject_of_row(&mine, &[]).as_ref(), Some(&here));
+        assert_ne!(subject_of_row(&theirs, &[]).as_ref(), Some(&here));
+    }
+
+    /// A conversation about no paper at all belongs to no subject, so it is only
+    /// reachable once the list is widened.
+    #[test]
+    fn a_general_conversation_matches_no_subject() {
+        assert_eq!(subject_of_row(&row("general", None), &[]), None);
+    }
+
     /// The list renders before the stored record loads. A row must not settle on
     /// "Untitled chat" in that gap — the subject and time are there, one frame
     /// later, and that is what the row should end up saying.

--- a/src/ui/graph_view.rs
+++ b/src/ui/graph_view.rs
@@ -3,6 +3,7 @@ use rotero_graph::{GraphData, GraphFilter};
 
 use crate::state::app_state::{LibraryState, PdfTabManager};
 use rotero_db::Database;
+use rotero_db::chat_sessions::ChatSubject;
 
 #[derive(serde::Deserialize)]
 struct GraphEvent {
@@ -73,6 +74,9 @@ pub fn GraphView() -> Element {
     let mut tabs = use_context::<Signal<PdfTabManager>>();
     let config = use_context::<Signal<crate::sync::engine::SyncConfig>>();
     let dpr = use_context::<Signal<crate::app::DevicePixelRatio>>();
+
+    let mut chat_state = use_context::<Signal<crate::agent::types::ChatState>>();
+    let agent_channel = use_context::<crate::ui::chat_panel::AgentChannel>();
 
     let mut graph_json = use_signal(|| None::<String>);
     let mut edge_mode = use_signal(|| EdgeMode::Tags);
@@ -186,6 +190,30 @@ pub fn GraphView() -> Element {
         }
     });
 
+    // Mirror the selection into the canvas, which draws its own ring.
+    //
+    // The read is deliberately outside the spawn: a signal read inside an async
+    // future is not tracked, so the effect would run once and the ring would
+    // never follow the selection. The data-loading effect above carries the
+    // same note for the same reason.
+    use_effect(move || {
+        let mut selected: Vec<String> = lib_state
+            .read()
+            .selected_paper_ids
+            .iter()
+            .cloned()
+            .collect();
+        // Sorted so an unchanged selection serialises identically each time,
+        // rather than re-sending a reshuffled list on every render.
+        selected.sort();
+        spawn(async move {
+            let ids_json = serde_json::to_string(&selected).unwrap_or_default();
+            let _ = document::eval(&format!("window.__roteroGraph.setSelection({ids_json})"));
+        });
+    });
+
+    let db_bar = db.clone();
+
     // Long-lived eval that polls the JS event queue and sends results via dioxus.send()
     use_hook(move || {
         spawn(async move {
@@ -213,6 +241,11 @@ pub fn GraphView() -> Element {
                     "click" => {
                         lib_state.with_mut(|s| {
                             s.select_one(event.id.clone());
+                        });
+                    }
+                    "toggle" => {
+                        lib_state.with_mut(|s| {
+                            s.toggle_select(&event.id);
                         });
                     }
                     "open" | "dblclick" => {
@@ -247,6 +280,22 @@ pub fn GraphView() -> Element {
 
     let paper_count = lib_state.read().papers.len();
     let current_mode = edge_mode();
+    // Sorted because the selection is a HashSet: left in iteration order, the
+    // group's members would shuffle between renders. `ChatSubject::id` sorts
+    // for identity, but the papers it carries are shown in the order given.
+    let selected_ids: Vec<String> = {
+        let mut ids: Vec<String> = lib_state
+            .read()
+            .selected_paper_ids
+            .iter()
+            .cloned()
+            .collect();
+        ids.sort();
+        ids
+    };
+    // One paper is an ordinary click, not a gathered set: the bar is for acting
+    // on a selection the user built up, so it waits for a second paper.
+    let show_selection_bar = selected_ids.len() > 1;
 
     rsx! {
         div { class: "graph-view",
@@ -294,6 +343,43 @@ pub fn GraphView() -> Element {
                     canvas { id: "graph-canvas" }
                     div { id: "graph-tooltip", class: "graph-tooltip" }
                     div { id: "graph-hint", class: "graph-hint" }
+                    if show_selection_bar {
+                        div { class: "graph-selection-bar",
+                            span { class: "graph-selection-count",
+                                "{selected_ids.len()} papers selected"
+                            }
+                            button {
+                                class: "btn btn--primary graph-selection-chat",
+                                onclick: {
+                                    let db_chat = db_bar.clone();
+                                    let ids = selected_ids.clone();
+                                    move |_| {
+                                        // The gathered set is one subject: these
+                                        // papers discussed together, not one
+                                        // conversation apiece.
+                                        let subject = ChatSubject::Group(ids.clone());
+                                        chat_state.with_mut(|s| s.panel_open = true);
+                                        crate::ui::chat_panel::switch_to(
+                                            &mut chat_state,
+                                            &agent_channel,
+                                            &db_chat,
+                                            subject,
+                                        );
+                                    }
+                                },
+                                i { class: "bi bi-chat-dots" }
+                                " Chat About These"
+                            }
+                            button {
+                                class: "graph-selection-clear",
+                                title: "Clear selection",
+                                onclick: move |_| {
+                                    lib_state.with_mut(|s| s.clear_selection());
+                                },
+                                "\u{00d7}"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/ui/graph_view.rs
+++ b/src/ui/graph_view.rs
@@ -18,6 +18,7 @@ enum EdgeMode {
     Authors,
     Journals,
     Citations,
+    Conversations,
 }
 
 impl EdgeMode {
@@ -28,6 +29,7 @@ impl EdgeMode {
             Self::Authors => "Authors",
             Self::Journals => "Journals",
             Self::Citations => "Citations",
+            Self::Conversations => "Chats",
         }
     }
 
@@ -38,6 +40,7 @@ impl EdgeMode {
             show_author_edges: self == Self::Authors,
             show_journal_edges: self == Self::Journals,
             show_citation_edges: self == Self::Citations,
+            show_conversation_edges: self == Self::Conversations,
             ..Default::default()
         }
     }
@@ -49,16 +52,18 @@ impl EdgeMode {
             Self::Authors => "#f59e0b",
             Self::Journals => "#94a3b8",
             Self::Citations => "#e11d48",
+            Self::Conversations => "#a855f7",
         }
     }
 }
 
-const ALL_MODES: [EdgeMode; 5] = [
+const ALL_MODES: [EdgeMode; 6] = [
     EdgeMode::Tags,
     EdgeMode::Collections,
     EdgeMode::Authors,
     EdgeMode::Journals,
     EdgeMode::Citations,
+    EdgeMode::Conversations,
 ];
 
 #[component]
@@ -93,15 +98,19 @@ pub fn GraphView() -> Element {
             let tag_pairs = db.list_all_paper_tags().await.unwrap_or_default();
             let coll_pairs = db.list_all_paper_collections().await.unwrap_or_default();
             let citation_pairs = db.list_all_citations().await.unwrap_or_default();
+            let chat_pairs = db.all_chat_session_subjects().await.unwrap_or_default();
 
             let filter = mode.to_filter();
 
             let mut data = rotero_graph::build_and_simulate(
                 &papers,
                 &tags,
-                &tag_pairs,
-                &coll_pairs,
-                &citation_pairs,
+                rotero_graph::Relations {
+                    paper_tags: &tag_pairs,
+                    paper_collections: &coll_pairs,
+                    citations: &citation_pairs,
+                    conversations: &chat_pairs,
+                },
                 &filter,
                 500,
             );
@@ -112,6 +121,20 @@ pub fn GraphView() -> Element {
                     .find(|p| p.id.as_deref() == Some(node.id.as_str()))
                 {
                     node.label = crate::ui::truncate_text(&paper.title, 25);
+                }
+            }
+
+            // Papers with a conversation are drawn larger and in the mode's own
+            // colour, but only in this mode: elsewhere it would be noise on a
+            // graph that is about something else. This is what makes a chat
+            // about a single paper visible — it has no second paper to link to,
+            // so an edge alone would leave it looking untouched.
+            if mode == EdgeMode::Conversations {
+                for node in &mut data.nodes {
+                    if node.is_discussed {
+                        node.size = 6.0;
+                        node.color = EdgeMode::Conversations.edge_color().to_string();
+                    }
                 }
             }
 

--- a/src/ui/paper_detail/conversations.rs
+++ b/src/ui/paper_detail/conversations.rs
@@ -1,0 +1,114 @@
+//! The agent conversations a paper belongs to.
+//!
+//! Sits alongside notes because it is the same kind of thing: something you
+//! wrote about this paper and will want back. A conversation covering several
+//! papers appears under each of them, which is how a group chat is found again
+//! without remembering the exact selection that started it.
+
+use dioxus::prelude::*;
+use rotero_db::Database;
+use rotero_db::chat_sessions::{ChatSessionRow, ChatSubject};
+
+use crate::agent::types::ChatState;
+use crate::state::app_state::LibraryState;
+use crate::ui::chat_panel::{AgentChannel, switch_to};
+
+/// How a conversation's subject reads in this list.
+fn describe(row: &ChatSessionRow, paper_id: &str, lib: &LibraryState) -> String {
+    match row.subject_kind.as_str() {
+        "collection" => row
+            .subject_id
+            .as_ref()
+            .and_then(|id| {
+                lib.collections
+                    .iter()
+                    .find(|c| c.id.as_deref() == Some(id.as_str()))
+            })
+            .map(|c| format!("About the collection “{}”", c.name))
+            .unwrap_or_else(|| "About a collection".into()),
+        "group" => "Part of a conversation about several papers".into(),
+        // The common case needs no explanation: the conversation is about the
+        // paper whose panel this is.
+        _ if row.subject_id.as_deref() == Some(paper_id) => String::new(),
+        _ => "About another paper".into(),
+    }
+}
+
+/// The subject to resume a listed conversation under.
+fn subject_of(row: &ChatSessionRow, papers: Vec<String>) -> ChatSubject {
+    match (row.subject_kind.as_str(), row.subject_id.as_deref()) {
+        ("collection", Some(id)) => ChatSubject::Collection(id.to_string()),
+        ("group", _) => ChatSubject::Group(papers),
+        (_, Some(id)) => ChatSubject::Paper(id.to_string()),
+        _ => ChatSubject::Group(papers),
+    }
+}
+
+#[component]
+pub fn ConversationsSection(paper_id: String) -> Element {
+    let db = use_context::<Database>();
+    let lib_state = use_context::<Signal<LibraryState>>();
+    let mut chat_state = use_context::<Signal<ChatState>>();
+    let agent_channel = use_context::<AgentChannel>();
+    let mut sessions = use_signal(Vec::<(ChatSessionRow, Vec<String>)>::new);
+
+    {
+        let db = db.clone();
+        let pid = paper_id.clone();
+        use_effect(move || {
+            let db = db.clone();
+            let pid = pid.clone();
+            spawn(async move {
+                let rows = db.chat_sessions_for_paper(&pid).await.unwrap_or_default();
+                let mut with_papers = Vec::new();
+                for row in rows {
+                    let papers = db
+                        .chat_session_paper_ids(&row.session_id)
+                        .await
+                        .unwrap_or_default();
+                    with_papers.push((row, papers));
+                }
+                sessions.set(with_papers);
+            });
+        });
+    }
+
+    let listed = sessions.read();
+    if listed.is_empty() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "detail-chats-section",
+            label { class: "detail-label", "Conversations ({listed.len()})" }
+            for (row, papers) in listed.iter() {
+                {
+                    let summary = row.summary.clone().unwrap_or_default();
+                    let context = describe(row, &paper_id, &lib_state.read());
+                    let subject = subject_of(row, papers.clone());
+                    let db_open = db.clone();
+                    rsx! {
+                        button {
+                            key: "chat-{row.session_id}",
+                            class: "detail-chat-card",
+                            onclick: move |_| {
+                                chat_state.with_mut(|s| s.panel_open = true);
+                                switch_to(&mut chat_state, &agent_channel, &db_open, subject.clone());
+                            },
+                            if summary.is_empty() {
+                                div { class: "detail-chat-summary detail-chat-summary--empty",
+                                    "Untitled conversation"
+                                }
+                            } else {
+                                div { class: "detail-chat-summary", "{summary}" }
+                            }
+                            if !context.is_empty() {
+                                div { class: "detail-chat-context", "{context}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/paper_detail/conversations.rs
+++ b/src/ui/paper_detail/conversations.rs
@@ -50,15 +50,17 @@ pub fn ConversationsSection(paper_id: String) -> Element {
     let lib_state = use_context::<Signal<LibraryState>>();
     let mut chat_state = use_context::<Signal<ChatState>>();
     let agent_channel = use_context::<AgentChannel>();
-    let mut sessions = use_signal(Vec::<(ChatSessionRow, Vec<String>)>::new);
-
-    {
+    // Keyed on the prop rather than an effect over a captured copy: the panel
+    // reuses this component when the selection changes, so an effect that read
+    // `paper_id` once would keep listing the first paper's conversations under
+    // every paper selected after it.
+    let loaded = use_resource({
         let db = db.clone();
         let pid = paper_id.clone();
-        use_effect(move || {
+        move || {
             let db = db.clone();
             let pid = pid.clone();
-            spawn(async move {
+            async move {
                 let rows = db.chat_sessions_for_paper(&pid).await.unwrap_or_default();
                 let mut with_papers = Vec::new();
                 for row in rows {
@@ -68,12 +70,16 @@ pub fn ConversationsSection(paper_id: String) -> Element {
                         .unwrap_or_default();
                     with_papers.push((row, papers));
                 }
-                sessions.set(with_papers);
-            });
-        });
-    }
+                with_papers
+            }
+        }
+    });
 
-    let listed = sessions.read();
+    let listed = loaded.read();
+    let listed = match listed.as_ref() {
+        Some(rows) => rows,
+        None => return rsx! {},
+    };
     if listed.is_empty() {
         return rsx! {};
     }

--- a/src/ui/paper_detail/conversations.rs
+++ b/src/ui/paper_detail/conversations.rs
@@ -50,30 +50,29 @@ pub fn ConversationsSection(paper_id: String) -> Element {
     let lib_state = use_context::<Signal<LibraryState>>();
     let mut chat_state = use_context::<Signal<ChatState>>();
     let agent_channel = use_context::<AgentChannel>();
-    // Keyed on the prop rather than an effect over a captured copy: the panel
-    // reuses this component when the selection changes, so an effect that read
-    // `paper_id` once would keep listing the first paper's conversations under
-    // every paper selected after it.
-    let loaded = use_resource({
-        let db = db.clone();
-        let pid = paper_id.clone();
-        move || {
-            let db = db.clone();
-            let pid = pid.clone();
-            async move {
-                let rows = db.chat_sessions_for_paper(&pid).await.unwrap_or_default();
-                let mut with_papers = Vec::new();
-                for row in rows {
-                    let papers = db
-                        .chat_session_paper_ids(&row.session_id)
-                        .await
-                        .unwrap_or_default();
-                    with_papers.push((row, papers));
-                }
-                with_papers
+    // `use_reactive` is what ties this to the prop: the panel reuses this
+    // component when the selection changes, and a plain captured clone is not
+    // reactive, so the query would run once and every later paper would show
+    // the first one's conversations.
+    let db_load = db.clone();
+    let loaded = use_resource(use_reactive!(|paper_id| {
+        let db = db_load.clone();
+        async move {
+            let rows = db
+                .chat_sessions_for_paper(&paper_id)
+                .await
+                .unwrap_or_default();
+            let mut with_papers = Vec::new();
+            for row in rows {
+                let papers = db
+                    .chat_session_paper_ids(&row.session_id)
+                    .await
+                    .unwrap_or_default();
+                with_papers.push((row, papers));
             }
+            with_papers
         }
-    });
+    }));
 
     let listed = loaded.read();
     let listed = match listed.as_ref() {

--- a/src/ui/paper_detail/detail.rs
+++ b/src/ui/paper_detail/detail.rs
@@ -5,6 +5,7 @@ use crate::sync::engine::SyncConfig;
 use rotero_db::Database;
 
 use super::DetailShell;
+use super::conversations::ConversationsSection;
 use super::detail_fields::DetailFields;
 use super::fields::{CollectionsField, TagsField};
 use super::notes::NotesSection;
@@ -185,6 +186,7 @@ pub fn PaperDetail() -> Element {
                 crate::ui::citation_dialog::CitationDialog {}
             }
 
+            ConversationsSection { paper_id: paper_id.clone() }
             NotesSection { paper_id: paper_id.clone() }
 
             div { class: "detail-delete-section",

--- a/src/ui/paper_detail/detail.rs
+++ b/src/ui/paper_detail/detail.rs
@@ -186,6 +186,9 @@ pub fn PaperDetail() -> Element {
                 crate::ui::citation_dialog::CitationDialog {}
             }
 
+            // These reload on `paper_id` via `use_reactive!` internally: the
+            // panel reuses the instance across selections, and a key here is
+            // not allowed on a non-first node.
             ConversationsSection { paper_id: paper_id.clone() }
             NotesSection { paper_id: paper_id.clone() }
 

--- a/src/ui/paper_detail/mod.rs
+++ b/src/ui/paper_detail/mod.rs
@@ -1,3 +1,4 @@
+mod conversations;
 mod detail;
 mod detail_fields;
 mod fields;

--- a/src/ui/paper_detail/multi_select.rs
+++ b/src/ui/paper_detail/multi_select.rs
@@ -1,7 +1,9 @@
 use dioxus::prelude::*;
 
 use crate::state::app_state::LibraryState;
+use crate::ui::chat_panel::switch_to;
 use rotero_db::Database;
+use rotero_db::chat_sessions::ChatSubject;
 use rotero_models::Paper;
 
 use super::DetailShell;
@@ -10,6 +12,8 @@ use super::DetailShell;
 pub fn MultiSelectSummary() -> Element {
     let mut lib_state = use_context::<Signal<LibraryState>>();
     let db = use_context::<Database>();
+    let mut chat_state = use_context::<Signal<crate::agent::types::ChatState>>();
+    let agent_channel = use_context::<crate::ui::chat_panel::AgentChannel>();
 
     let state = lib_state.read();
     let count = state.selection_count();
@@ -83,6 +87,25 @@ pub fn MultiSelectSummary() -> Element {
                             },
                             i { class: "bi bi-book-fill" }
                             " Mark All Read"
+                        }
+                    }
+                }
+
+                {
+                    // The selection is the subject: several papers discussed
+                    // together are one conversation, not one per paper.
+                    let ids_chat = ids.clone();
+                    let db_chat = db.clone();
+                    rsx! {
+                        button {
+                            class: "btn btn--ghost multi-select-btn",
+                            onclick: move |_| {
+                                let subject = ChatSubject::Group(ids_chat.clone());
+                                chat_state.with_mut(|s| s.panel_open = true);
+                                switch_to(&mut chat_state, &agent_channel, &db_chat, subject);
+                            },
+                            i { class: "bi bi-chat-dots" }
+                            " Chat About These"
                         }
                     }
                 }

--- a/src/ui/paper_detail/notes.rs
+++ b/src/ui/paper_detail/notes.rs
@@ -5,26 +5,26 @@ use rotero_db::Database;
 #[component]
 pub fn NotesSection(paper_id: String) -> Element {
     let db = use_context::<Database>();
-    let mut notes = use_signal(Vec::new);
 
-    {
+    // Keyed on the prop rather than an effect over a captured copy: the panel
+    // reuses this component when the selection changes, so an effect that read
+    // `paper_id` once would keep showing the first paper's notes under every
+    // paper selected after it.
+    let notes = use_resource({
         let db = db.clone();
         let pid = paper_id.clone();
-        use_effect(move || {
+        move || {
             let db = db.clone();
             let pid = pid.clone();
-            spawn(async move {
-                if let Ok(paper_notes) = db.list_notes_for_paper(&pid).await {
-                    notes.set(paper_notes);
-                }
-            });
-        });
-    }
+            async move { db.list_notes_for_paper(&pid).await.unwrap_or_default() }
+        }
+    });
 
     let note_list = notes.read();
-    if note_list.is_empty() {
-        return rsx! {};
-    }
+    let note_list = match note_list.as_ref() {
+        Some(notes) if !notes.is_empty() => notes,
+        _ => return rsx! {},
+    };
 
     rsx! {
         div { class: "detail-notes-section",
@@ -40,7 +40,6 @@ pub fn NotesSection(paper_id: String) -> Element {
                     let body_preview = rotero_models::truncate_chars(&note.body, 117);
                     let body_html = crate::ui::markdown::md_to_html(&body_preview);
                     let db_del = db.clone();
-                    let pid = paper_id.clone();
                     rsx! {
                         div { key: "note-{note_id}", class: "detail-note-card",
                             div { class: "detail-note-title", "{title}" }
@@ -53,12 +52,12 @@ pub fn NotesSection(paper_id: String) -> Element {
                                 onclick: move |_| {
                                     let db = db_del.clone();
                                     let nid = note_id.clone();
-                                    let pid = pid.clone();
+                                    let mut notes = notes;
                                     spawn(async move {
                                         let _ = db.delete_note(&nid).await;
-                                        if let Ok(paper_notes) = db.list_notes_for_paper(&pid).await {
-                                            notes.set(paper_notes);
-                                        }
+                                        // Re-reads through the same query the
+                                        // list was built from.
+                                        notes.restart();
                                     });
                                 },
                                 "Delete"

--- a/src/ui/paper_detail/notes.rs
+++ b/src/ui/paper_detail/notes.rs
@@ -6,19 +6,15 @@ use rotero_db::Database;
 pub fn NotesSection(paper_id: String) -> Element {
     let db = use_context::<Database>();
 
-    // Keyed on the prop rather than an effect over a captured copy: the panel
-    // reuses this component when the selection changes, so an effect that read
-    // `paper_id` once would keep showing the first paper's notes under every
-    // paper selected after it.
-    let notes = use_resource({
-        let db = db.clone();
-        let pid = paper_id.clone();
-        move || {
-            let db = db.clone();
-            let pid = pid.clone();
-            async move { db.list_notes_for_paper(&pid).await.unwrap_or_default() }
-        }
-    });
+    // `use_reactive` is what ties this to the prop: the panel reuses this
+    // component when the selection changes, and a plain captured clone is not
+    // reactive, so the query would run once and every later paper would show
+    // the first one's notes.
+    let db_load = db.clone();
+    let notes = use_resource(use_reactive!(|paper_id| {
+        let db = db_load.clone();
+        async move { db.list_notes_for_paper(&paper_id).await.unwrap_or_default() }
+    }));
 
     let note_list = notes.read();
     let note_list = match note_list.as_ref() {


### PR DESCRIPTION
A conversation belongs to what it is about. Opening a paper continues that
paper's chat; selecting several starts one about the group. Previously a chat
was reachable only through a clock icon listing every past session — a
retrieval affordance for something that is not retrieved.

## What this adds

- **Subject-keyed conversations.** A paper, a collection, or an ad-hoc group of
  papers each own their conversation. A group is identified by its members
  rather than a name, so re-selecting the same papers in any order resumes the
  same chat.
- **Auto-resume.** Opening a paper switches the panel to its conversation, but
  only while the panel is idle — doing it mid-reply would abandon a chat still
  streaming, so that asks first, and a declined subject is not re-offered.
- **Group chats.** A "Chat About These" button in the multi-select panel. The
  context block names every paper in the group, capped at 25 so a large
  selection cannot crowd out the conversation itself.
- **Conversations in the detail panel.** Beside a paper's notes, listing the
  chats it is the subject of.
- **Labelled history.** The past-chats list shows our own summary and subject
  instead of the agent's title.

## Notes for review

The last five commits are bug fixes found by running the app against a real
library rather than tests, and each one is worth a look:

- **`is_subject`** — every paper the agent read while answering was linked as
  though the conversation were about it, so one chat appeared on the detail
  panel of every search result. Subject papers are now distinguished from
  incidental reads, which stay on record but do not claim the conversation.
- **The label write** — the row is created when the agent announces the
  session and the label when the user sends a message, both spawned
  independently. The label was an `UPDATE`, so whenever it won the race it
  updated nothing. It is an upsert now.
- **The v16 migration** — the `ALTER` sat inside the `< 15` block, so a library
  already at 15 skipped it while `SCHEMA_VERSION` still stamped to 16. Such a
  library reports itself up to date with the column missing, and no version
  guard can identify it, so the `ALTER` runs unconditionally.
- **Row-on-connect** — the agent opens a session when it connects, and the row
  was filed there, so every launch left a conversation behind whether or not
  anything was said. A real library had eight rows for three conversations.
  Recording moved to the send path; v17 clears the existing shells.
- **The list labels** — resolved inside the resource's future, where neither
  the library (reactive state) nor the session list registers as a dependency,
  so every row read "Untitled chat". Only the database read is deferred now.

Schema v15→v17. Chat tables are local-only and absent from `SYNCED_TABLES`:
session ids are minted by the agent binary on this machine, so a synced row
would name a session that resolves to nothing elsewhere.

## Testing

356 workspace tests pass; clippy clean. New coverage includes the subject
round-trip and group identity, the two link-classification bugs, the
write-before-row race, and one migration test per version — including a
library stamped 16 without its column, which is the state a real library was
found in.

The migrations were also run against a copy of a real library: the stranded
column was added, and eight session rows collapsed to five with all three
transcript-bearing conversations intact.

## Not included

Sessions as graph nodes (the original Phase 3) — it needs accumulated data to
show anything, so it is worth using this first. The graph multi-select
(shift-click to accumulate) is also left out: it is the one piece of genuinely
new UI here and is independent of everything above.
