### PR TITLE
Move schema DDL into .sql files

### DIFF
--- a/crates/rotero-db/src/schema/sql/fts_index.sql
+++ b/crates/rotero-db/src/schema/sql/fts_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_papers_fts ON papers
+    USING fts (title, authors, abstract_text, journal, fulltext)
+    WITH (weights = 'title=3.0,authors=2.0,abstract_text=1.5,journal=1.0,fulltext=1.0')

--- a/crates/rotero-db/src/schema/sql/live_views.sql
+++ b/crates/rotero-db/src/schema/sql/live_views.sql
@@ -1,0 +1,9 @@
+CREATE VIEW IF NOT EXISTS papers_live AS SELECT * FROM papers WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS collections_live AS SELECT * FROM collections WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS tags_live AS SELECT * FROM tags WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS annotations_live AS SELECT * FROM annotations WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS notes_live AS SELECT * FROM notes WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS saved_searches_live AS SELECT * FROM saved_searches WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS paper_collections_live AS SELECT * FROM paper_collections WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS paper_tags_live AS SELECT * FROM paper_tags WHERE deleted = 0;
+CREATE VIEW IF NOT EXISTS paper_citations_live AS SELECT * FROM paper_citations WHERE deleted = 0;

--- a/crates/rotero-db/src/schema/sql/tables.sql
+++ b/crates/rotero-db/src/schema/sql/tables.sql
@@ -1,0 +1,164 @@
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS papers (
+    id            TEXT PRIMARY KEY,
+    title         TEXT NOT NULL DEFAULT '',
+    authors       TEXT NOT NULL DEFAULT '[]',
+    year          INTEGER,
+    doi           TEXT,
+    abstract_text TEXT,
+    journal       TEXT,
+    volume        TEXT,
+    issue         TEXT,
+    pages         TEXT,
+    publisher     TEXT,
+    url           TEXT,
+    pdf_path      TEXT,
+    date_added    TEXT NOT NULL,
+    date_modified TEXT NOT NULL,
+    is_favorite   INTEGER NOT NULL DEFAULT 0,
+    is_read       INTEGER NOT NULL DEFAULT 0,
+    extra_meta    TEXT,
+    fulltext      TEXT,
+    citation_count INTEGER,
+    citation_key  TEXT,
+    pdf_url       TEXT,
+    item_type     TEXT NOT NULL DEFAULT 'journalArticle',
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS collections (
+    id        TEXT PRIMARY KEY,
+    name      TEXT NOT NULL,
+    parent_id TEXT REFERENCES collections(id) ON DELETE CASCADE,
+    position  INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS paper_collections (
+    paper_id      TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (paper_id, collection_id)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id    TEXT PRIMARY KEY,
+    name  TEXT NOT NULL UNIQUE,
+    color TEXT,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS paper_tags (
+    paper_id TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    tag_id   TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (paper_id, tag_id)
+);
+
+-- This device's sync identity, created here so a fresh database has one before
+-- anything tries to stamp a row with it. It used to be created only by the
+-- migrations that needed it, which left a database starting at the current
+-- version without the table at all.
+CREATE TABLE IF NOT EXISTS crr_site_id (
+    site_id BLOB PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS paper_citations (
+    citing_paper_id TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    cited_paper_id  TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (citing_paper_id, cited_paper_id)
+);
+
+-- Bookkeeping for one-time app tasks (e.g. the initial citation scan), keyed by
+-- a task name. Local-only: not replicated, since it records what THIS install has
+-- done, not shared library state.
+CREATE TABLE IF NOT EXISTS app_flags (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+
+-- The agent conversation for one subject: a paper, a collection, or an ad-hoc
+-- set of papers. Local-only for the same reason as app_flags, and a stronger
+-- one: session ids are minted by the agent binary on THIS machine, so a synced
+-- row would name a session that resolves to nothing on the other device. Hence
+-- no updated_at/updated_by/deleted columns and no _live view.
+--
+-- subject_id is deliberately not a foreign key: deleting a paper should leave
+-- the conversation on record rather than erase it.
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    session_id   TEXT PRIMARY KEY,
+    provider_id  TEXT NOT NULL DEFAULT '',
+    subject_kind TEXT NOT NULL,
+    subject_id   TEXT,
+    summary      TEXT,
+    created_at   TEXT NOT NULL,
+    last_used_at TEXT NOT NULL,
+    is_dead      INTEGER NOT NULL DEFAULT 0
+);
+
+-- Papers a conversation touched. `is_subject` marks the ones it is actually
+-- about — the single anchor for a 'paper' subject, the whole member set for
+-- 'collection' and 'group'. The rest are papers the agent read while answering,
+-- recorded so the conversation can be traced, but not claiming to be about them.
+CREATE TABLE IF NOT EXISTS chat_session_papers (
+    session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+    paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    is_subject INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (session_id, paper_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_subject ON chat_sessions (subject_kind, subject_id);
+CREATE INDEX IF NOT EXISTS idx_chat_session_papers_paper ON chat_session_papers (paper_id);
+
+CREATE TABLE IF NOT EXISTS annotations (
+    id          TEXT PRIMARY KEY,
+    paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    page        INTEGER NOT NULL,
+    ann_type    TEXT NOT NULL,
+    color       TEXT NOT NULL DEFAULT '#ffff00',
+    content     TEXT,
+    geometry    TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    modified_at TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS notes (
+    id          TEXT PRIMARY KEY,
+    paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    title       TEXT NOT NULL DEFAULT '',
+    body        TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    modified_at TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS saved_searches (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    query      TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    updated_by TEXT NOT NULL DEFAULT '',
+    deleted    INTEGER NOT NULL DEFAULT 0
+);

--- a/crates/rotero-db/src/schema/tables.rs
+++ b/crates/rotero-db/src/schema/tables.rs
@@ -1,174 +1,12 @@
 //! CREATE TABLE statements for all core tables.
+//!
+//! The DDL itself lives in `sql/*.sql` so an editor highlights it as SQL;
+//! `include_str!` pulls each file in at compile time, so these stay ordinary
+//! `&'static str` constants with no runtime loading and no missing-file mode.
 
 /// SQL batch that creates all core tables if they do not already exist.
-pub const CREATE_TABLES: &str = "
-CREATE TABLE IF NOT EXISTS schema_version (
-    version INTEGER NOT NULL
-);
+pub const CREATE_TABLES: &str = include_str!("sql/tables.sql");
 
-CREATE TABLE IF NOT EXISTS papers (
-    id            TEXT PRIMARY KEY,
-    title         TEXT NOT NULL DEFAULT '',
-    authors       TEXT NOT NULL DEFAULT '[]',
-    year          INTEGER,
-    doi           TEXT,
-    abstract_text TEXT,
-    journal       TEXT,
-    volume        TEXT,
-    issue         TEXT,
-    pages         TEXT,
-    publisher     TEXT,
-    url           TEXT,
-    pdf_path      TEXT,
-    date_added    TEXT NOT NULL,
-    date_modified TEXT NOT NULL,
-    is_favorite   INTEGER NOT NULL DEFAULT 0,
-    is_read       INTEGER NOT NULL DEFAULT 0,
-    extra_meta    TEXT,
-    fulltext      TEXT,
-    citation_count INTEGER,
-    citation_key  TEXT,
-    pdf_url       TEXT,
-    item_type     TEXT NOT NULL DEFAULT 'journalArticle',
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS collections (
-    id        TEXT PRIMARY KEY,
-    name      TEXT NOT NULL,
-    parent_id TEXT REFERENCES collections(id) ON DELETE CASCADE,
-    position  INTEGER NOT NULL DEFAULT 0,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS paper_collections (
-    paper_id      TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (paper_id, collection_id)
-);
-
-CREATE TABLE IF NOT EXISTS tags (
-    id    TEXT PRIMARY KEY,
-    name  TEXT NOT NULL UNIQUE,
-    color TEXT,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS paper_tags (
-    paper_id TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    tag_id   TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (paper_id, tag_id)
-);
-
--- This device's sync identity, created here so a fresh database has one before
--- anything tries to stamp a row with it. It used to be created only by the
--- migrations that needed it, which left a database starting at the current
--- version without the table at all.
-CREATE TABLE IF NOT EXISTS crr_site_id (
-    site_id BLOB PRIMARY KEY
-);
-
-CREATE TABLE IF NOT EXISTS paper_citations (
-    citing_paper_id TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    cited_paper_id  TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (citing_paper_id, cited_paper_id)
-);
-
--- Bookkeeping for one-time app tasks (e.g. the initial citation scan), keyed by
--- a task name. Local-only: not replicated, since it records what THIS install has
--- done, not shared library state.
-CREATE TABLE IF NOT EXISTS app_flags (
-    key   TEXT PRIMARY KEY,
-    value TEXT
-);
-
--- The agent conversation for one subject: a paper, a collection, or an ad-hoc
--- set of papers. Local-only for the same reason as app_flags, and a stronger
--- one: session ids are minted by the agent binary on THIS machine, so a synced
--- row would name a session that resolves to nothing on the other device. Hence
--- no updated_at/updated_by/deleted columns and no _live view.
---
--- subject_id is deliberately not a foreign key: deleting a paper should leave
--- the conversation on record rather than erase it.
-CREATE TABLE IF NOT EXISTS chat_sessions (
-    session_id   TEXT PRIMARY KEY,
-    provider_id  TEXT NOT NULL DEFAULT '',
-    subject_kind TEXT NOT NULL,
-    subject_id   TEXT,
-    summary      TEXT,
-    created_at   TEXT NOT NULL,
-    last_used_at TEXT NOT NULL,
-    is_dead      INTEGER NOT NULL DEFAULT 0
-);
-
--- Papers a conversation touched. `is_subject` marks the ones it is actually
--- about — the single anchor for a 'paper' subject, the whole member set for
--- 'collection' and 'group'. The rest are papers the agent read while answering,
--- recorded so the conversation can be traced, but not claiming to be about them.
-CREATE TABLE IF NOT EXISTS chat_session_papers (
-    session_id TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
-    paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    is_subject INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (session_id, paper_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_chat_sessions_subject ON chat_sessions (subject_kind, subject_id);
-CREATE INDEX IF NOT EXISTS idx_chat_session_papers_paper ON chat_session_papers (paper_id);
-
-CREATE TABLE IF NOT EXISTS annotations (
-    id          TEXT PRIMARY KEY,
-    paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    page        INTEGER NOT NULL,
-    ann_type    TEXT NOT NULL,
-    color       TEXT NOT NULL DEFAULT '#ffff00',
-    content     TEXT,
-    geometry    TEXT NOT NULL,
-    created_at  TEXT NOT NULL,
-    modified_at TEXT NOT NULL,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS notes (
-    id          TEXT PRIMARY KEY,
-    paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
-    title       TEXT NOT NULL DEFAULT '',
-    body        TEXT NOT NULL DEFAULT '',
-    created_at  TEXT NOT NULL,
-    modified_at TEXT NOT NULL,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS saved_searches (
-    id         TEXT PRIMARY KEY,
-    name       TEXT NOT NULL,
-    query      TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    updated_at INTEGER NOT NULL DEFAULT 0,
-    updated_by TEXT NOT NULL DEFAULT '',
-    deleted    INTEGER NOT NULL DEFAULT 0
-);
-";
-
-/// SQL statement that creates the turso FTS index over paper text fields with weighted columns.
 /// Views exposing only live (non-tombstoned) rows of each synced table.
 ///
 /// Reads go through `<table>_live` so a query that forgets `deleted = 0` names a
@@ -179,18 +17,7 @@ CREATE TABLE IF NOT EXISTS saved_searches (
 /// `papers_live` deliberately has no FTS index: `idx_papers_fts` is built on
 /// `papers` and cannot be filtered, so full-text search matches tombstoned rows
 /// and drops them after the match.
-pub const CREATE_LIVE_VIEWS: &str = "
-CREATE VIEW IF NOT EXISTS papers_live AS SELECT * FROM papers WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS collections_live AS SELECT * FROM collections WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS tags_live AS SELECT * FROM tags WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS annotations_live AS SELECT * FROM annotations WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS notes_live AS SELECT * FROM notes WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS saved_searches_live AS SELECT * FROM saved_searches WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS paper_collections_live AS SELECT * FROM paper_collections WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS paper_tags_live AS SELECT * FROM paper_tags WHERE deleted = 0;
-CREATE VIEW IF NOT EXISTS paper_citations_live AS SELECT * FROM paper_citations WHERE deleted = 0;
-";
+pub const CREATE_LIVE_VIEWS: &str = include_str!("sql/live_views.sql");
 
-pub const CREATE_FTS_INDEX: &str = "CREATE INDEX IF NOT EXISTS idx_papers_fts ON papers \
-     USING fts (title, authors, abstract_text, journal, fulltext) \
-     WITH (weights = 'title=3.0,authors=2.0,abstract_text=1.5,journal=1.0,fulltext=1.0')";
+/// SQL statement that creates the turso FTS index over paper text fields with weighted columns.
+pub const CREATE_FTS_INDEX: &str = include_str!("sql/fts_index.sql");


### PR DESCRIPTION
The `CREATE TABLE`, live-view, and FTS-index statements were ~6.4KB of SQL living in Rust string literals, where no editor highlights them. They now live in `crates/rotero-db/src/schema/sql/`, pulled back in with `include_str!`.

`tables.rs` goes from 174 lines to 23 — three documented constants and nothing else.

| File | Contents |
|---|---|
| `sql/tables.sql` | 14 `CREATE TABLE` + 2 `CREATE INDEX` |
| `sql/live_views.sql` | 9 `_live` views |
| `sql/fts_index.sql` | the weighted FTS index |

### Why `include_str!` rather than loading at runtime

The constants stay `&'static str` resolved at compile time, so this gives up nothing: a renamed or missing `.sql` file is a **compile error**, not a startup failure, and there is no new I/O path or error case. The public API of the module is unchanged — every call site still sees the same three `&str` constants.

### Also fixed

A misplaced doc comment: the `CREATE_FTS_INDEX` docstring sat above `CREATE_LIVE_VIEWS`, which left the index constant undocumented and stacked two docstrings on the views.

### Scope

Only the DDL moved. Two groups were deliberately left alone:

- **`sync_sql.rs`** — every statement is built by `format!()` from `SYNCED_TABLES` metadata. There is no static string to extract; moving fragments to files would obscure them.
- **`queries.rs`** — 85 constants averaging ~2 lines each, where the rustdoc above each query is carrying real information (the `PAPER_SEARCH_FTS` comment explaining turso's `fts_match()` requirement, for one). Splitting those into 85 files would trade a browsable documented file for a directory, and `grep PAPER_INSERT` would stop showing the SQL.

### Verification

The extracted `tables.sql` is **byte-identical** to the string it replaced (verified with `diff` against the constant body on `master`, including the `chat_sessions` tables added by #25 during the rebase).

- `cargo test -p rotero-db` — 116 passed, 0 failed
- `cargo clippy -p rotero-db` — clean
- `cargo check --workspace` — clean

The schema-guard and FTS tests exercise this DDL directly, so a dropped or malformed statement would fail the suite rather than pass silently.