### PR TITLE
Make a table's sync status a decision, not an omission

### DIFF
--- a/crates/rotero-db/tests/sync_schema_test.rs
+++ b/crates/rotero-db/tests/sync_schema_test.rs
@@ -1,10 +1,14 @@
 //! `SYNCED_TABLES` must describe the database it claims to describe.
 //!
 //! The manifest decides what a snapshot carries and what the merge applies. A
-//! column in the database but missing from the manifest is silently never
-//! synced — the row saves locally, looks right in the UI, and never reaches the
-//! other device. That is the failure mode this whole rewrite exists to remove,
-//! so it is checked mechanically rather than by review.
+//! column — or a whole table — in the database but missing from the manifest is
+//! silently never synced: the row saves locally, looks right in the UI, and
+//! never reaches the other device. That is the failure mode this whole rewrite
+//! exists to remove, so it is checked mechanically rather than by review.
+//!
+//! Both directions are checked, and in both the allowlist is the point: staying
+//! local is a legitimate choice, but it has to be written down rather than
+//! arrived at by forgetting.
 
 mod common;
 
@@ -86,6 +90,73 @@ async fn every_table_column_is_accounted_for() {
                 table.name
             );
         }
+    }
+}
+
+/// Every table in the database must either sync or say why it does not.
+///
+/// The column checks above only ever look at tables the manifest already names,
+/// so a whole table added to the SQL and forgotten is invisible to them — the
+/// one direction that was still uncovered. It is also the easier mistake: a new
+/// feature adds its table, the app works on that device, and nothing says the
+/// data never leaves it.
+///
+/// Being local-only is a legitimate answer, and often the right one. The point
+/// is that it has to be *chosen* — an entry here — rather than reached by
+/// forgetting the manifest exists.
+#[tokio::test]
+async fn every_table_either_syncs_or_is_declared_local() {
+    /// Tables that exist but deliberately do not sync, and why.
+    const LOCAL_ONLY_TABLES: &[(&str, &str)] = &[
+        // Records what THIS install has done, not shared library state.
+        ("app_flags", "per-install task bookkeeping"),
+        // This device's sync identity. Replicating it would give two devices
+        // the same name, and every clock comparison keys on that name.
+        ("crr_site_id", "this device's own identity"),
+        // Where the local schema has got to. A peer mid-migration would
+        // otherwise be told it is already done.
+        ("schema_version", "local migration state"),
+        // Session ids are minted by the agent binary on this machine, so a
+        // synced row would name a session that resolves to nothing elsewhere.
+        // These carry none of the bookkeeping columns and have no `_live` view.
+        ("chat_sessions", "agent session ids are machine-local"),
+        ("chat_session_papers", "child of chat_sessions"),
+    ];
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+
+    let mut rows = db
+        .conn()
+        .query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+            (),
+        )
+        .await
+        .unwrap();
+
+    while let Some(row) = rows.next().await.unwrap() {
+        let Some(name) = row.get_value(0).ok().and_then(|v| v.as_text().cloned()) else {
+            continue;
+        };
+        // SQLite's own bookkeeping and turso's FTS shadow tables are not ours
+        // to classify: they are created by the engine, and their names are an
+        // implementation detail rather than a decision anyone makes.
+        if name.starts_with("sqlite_") || name.starts_with("__turso_internal_") {
+            continue;
+        }
+        let synced = SYNCED_TABLES.iter().any(|t| t.name == name);
+        let local = LOCAL_ONLY_TABLES.iter().any(|(t, _)| *t == name);
+        assert!(
+            synced || local,
+            "table `{name}` is in the database but neither in SYNCED_TABLES nor \
+             LOCAL_ONLY_TABLES. Add it to the manifest so it syncs, or to \
+             LOCAL_ONLY_TABLES with the reason it must not."
+        );
+        assert!(
+            !(synced && local),
+            "table `{name}` is both in SYNCED_TABLES and LOCAL_ONLY_TABLES"
+        );
     }
 }
 


### PR DESCRIPTION
The schema guards only ever looked at tables `SYNCED_TABLES` already names — one checks every manifest column exists, the other that every column of those tables is accounted for. A whole table added to the SQL and forgotten was invisible to both.

That is the easier mistake to make: the feature works fine on the device that created it, and nothing says the data never leaves.

## What this adds

Every table in `sqlite_master` must appear in `SYNCED_TABLES` or in a new `LOCAL_ONLY_TABLES` allowlist with a reason. The five current entries all have real ones:

| table | why it stays local |
|---|---|
| `app_flags` | records what *this install* has done |
| `crr_site_id` | the device's own sync identity — replicating it would give two devices the same name |
| `schema_version` | local migration state |
| `chat_sessions` | agent session ids are minted on this machine, so a synced row names a session that resolves to nothing elsewhere |
| `chat_session_papers` | child of `chat_sessions` |

SQLite's own tables and turso's FTS shadow tables are skipped by prefix — they are created by the engine, so their names are an implementation detail rather than anyone's decision.

## Verification

Mutation-checked: adding a `reading_sessions` table without touching the manifest fails with

```
table `reading_sessions` is in the database but neither in SYNCED_TABLES nor
LOCAL_ONLY_TABLES. Add it to the manifest so it syncs, or to LOCAL_ONLY_TABLES
with the reason it must not.
```

152/152, clippy and fmt clean.

## Context

Came out of reviewing #24 against the sync work in #23. The chat tables are correctly local-only and needed no changes — they are absent from the manifest, carry none of the `updated_at`/`updated_by`/`deleted` columns, have no `_live` view, never call `touch`, and their read path joins `papers_live` so a tombstoned paper drops out. This PR only makes that choice checkable for the next table someone adds.