### PR TITLE
Address synced PDFs by content, not by filename

### DIFF
--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -412,8 +412,8 @@ impl Database {
     /// so a stored path cannot reach outside the papers directory.
     pub fn hash_stored_pdf(&self, rel_path: &str) -> Result<String, String> {
         let abs = self.resolve_pdf_path(rel_path);
-        let bytes = std::fs::read(&abs)
-            .map_err(|e| format!("Failed to read {}: {e}", abs.display()))?;
+        let bytes =
+            std::fs::read(&abs).map_err(|e| format!("Failed to read {}: {e}", abs.display()))?;
         Ok(crate::snapshot::checksum(&bytes))
     }
 }

--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -298,14 +298,18 @@ impl Database {
     }
 
     /// Import a PDF into the library.
-    /// Layout: `papers/{year}/{Title} - {FirstAuthor}.pdf`, falling back to `papers/unsorted/`.
+    ///
+    /// Layout: `papers/{year}/{Title} - {FirstAuthor}.pdf`, falling back to
+    /// `papers/unsorted/`. Returns the relative path and the SHA-256 of the
+    /// file's contents — see [`import_pdf_bytes`](Self::import_pdf_bytes) for
+    /// why the hash comes back with the path rather than being derived later.
     pub fn import_pdf(
         &self,
         source_path: &str,
         title: Option<&str>,
         first_author: Option<&str>,
         year: Option<i32>,
-    ) -> Result<String, String> {
+    ) -> Result<(String, String), String> {
         let source = Path::new(source_path);
 
         let clean_name = build_clean_filename(source, title, first_author);
@@ -334,22 +338,33 @@ impl Database {
 
         std::fs::copy(source, &dest).map_err(|e| format!("Failed to copy PDF: {e}"))?;
 
+        let bytes = std::fs::read(&dest).map_err(|e| format!("Failed to re-read PDF: {e}"))?;
+        let sha256 = crate::snapshot::checksum(&bytes);
+
         let rel_path = std::path::Path::new(&subfolder)
             .join(&dest_name)
             .to_string_lossy()
             .into_owned();
-        Ok(rel_path)
+        Ok((rel_path, sha256))
     }
 
     /// Import a PDF from bytes (e.g. downloaded from the web).
-    /// Returns the relative path within the papers directory.
+    ///
+    /// Returns the relative path within the papers directory and the SHA-256 of
+    /// the contents.
+    ///
+    /// The hash is produced here rather than recomputed later because this is
+    /// the one moment the bytes are already in hand. The filename is derived
+    /// from `(year, title, first_author)` alone and its collision counter only
+    /// sees the local disk, so the path is not a stable identity across devices
+    /// — the hash is.
     pub fn import_pdf_bytes(
         &self,
         bytes: &[u8],
         title: &str,
         first_author: Option<&str>,
         year: Option<i32>,
-    ) -> Result<String, String> {
+    ) -> Result<(String, String), String> {
         if bytes.len() < 5 || &bytes[..5] != b"%PDF-" {
             return Err("Not a valid PDF file".to_string());
         }
@@ -381,11 +396,25 @@ impl Database {
 
         std::fs::write(&dest, bytes).map_err(|e| format!("Failed to write PDF: {e}"))?;
 
+        let sha256 = crate::snapshot::checksum(bytes);
+
         let rel_path = std::path::Path::new(&subfolder)
             .join(&dest_name)
             .to_string_lossy()
             .into_owned();
-        Ok(rel_path)
+        Ok((rel_path, sha256))
+    }
+
+    /// The SHA-256 of a PDF already sitting in the library.
+    ///
+    /// For the backfill, which is hashing files that were imported before the
+    /// column existed. Reads through [`resolve_pdf_path`](Self::resolve_pdf_path)
+    /// so a stored path cannot reach outside the papers directory.
+    pub fn hash_stored_pdf(&self, rel_path: &str) -> Result<String, String> {
+        let abs = self.resolve_pdf_path(rel_path);
+        let bytes = std::fs::read(&abs)
+            .map_err(|e| format!("Failed to read {}: {e}", abs.display()))?;
+        Ok(crate::snapshot::checksum(&bytes))
     }
 }
 

--- a/crates/rotero-db/src/papers.rs
+++ b/crates/rotero-db/src/papers.rs
@@ -359,13 +359,25 @@ impl Database {
         Ok(())
     }
 
-    /// Update the relative PDF file path for a paper.
-    pub async fn update_pdf_path(&self, id: &str, pdf_path: &str) -> Result<(), crate::DbError> {
+    /// Update the relative PDF file path for a paper, and the hash of the file
+    /// it names.
+    ///
+    /// The hash is what the sync engine addresses the shared copy by. Passing
+    /// `None` records a path whose contents are not yet known — the backfill
+    /// will fill it in — but every caller that has the bytes should supply it,
+    /// because a path without a hash cannot be published to peers.
+    pub async fn update_pdf_path(
+        &self,
+        id: &str,
+        pdf_path: &str,
+        pdf_sha256: Option<&str>,
+    ) -> Result<(), crate::DbError> {
         let conn = self.conn();
         conn.execute(
             queries::PAPER_UPDATE_PDF_PATH,
             turso::params::Params::Positional(vec![
                 Value::Text(pdf_path.to_string()),
+                crate::opt_text(pdf_sha256.map(str::to_string).as_ref()),
                 Value::Text(chrono::Utc::now().to_rfc3339()),
                 Value::Text(id.to_string()),
             ]),
@@ -373,6 +385,117 @@ impl Database {
         .await?;
         self.touch("papers", crate::clock::Pk::Single(id)).await?;
         Ok(())
+    }
+
+    /// The stored content hash of a paper's PDF, if one has been computed.
+    pub async fn pdf_sha256(&self, id: &str) -> Result<Option<String>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn
+            .query(
+                queries::PAPER_SELECT_PDF_SHA256,
+                [Value::Text(id.to_string())],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(None);
+        };
+        Ok(crate::get_opt_text(&row, 0).filter(|h| !h.is_empty()))
+    }
+
+    /// Record a computed hash without disturbing the path.
+    ///
+    /// Deliberately does **not** stamp the sync clock. The hash of an unchanged
+    /// file is a local repair of a row that predates the column, not an edit —
+    /// stamping it would republish every backfilled paper and let a backfill on
+    /// one device outrank a real metadata edit made on another.
+    pub async fn set_pdf_sha256(&self, id: &str, sha256: &str) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            queries::PAPER_UPDATE_PDF_SHA256,
+            [Value::Text(sha256.to_string()), Value::Text(id.to_string())],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Every live paper that names a PDF, as `(id, pdf_path, pdf_sha256)`.
+    ///
+    /// What PDF sync iterates. Unlike [`list_papers`](Self::list_papers) this is
+    /// the whole library, not the 500 most recent — that cap is a UI concern,
+    /// and applying it to sync silently excluded everything past it.
+    pub async fn list_papers_with_pdfs(
+        &self,
+    ) -> Result<Vec<(String, String, Option<String>)>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn.query(queries::PAPER_LIST_WITH_PDFS, ()).await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let id = crate::get_text(&row, 0);
+            let path = crate::get_text(&row, 1);
+            let hash = crate::get_opt_text(&row, 2).filter(|h| !h.is_empty());
+            if !id.is_empty() && !path.is_empty() {
+                out.push((id, path, hash));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Live papers with a PDF but no hash yet, as `(id, pdf_path)`.
+    pub async fn list_papers_needing_pdf_hashes(
+        &self,
+    ) -> Result<Vec<(String, String)>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn
+            .query(queries::PAPER_LIST_NEEDING_PDF_HASHES, ())
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let id = crate::get_text(&row, 0);
+            let path = crate::get_text(&row, 1);
+            if !id.is_empty() && !path.is_empty() {
+                out.push((id, path));
+            }
+        }
+        Ok(out)
+    }
+
+    /// PDF hashes that only tombstoned papers still name.
+    ///
+    /// Read *before* reaping tombstones, because reaping removes the rows that
+    /// carry these hashes — after which nothing records which shared blobs the
+    /// deletion orphaned.
+    pub async fn orphaned_pdf_hashes(&self) -> Result<Vec<String>, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn.query(queries::PAPER_ORPHANED_PDF_HASHES, ()).await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            if let Some(h) = crate::get_opt_text(&row, 0).filter(|h| !h.is_empty()) {
+                out.push(h);
+            }
+        }
+        Ok(out)
+    }
+
+    /// How many live papers still point at a given PDF hash.
+    ///
+    /// A shared blob may only be reaped when this is zero: content addressing
+    /// means one file can back several papers, so deleting on behalf of one
+    /// would strand the others.
+    pub async fn count_live_papers_with_pdf_hash(
+        &self,
+        sha256: &str,
+    ) -> Result<i64, crate::DbError> {
+        let conn = self.conn();
+        let mut rows = conn
+            .query(
+                queries::PAPER_COUNT_LIVE_BY_PDF_SHA256,
+                [Value::Text(sha256.to_string())],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(0);
+        };
+        Ok(crate::get_opt_i64(&row, 0).unwrap_or(0))
     }
 
     /// Update a paper's `date_modified` to now.

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_LIVE_VIEWS, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub const SCHEMA_VERSION: i64 = 17;
+pub const SCHEMA_VERSION: i64 = 18;
 
 /// Why a database could not be prepared for use.
 #[derive(Debug, thiserror::Error)]
@@ -381,6 +381,20 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
             )
             .await;
     }
+
+    // Content identity for the PDF a paper points at.
+    //
+    // `pdf_path` syncs but the bytes behind it do not, and the path is derived
+    // from title/author/year alone — so two devices that add the same paper
+    // agree on a filename while holding different files. The hash is what makes
+    // a PDF addressable by what it *is* rather than what it is called.
+    //
+    // Unconditional rather than version-guarded, matching the ALTER above: a
+    // library stamped forward without the column would otherwise be stranded,
+    // and a duplicate ALTER costs one failed statement.
+    let _ = conn
+        .execute("ALTER TABLE papers ADD COLUMN pdf_sha256 TEXT", ())
+        .await;
 
     if current_version < SCHEMA_VERSION {
         conn.execute("UPDATE schema_version SET version = ?1", [SCHEMA_VERSION])

--- a/crates/rotero-db/src/schema/sql/tables.sql
+++ b/crates/rotero-db/src/schema/sql/tables.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS papers (
     citation_count INTEGER,
     citation_key  TEXT,
     pdf_url       TEXT,
+    pdf_sha256    TEXT,
     item_type     TEXT NOT NULL DEFAULT 'journalArticle',
     updated_at INTEGER NOT NULL DEFAULT 0,
     updated_by TEXT NOT NULL DEFAULT '',

--- a/crates/rotero-db/src/sync_schema.rs
+++ b/crates/rotero-db/src/sync_schema.rs
@@ -83,6 +83,7 @@ pub const SYNCED_TABLES: &[SyncedTable] = &[
             "publisher",
             "url",
             "pdf_path",
+            "pdf_sha256",
             "date_added",
             "date_modified",
             "is_favorite",

--- a/crates/rotero-db/tests/migration_v18_test.rs
+++ b/crates/rotero-db/tests/migration_v18_test.rs
@@ -1,0 +1,162 @@
+//! The v18 migration adds `papers.pdf_sha256`, the content identity PDF sync
+//! addresses a shared file by.
+//!
+//! A library written before it existed has papers with a `pdf_path` and no
+//! hash. Those rows have to survive the migration intact and become
+//! backfillable — a row that arrived without a hash and could not acquire one
+//! would have its PDF silently excluded from sync, which is the failure the
+//! column exists to end.
+
+mod common;
+
+use rotero_models::Paper;
+
+/// Rewind so reopening runs the v18 block.
+async fn rewind_to_v17(dir: &std::path::Path) {
+    let db_path = dir.join("rotero.db");
+    let raw = turso::Builder::new_local(db_path.to_str().unwrap())
+        .experimental_index_method(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = raw.connect().unwrap();
+    conn.execute(
+        "UPDATE schema_version SET version = ?1",
+        [turso::Value::Integer(17)],
+    )
+    .await
+    .unwrap();
+}
+
+/// A pre-v18 paper keeps its path, and is offered to the backfill.
+#[tokio::test]
+async fn a_paper_imported_before_the_column_is_queued_for_hashing() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (with_pdf, without_pdf) = {
+        let db = common::open_test_db(dir.path()).await;
+        let with_pdf = db
+            .insert_paper(&Paper {
+                title: "Has a PDF".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        // Written the way a pre-v18 build would: a path, no hash.
+        db.update_pdf_path(&with_pdf, "2024/Has a PDF - Author.pdf", None)
+            .await
+            .unwrap();
+
+        let without_pdf = db
+            .insert_paper(&Paper {
+                title: "No PDF".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        (with_pdf, without_pdf)
+    };
+
+    rewind_to_v17(dir.path()).await;
+    let db = common::open_test_db(dir.path()).await;
+
+    // The path survived the migration.
+    let pending = db.list_papers_needing_pdf_hashes().await.unwrap();
+    assert_eq!(
+        pending,
+        vec![(with_pdf.clone(), "2024/Has a PDF - Author.pdf".to_string())],
+        "the pre-existing paper must be queued for hashing, and only it"
+    );
+
+    // A paper with no PDF is not queued — there is nothing to hash.
+    assert!(
+        !pending.iter().any(|(id, _)| id == &without_pdf),
+        "a paper with no PDF must not be queued"
+    );
+
+    // And it has no hash yet, so sync correctly skips it until the backfill runs.
+    assert_eq!(db.pdf_sha256(&with_pdf).await.unwrap(), None);
+}
+
+/// Backfilling a hash must not republish the row.
+///
+/// The clock decides which copy of a row wins a merge. Hashing a file that has
+/// not changed is a local repair of a row that predates the column, not an
+/// edit — stamping it would let a backfill on one device outrank a real
+/// metadata edit made on another, which is how retiring a tag by stamped rename
+/// blanked out real names in the previous pass.
+#[tokio::test]
+async fn backfilling_a_hash_does_not_stamp_the_sync_clock() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+
+    let id = db
+        .insert_paper(&Paper {
+            title: "Backfilled".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    db.update_pdf_path(&id, "2024/Backfilled - Author.pdf", None)
+        .await
+        .unwrap();
+
+    let clock_before = clock_of(&db, &id).await;
+    db.set_pdf_sha256(&id, &"a".repeat(64)).await.unwrap();
+    let clock_after = clock_of(&db, &id).await;
+
+    assert_eq!(
+        clock_before, clock_after,
+        "recording a hash for an unchanged file must not republish the paper"
+    );
+    assert_eq!(
+        db.pdf_sha256(&id).await.unwrap(),
+        Some("a".repeat(64)),
+        "but the hash must still be stored"
+    );
+}
+
+/// Setting a path *with* a hash is a real edit and must stamp.
+///
+/// The counterpart to the test above: attaching a PDF changes what the row
+/// says, and a peer has to hear about it.
+#[tokio::test]
+async fn attaching_a_pdf_does_stamp_the_sync_clock() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+
+    let id = db
+        .insert_paper(&Paper {
+            title: "Attached".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let clock_before = clock_of(&db, &id).await;
+    db.update_pdf_path(&id, "2024/Attached - Author.pdf", Some(&"b".repeat(64)))
+        .await
+        .unwrap();
+    let clock_after = clock_of(&db, &id).await;
+
+    assert!(
+        clock_after > clock_before,
+        "attaching a PDF must publish the row: {clock_before} -> {clock_after}"
+    );
+}
+
+async fn clock_of(db: &rotero_db::Database, id: &str) -> i64 {
+    let mut rows = db
+        .conn()
+        .query(
+            "SELECT updated_at FROM papers WHERE id = ?1",
+            [turso::Value::Text(id.to_string())],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("the paper must exist");
+    row.get_value(0)
+        .ok()
+        .and_then(|v| v.as_integer().copied())
+        .unwrap_or_default()
+}

--- a/crates/rotero-db/tests/soft_delete_guard_test.rs
+++ b/crates/rotero-db/tests/soft_delete_guard_test.rs
@@ -52,6 +52,16 @@ const READS_ALL_ROWS: &[(&str, &str)] = &[
     // holds its name against the survivor. Looking only at live rows would miss
     // the clash and the insert would fail on every later merge.
     ("TAG_FIND_NAME_CLASH", "UNIQUE spans tombstones"),
+    // Finding which shared PDFs a deletion orphaned means reading the deleted
+    // rows: they are the only record of which hash the deleted paper pointed
+    // at. The live half of the question is asked in the same statement, as a
+    // `NOT IN` against `papers_live`, so a blob another paper still uses is
+    // never reported.
+    (
+        "PAPER_ORPHANED_PDF_HASHES",
+        "reads tombstones to find the PDFs they orphaned; excludes live rows \
+         via NOT IN papers_live",
+    ),
 ];
 
 #[test]

--- a/crates/rotero-mcp/src/db.rs
+++ b/crates/rotero-mcp/src/db.rs
@@ -610,9 +610,18 @@ impl Database {
     }
 
     /// Update the pdf_path for a paper after downloading a PDF.
-    pub async fn update_pdf_path(&self, id: &str, pdf_path: &str) -> Result<(), turso::Error> {
+    ///
+    /// `pdf_sha256` is the hash of the file now at that path, which the sync
+    /// engine addresses the shared copy by. Callers that wrote the file through
+    /// `import_pdf`/`import_pdf_bytes` already have it back from those.
+    pub async fn update_pdf_path(
+        &self,
+        id: &str,
+        pdf_path: &str,
+        pdf_sha256: Option<&str>,
+    ) -> Result<(), turso::Error> {
         self.as_rotero_db()
-            .update_pdf_path(id, pdf_path)
+            .update_pdf_path(id, pdf_path, pdf_sha256)
             .await
             .map_err(to_turso)?;
         self.notify();

--- a/crates/rotero-mcp/src/server/tools.rs
+++ b/crates/rotero-mcp/src/server/tools.rs
@@ -684,9 +684,15 @@ impl RoteroMcp {
         let dest = papers_dir.join(&filename);
         std::fs::write(&dest, &bytes).map_err(|e| err(format!("Failed to save PDF: {e}")))?;
 
+        // Record the hash alongside the path. This is a third PDF write path,
+        // independent of `Database::import_pdf{,_bytes}` and with its own naming
+        // scheme, so it has to compute the hash itself — a path stored without
+        // one cannot be published to peers.
+        let sha256 = rotero_db::snapshot::checksum(&bytes);
+
         // Update the paper's pdf_path in the database
         self.db
-            .update_pdf_path(&params.paper_id, &filename)
+            .update_pdf_path(&params.paper_id, &filename, Some(&sha256))
             .await
             .map_err(err)?;
 

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -58,9 +58,63 @@ pub const PAPER_UPDATE_METADATA: &str = "\
 
 /// Read a paper's extracted full text.
 pub const PAPER_SELECT_FULLTEXT: &str = "SELECT fulltext FROM papers_live WHERE id = ?1";
-/// Set or replace the local PDF file path for a paper.
+/// Set or replace the local PDF file path for a paper, along with the hash of
+/// its contents.
+///
+/// The two are written together on purpose. `pdf_path` syncs, so a path without
+/// its hash reaches a peer that then cannot tell which file the name refers to —
+/// the state that lets two devices hold different documents under one name.
 pub const PAPER_UPDATE_PDF_PATH: &str =
-    "UPDATE papers SET pdf_path = ?1, date_modified = ?2 WHERE id = ?3";
+    "UPDATE papers SET pdf_path = ?1, pdf_sha256 = ?2, date_modified = ?3 WHERE id = ?4";
+
+/// The stored content hash of a paper's PDF, if one has been computed.
+pub const PAPER_SELECT_PDF_SHA256: &str =
+    "SELECT pdf_sha256 FROM papers_live WHERE id = ?1";
+
+/// Record a freshly computed hash without touching the path.
+///
+/// Used by the backfill, which is repairing rows that predate the column rather
+/// than reacting to a new file.
+pub const PAPER_UPDATE_PDF_SHA256: &str =
+    "UPDATE papers SET pdf_sha256 = ?1 WHERE id = ?2";
+
+/// Every live paper that names a PDF, with its hash where one is known.
+///
+/// Drives PDF sync. Deliberately not `list_papers`, which is capped at the 500
+/// most recently added and is loaded for the UI — a library past that cap had
+/// the rest of its PDFs silently excluded from sync entirely.
+pub const PAPER_LIST_WITH_PDFS: &str =
+    "SELECT id, pdf_path, pdf_sha256 FROM papers_live \
+     WHERE pdf_path IS NOT NULL AND pdf_path <> ''";
+
+/// Live papers that have a PDF but no hash for it yet.
+///
+/// The backfill queue for libraries created before `pdf_sha256` existed.
+pub const PAPER_LIST_NEEDING_PDF_HASHES: &str =
+    "SELECT id, pdf_path FROM papers_live \
+     WHERE pdf_path IS NOT NULL AND pdf_path <> '' \
+       AND (pdf_sha256 IS NULL OR pdf_sha256 = '')";
+
+/// PDF hashes named only by tombstoned papers.
+///
+/// The shared blobs that no live paper anywhere still needs. Deliberately a
+/// `NOT IN` against the live set rather than a scan of deleted rows alone:
+/// content addressing means one blob can back several papers, so a hash is only
+/// orphaned when *every* paper naming it is gone.
+pub const PAPER_ORPHANED_PDF_HASHES: &str = "\
+    SELECT DISTINCT pdf_sha256 FROM papers \
+    WHERE deleted = 1 AND pdf_sha256 IS NOT NULL AND pdf_sha256 <> '' \
+      AND pdf_sha256 NOT IN ( \
+          SELECT pdf_sha256 FROM papers_live \
+          WHERE pdf_sha256 IS NOT NULL AND pdf_sha256 <> '')";
+
+/// Whether any live paper still points at a given PDF hash.
+///
+/// Content addressing means one blob can back several papers — a deduplicated
+/// import, or a merged duplicate. Reaping a shared blob is only safe when this
+/// finds nothing.
+pub const PAPER_COUNT_LIVE_BY_PDF_SHA256: &str =
+    "SELECT COUNT(*) FROM papers_live WHERE pdf_sha256 = ?1";
 /// Set the title for a paper, leaving every other bibliographic field alone.
 pub const PAPER_UPDATE_TITLE: &str =
     "UPDATE papers SET title = ?1, date_modified = ?2 WHERE id = ?3";

--- a/crates/rotero-models/src/queries.rs
+++ b/crates/rotero-models/src/queries.rs
@@ -68,30 +68,26 @@ pub const PAPER_UPDATE_PDF_PATH: &str =
     "UPDATE papers SET pdf_path = ?1, pdf_sha256 = ?2, date_modified = ?3 WHERE id = ?4";
 
 /// The stored content hash of a paper's PDF, if one has been computed.
-pub const PAPER_SELECT_PDF_SHA256: &str =
-    "SELECT pdf_sha256 FROM papers_live WHERE id = ?1";
+pub const PAPER_SELECT_PDF_SHA256: &str = "SELECT pdf_sha256 FROM papers_live WHERE id = ?1";
 
 /// Record a freshly computed hash without touching the path.
 ///
 /// Used by the backfill, which is repairing rows that predate the column rather
 /// than reacting to a new file.
-pub const PAPER_UPDATE_PDF_SHA256: &str =
-    "UPDATE papers SET pdf_sha256 = ?1 WHERE id = ?2";
+pub const PAPER_UPDATE_PDF_SHA256: &str = "UPDATE papers SET pdf_sha256 = ?1 WHERE id = ?2";
 
 /// Every live paper that names a PDF, with its hash where one is known.
 ///
 /// Drives PDF sync. Deliberately not `list_papers`, which is capped at the 500
 /// most recently added and is loaded for the UI — a library past that cap had
 /// the rest of its PDFs silently excluded from sync entirely.
-pub const PAPER_LIST_WITH_PDFS: &str =
-    "SELECT id, pdf_path, pdf_sha256 FROM papers_live \
+pub const PAPER_LIST_WITH_PDFS: &str = "SELECT id, pdf_path, pdf_sha256 FROM papers_live \
      WHERE pdf_path IS NOT NULL AND pdf_path <> ''";
 
 /// Live papers that have a PDF but no hash for it yet.
 ///
 /// The backfill queue for libraries created before `pdf_sha256` existed.
-pub const PAPER_LIST_NEEDING_PDF_HASHES: &str =
-    "SELECT id, pdf_path FROM papers_live \
+pub const PAPER_LIST_NEEDING_PDF_HASHES: &str = "SELECT id, pdf_path FROM papers_live \
      WHERE pdf_path IS NOT NULL AND pdf_path <> '' \
        AND (pdf_sha256 IS NULL OR pdf_sha256 = '')";
 

--- a/src/app/library_loader.rs
+++ b/src/app/library_loader.rs
@@ -187,7 +187,10 @@ pub fn LoadLibraryData() -> Element {
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
                 loop {
-                    let pending = db.list_papers_needing_pdf_hashes().await.unwrap_or_default();
+                    let pending = db
+                        .list_papers_needing_pdf_hashes()
+                        .await
+                        .unwrap_or_default();
                     if pending.is_empty() {
                         break;
                     }

--- a/src/app/library_loader.rs
+++ b/src/app/library_loader.rs
@@ -164,6 +164,80 @@ pub fn LoadLibraryData() -> Element {
         });
     }
 
+    // Backfill content hashes for PDFs imported before `pdf_sha256` existed.
+    //
+    // Sync addresses a shared PDF by its hash, so a row without one is simply
+    // skipped by the transfer — its file never publishes and never arrives.
+    // This drains the queue in small batches rather than hashing the whole
+    // library at once: a library of thousands of PDFs must stay responsive
+    // while it catches up, and reading every one of them is the single most
+    // expensive thing startup could do.
+    //
+    // Resumable by construction — the queue is "has a path, has no hash", so an
+    // interrupted run simply picks up where it stopped, and a completed one
+    // costs one empty query per pass.
+    #[cfg(feature = "desktop")]
+    {
+        let db_hash = db.clone();
+        use_future(move || {
+            let db = db_hash.clone();
+            async move {
+                // Let the library finish loading first; this is repair work,
+                // not anything the user is waiting on.
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+                loop {
+                    let pending = db.list_papers_needing_pdf_hashes().await.unwrap_or_default();
+                    if pending.is_empty() {
+                        break;
+                    }
+
+                    // Whether this pass hashed anything. A row whose file is
+                    // missing stays in the queue, so without this the loop
+                    // would re-read the same unreadable rows every 5 seconds
+                    // for as long as the app runs.
+                    let mut progressed = false;
+
+                    for (paper_id, rel_path) in pending.iter().take(20) {
+                        let hasher = db.clone();
+                        let (id, path) = (paper_id.clone(), rel_path.clone());
+                        // Hashing reads the whole file, so keep it off the UI
+                        // thread the way the PDF import path already does.
+                        let hashed = tokio::task::spawn_blocking(move || {
+                            hasher.hash_stored_pdf(&path).map(|h| (id, h))
+                        })
+                        .await;
+
+                        match hashed {
+                            Ok(Ok((id, hash))) => match db.set_pdf_sha256(&id, &hash).await {
+                                Ok(()) => progressed = true,
+                                Err(e) => tracing::warn!("Could not record PDF hash: {e}"),
+                            },
+                            // A paper whose file is gone — deleted outside the
+                            // app, or never downloaded. Nothing to hash, and
+                            // retrying will not change that.
+                            Ok(Err(e)) => tracing::debug!("Skipping PDF hash: {e}"),
+                            Err(e) => tracing::warn!("PDF hash task failed: {e}"),
+                        }
+                    }
+
+                    if !progressed {
+                        tracing::debug!(
+                            "PDF hash backfill stopping: {} row(s) name files that \
+                             cannot be read",
+                            pending.len()
+                        );
+                        break;
+                    }
+
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+
+                tracing::info!("PDF hash backfill complete");
+            }
+        });
+    }
+
     #[cfg(feature = "desktop")]
     use_future(move || {
         let db = db.clone();

--- a/src/app/sync_loop.rs
+++ b/src/app/sync_loop.rs
@@ -56,12 +56,25 @@ pub fn SyncLoop() -> Element {
                                 0
                             }
                         };
-                        crate::init::preflight::record(|p| p.sync_folder = failure);
+                        // Reported jointly with the PDF half at the end of the
+                        // tick — see below. Publishing here as well would let
+                        // whichever ran last decide what the user sees, so a
+                        // snapshot failure could be erased by PDFs succeeding.
 
                         // Drop tombstones every peer has certainly seen. Rate-
                         // limited internally to roughly weekly, and a no-op
                         // unless every peer's snapshot is well past them, so
                         // running it on the sync tick costs a flag read.
+                        //
+                        // Collect the orphaned PDF hashes *before* reaping:
+                        // reaping removes the tombstones that carry them, after
+                        // which nothing records which shared blobs the deletion
+                        // left behind.
+                        let orphaned = db.orphaned_pdf_hashes().await.unwrap_or_else(|e| {
+                            tracing::warn!("Could not list orphaned PDF hashes: {e}");
+                            Vec::new()
+                        });
+
                         match db
                             .reap_tombstones(
                                 engine.peer_horizon().await,
@@ -71,19 +84,86 @@ pub fn SyncLoop() -> Element {
                         {
                             Ok(stats) if stats.removed > 0 => {
                                 tracing::info!("Reaped {} settled tombstone(s)", stats.removed);
+
+                                // Only now, having reaped, is the deletion past
+                                // every peer's horizon and the TTL — so the
+                                // shared copy is safe to drop. The device's own
+                                // file is deliberately left alone: it is the
+                                // user's data, and sync does not unlink it.
+                                for sha256 in &orphaned {
+                                    if let Err(e) = engine.reap_shared_pdf(sha256) {
+                                        tracing::warn!("Could not reap shared PDF: {e}");
+                                    }
+                                }
                             }
                             Ok(_) => {}
                             Err(e) => tracing::warn!("Tombstone reap failed: {e}"),
                         }
 
+                        // Drive PDF transfer from the database, not from the
+                        // UI's paper list. `lib_state.papers` is
+                        // `list_papers()`, capped at the 500 most recently
+                        // added — so every library past that cap had the rest
+                        // of its PDFs silently excluded from sync in both
+                        // directions. Reading it here also meant working from
+                        // the pre-merge snapshot, since the refresh below runs
+                        // after this block.
+                        //
+                        // Blocking file copies, moved off the UI thread: this
+                        // runs inside a Dioxus future, and multi-megabyte reads
+                        // and writes over cloud-synced storage stalled it.
                         let papers_dir = db.papers_dir();
-                        let papers = lib_state.read().papers.clone();
-                        for paper in &papers {
-                            if let Some(ref path) = paper.links.pdf_path {
-                                let _ = engine.export_pdf(&papers_dir, path);
-                                let _ = engine.import_pdf(&papers_dir, path);
+                        let pdf_failure = match db.list_papers_with_pdfs().await {
+                            Ok(papers) => {
+                                let engine = engine.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    let mut first_error: Option<String> = None;
+                                    for (_, path, sha256) in &papers {
+                                        for outcome in [
+                                            engine.export_pdf(
+                                                &papers_dir,
+                                                path,
+                                                sha256.as_deref(),
+                                            ),
+                                            engine.import_pdf(
+                                                &papers_dir,
+                                                path,
+                                                sha256.as_deref(),
+                                            ),
+                                        ] {
+                                            if let Err(e) = outcome {
+                                                tracing::warn!("PDF sync failed for {path}: {e}");
+                                                first_error.get_or_insert(e);
+                                            }
+                                        }
+                                    }
+                                    first_error
+                                })
+                                .await
+                                .unwrap_or_else(|e| Some(format!("PDF sync task failed: {e}")))
                             }
-                        }
+                            Err(e) => {
+                                tracing::warn!("Could not list papers with PDFs: {e}");
+                                Some(format!("could not list PDFs: {e}"))
+                            }
+                        };
+
+                        // Report both halves together, rather than discarding
+                        // the PDF result the way `let _ =` used to. A sync that
+                        // has been failing for days otherwise looks exactly
+                        // like one with nothing to do.
+                        //
+                        // One field holds both, so a failure in either half has
+                        // to survive the other succeeding: the snapshot error
+                        // leads when there is one, since a library that is not
+                        // exchanging rows is the larger problem.
+                        let combined = match (failure, pdf_failure) {
+                            (Some(snapshot), _) => Some(snapshot),
+                            (None, Some(pdf)) => Some(format!("could not sync PDFs: {pdf}")),
+                            (None, None) => None,
+                        };
+                        crate::init::preflight::record(|p| p.sync_folder = combined);
+
                         imported
                     }
                     crate::sync::engine::SyncTransport::CloudKit => {

--- a/src/app/sync_loop.rs
+++ b/src/app/sync_loop.rs
@@ -120,16 +120,8 @@ pub fn SyncLoop() -> Element {
                                     let mut first_error: Option<String> = None;
                                     for (_, path, sha256) in &papers {
                                         for outcome in [
-                                            engine.export_pdf(
-                                                &papers_dir,
-                                                path,
-                                                sha256.as_deref(),
-                                            ),
-                                            engine.import_pdf(
-                                                &papers_dir,
-                                                path,
-                                                sha256.as_deref(),
-                                            ),
+                                            engine.export_pdf(&papers_dir, path, sha256.as_deref()),
+                                            engine.import_pdf(&papers_dir, path, sha256.as_deref()),
                                         ] {
                                             if let Err(e) = outcome {
                                                 tracing::warn!("PDF sync failed for {path}: {e}");

--- a/src/init/connector.rs
+++ b/src/init/connector.rs
@@ -209,7 +209,7 @@ pub async fn download_and_import_pdf(
     let author_names = paper.author_names();
     let first_author = author_names.first().map(|s| s.as_str());
 
-    let rel_path = crate::metadata::pdf_download::download_and_save_pdf(
+    let (rel_path, sha256) = crate::metadata::pdf_download::download_and_save_pdf(
         db,
         &[pdf_url.to_string()],
         &paper.title,
@@ -219,7 +219,7 @@ pub async fn download_and_import_pdf(
     .await
     .map_err(|e| format!("{e}"))?;
 
-    db.update_pdf_path(paper_id, &rel_path)
+    db.update_pdf_path(paper_id, &rel_path, Some(&sha256))
         .await
         .map_err(|e| format!("Failed to update pdf_path: {e}"))?;
 

--- a/src/metadata/pdf_download.rs
+++ b/src/metadata/pdf_download.rs
@@ -172,14 +172,16 @@ async fn translator_pdf_urls(doi: &str) -> Result<Vec<String>, String> {
 }
 
 /// Download a PDF from the first working URL and save it to the library.
-/// Returns the relative path within the papers directory.
+///
+/// Returns the relative path within the papers directory and the SHA-256 of the
+/// saved bytes, which the sync engine addresses the shared copy by.
 pub async fn download_and_save_pdf(
     db: &Database,
     urls: &[String],
     title: &str,
     first_author: Option<&str>,
     year: Option<i32>,
-) -> Result<String, PdfDownloadError> {
+) -> Result<(String, String), PdfDownloadError> {
     if urls.is_empty() {
         return Err(PdfDownloadError::NoUrls);
     }
@@ -304,6 +306,8 @@ async fn download_once(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, S
 /// `direct_url` is any PDF link the paper already carries (arXiv `pdf_url`, an
 /// OA location); it is tried first before falling back to translator scraping
 /// and the OA metadata APIs.
+///
+/// Returns the relative path and the SHA-256 of the saved bytes.
 pub async fn find_and_download_pdf(
     db: &Database,
     direct_url: Option<&str>,
@@ -311,7 +315,7 @@ pub async fn find_and_download_pdf(
     title: &str,
     first_author: Option<&str>,
     year: Option<i32>,
-) -> Result<String, PdfDownloadError> {
+) -> Result<(String, String), PdfDownloadError> {
     let urls = resolve_pdf_urls(direct_url, doi, title).await;
     download_and_save_pdf(db, &urls, title, first_author, year).await
 }

--- a/src/state/commands/import.rs
+++ b/src/state/commands/import.rs
@@ -123,8 +123,8 @@ pub async fn download_pdf_into_library(
     )
     .await
     {
-        Ok(rel_path) => {
-            let _ = db.update_pdf_path(paper_id, &rel_path).await;
+        Ok((rel_path, sha256)) => {
+            let _ = db.update_pdf_path(paper_id, &rel_path, Some(&sha256)).await;
             let pid = paper_id.to_string();
             lib_state.with_mut(|s| {
                 if let Some(p) = s

--- a/src/sync/cloudkit_sync.rs
+++ b/src/sync/cloudkit_sync.rs
@@ -2,6 +2,22 @@
 //!
 //! Uses the private CloudKit database with a custom zone "RoteroSync".
 //! Each changeset batch is stored as a CKRecord of type "Changeset".
+//!
+//! # PDFs do not sync over this transport
+//!
+//! This moves the database only. The file transport
+//! ([`FileSyncEngine::export_pdf`](crate::sync::file_sync::FileSyncEngine::export_pdf)
+//! and its counterpart) has no CloudKit equivalent, so a device syncing over
+//! iCloud publishes every paper's metadata — `pdf_path` included — and none of
+//! the files those paths name. A peer therefore holds rows pointing at PDFs it
+//! can never obtain.
+//!
+//! This is a known gap, not an oversight: attachments here would mean CKAsset
+//! records with their own upload lifecycle, which is a separate piece of work
+//! from the shared-folder copy the file transport does. What matters is that it
+//! is no longer *silent* — the settings pane says so where the transport is
+//! chosen, because a sync that quietly moves half the library is worse than one
+//! that admits its limits.
 
 use rotero_db::Database;
 

--- a/src/sync/file_sync.rs
+++ b/src/sync/file_sync.rs
@@ -1153,7 +1153,10 @@ mod tests {
                 .map(|e| e.file_name().to_string_lossy().into_owned())
                 .filter(|n| *n != format!("{sha}.pdf"))
                 .collect();
-            assert!(strays.is_empty(), "stray temp files left behind: {strays:?}");
+            assert!(
+                strays.is_empty(),
+                "stray temp files left behind: {strays:?}"
+            );
         }
 
         /// A blob two papers share must survive one of them being deleted.
@@ -1268,7 +1271,10 @@ mod tests {
             }
 
             let escaped = dir.path().parent().unwrap().join("etc");
-            assert!(!escaped.exists(), "a malformed hash escaped the sync folder");
+            assert!(
+                !escaped.exists(),
+                "a malformed hash escaped the sync folder"
+            );
         }
     }
 

--- a/src/sync/file_sync.rs
+++ b/src/sync/file_sync.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 
 use rotero_db::Database;
 
+#[derive(Clone)]
 pub struct FileSyncEngine {
     sync_folder: PathBuf,
     site_id: Vec<u8>,
@@ -187,9 +188,39 @@ impl FileSyncEngine {
         Ok(stats.applied)
     }
 
-    pub fn export_pdf(&self, library_papers_dir: &Path, rel_path: &str) -> Result<(), String> {
+    /// Where a PDF with a given content hash lives in the shared folder.
+    ///
+    /// Addressed by content rather than by name. `pdf_path` is derived from
+    /// title, author and year, and its collision counter only ever sees one
+    /// device's disk — so two devices that add the same paper agree on a
+    /// filename while holding different bytes, and a name-addressed shared
+    /// folder silently serves one of them to both. A hash cannot collide that
+    /// way, and it makes an identical file stored once rather than per-paper.
+    fn shared_pdf_path(&self, sha256: &str) -> PathBuf {
+        self.sync_folder
+            .join("papers")
+            .join("by-hash")
+            .join(format!("{sha256}.pdf"))
+    }
+
+    /// Publish a paper's PDF into the shared folder, keyed by its content hash.
+    ///
+    /// A no-op when the local file is missing, when the blob is already
+    /// published, or when `sha256` is `None` — the last meaning the hash has not
+    /// been computed yet, which the backfill resolves. Publishing without one
+    /// would have to fall back to the name, which is the collision this exists
+    /// to prevent.
+    pub fn export_pdf(
+        &self,
+        library_papers_dir: &Path,
+        rel_path: &str,
+        sha256: Option<&str>,
+    ) -> Result<(), String> {
         let Some(safe) = safe_relative_path(rel_path) else {
             return Err(format!("Refusing to sync PDF at unsafe path {rel_path:?}"));
+        };
+        let Some(sha256) = sha256.filter(|h| is_sha256(h)) else {
+            return Ok(());
         };
 
         let src = library_papers_dir.join(&safe);
@@ -197,7 +228,7 @@ impl FileSyncEngine {
             return Ok(());
         }
 
-        let dest = self.sync_folder.join("papers").join(&safe);
+        let dest = self.shared_pdf_path(sha256);
         if dest.exists() {
             return Ok(());
         }
@@ -206,24 +237,56 @@ impl FileSyncEngine {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create sync papers dir: {e}"))?;
         }
-        std::fs::copy(&src, &dest).map_err(|e| format!("Failed to copy PDF to sync: {e}"))?;
+
+        // Read and write rather than `fs::copy`, so the bytes land through
+        // `write_atomic`. This directory is watched by a cloud daemon, and a
+        // peer that observes a half-written PDF keeps it forever — nothing ever
+        // re-copies over a destination that exists.
+        let bytes = std::fs::read(&src).map_err(|e| format!("Failed to read PDF: {e}"))?;
+        write_atomic(&dest, &bytes).map_err(|e| format!("Failed to copy PDF to sync: {e}"))?;
         Ok(())
     }
 
-    pub fn import_pdf(&self, library_papers_dir: &Path, rel_path: &str) -> Result<(), String> {
+    /// Fetch a paper's PDF out of the shared folder, verifying it first.
+    ///
+    /// The bytes are hashed before they are installed, so a partly-uploaded or
+    /// placeholder file is skipped for this tick rather than written into the
+    /// library — where, the destination now existing, nothing would ever correct
+    /// it. This is the same contract [`merge_peer`](Self::merge_peer) applies to
+    /// snapshots via their checksum sidecar.
+    ///
+    /// Also replaces a local file whose contents no longer match, which is how
+    /// an edited or re-scanned PDF reaches the other device at all.
+    pub fn import_pdf(
+        &self,
+        library_papers_dir: &Path,
+        rel_path: &str,
+        sha256: Option<&str>,
+    ) -> Result<(), String> {
         let Some(safe) = safe_relative_path(rel_path) else {
             return Err(format!(
                 "Refusing to import PDF at unsafe path {rel_path:?}"
             ));
         };
+        let Some(sha256) = sha256.filter(|h| is_sha256(h)) else {
+            return Ok(());
+        };
 
-        let src = self.sync_folder.join("papers").join(&safe);
-        if !src.exists() {
+        let dest = library_papers_dir.join(&safe);
+        if dest.exists() && file_hash(&dest).as_deref() == Some(sha256) {
             return Ok(());
         }
 
-        let dest = library_papers_dir.join(&safe);
-        if dest.exists() {
+        let src = self.shared_pdf_path(sha256);
+        let Ok(bytes) = std::fs::read(&src) else {
+            // Not published yet, or still arriving.
+            return Ok(());
+        };
+
+        if rotero_db::snapshot::checksum(&bytes) != sha256 {
+            // A blob under a hash-named path whose contents hash to something
+            // else is still uploading, or truncated. Skip it; the next tick
+            // sees the finished file.
             return Ok(());
         }
 
@@ -231,9 +294,45 @@ impl FileSyncEngine {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create local papers dir: {e}"))?;
         }
-        std::fs::copy(&src, &dest).map_err(|e| format!("Failed to import PDF from sync: {e}"))?;
+        write_atomic(&dest, &bytes).map_err(|e| format!("Failed to import PDF from sync: {e}"))?;
         Ok(())
     }
+
+    /// Remove a published blob no live paper points at any more.
+    ///
+    /// Called only from the tombstone reaper, which runs a long way past
+    /// [`peer_horizon`](Self::peer_horizon) and the TTL — so every device has
+    /// provably seen the deletion. Deliberately touches only the shared copy:
+    /// each device's own file is the user's data, and sync has no business
+    /// unlinking it.
+    pub fn reap_shared_pdf(&self, sha256: &str) -> Result<(), String> {
+        if !is_sha256(sha256) {
+            return Ok(());
+        }
+        let blob = self.shared_pdf_path(sha256);
+        match std::fs::remove_file(&blob) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("Failed to remove shared PDF: {e}")),
+        }
+    }
+}
+
+/// Whether a string is a well-formed SHA-256 digest.
+///
+/// The hash reaches here from a peer's snapshot, and it is used to build a
+/// filename. Checking the shape keeps anything that is not one — a path
+/// fragment, an empty string, a stray placeholder — from ever becoming a path
+/// component.
+fn is_sha256(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// The SHA-256 of a file, or `None` if it cannot be read.
+fn file_hash(path: &Path) -> Option<String> {
+    std::fs::read(path)
+        .ok()
+        .map(|b| rotero_db::snapshot::checksum(&b))
 }
 
 /// A peer-supplied path, accepted only if it stays inside the directory it is
@@ -752,6 +851,424 @@ mod tests {
                 2,
                 "a corrupt file must self-heal on the next export"
             );
+        }
+    }
+
+    /// PDF file transfer between two devices, through the real engine.
+    ///
+    /// The snapshot half of sync is covered by `two_device` above. These cover
+    /// the *files*, which travel by a separate path and had no end-to-end
+    /// coverage at all — only `safe_relative_path` and `write_atomic` were
+    /// tested, both in isolation and neither reached through `export_pdf` or
+    /// `import_pdf`.
+    mod pdf_transfer {
+        use super::*;
+        use rotero_db::Database;
+
+        /// Two devices, two libraries, one shared folder — with the papers
+        /// directories exposed, which `two_device::Pair` keeps private.
+        struct Pair {
+            ea: FileSyncEngine,
+            eb: FileSyncEngine,
+            shared: tempfile::TempDir,
+            da: tempfile::TempDir,
+            db: tempfile::TempDir,
+        }
+
+        impl Pair {
+            async fn new() -> Self {
+                let shared = tempfile::tempdir().unwrap();
+                let da = tempfile::tempdir().unwrap();
+                let db_dir = tempfile::tempdir().unwrap();
+                // The libraries are opened and dropped: they create the
+                // `papers/` directories these tests write into, which is all the
+                // file-transfer path needs from them.
+                Database::open(da.path().to_path_buf()).await.unwrap();
+                Database::open(db_dir.path().to_path_buf()).await.unwrap();
+                Self {
+                    ea: engine(shared.path(), 0xa1),
+                    eb: engine(shared.path(), 0xb2),
+                    shared,
+                    da,
+                    db: db_dir,
+                }
+            }
+
+            fn a_papers(&self) -> PathBuf {
+                self.da.path().join("papers")
+            }
+
+            fn b_papers(&self) -> PathBuf {
+                self.db.path().join("papers")
+            }
+
+            /// One PDF sync tick on both devices, as the sync loop drives it.
+            ///
+            /// Each device publishes the file it currently holds and then tries
+            /// to fetch the one its row names — which is what the loop does once
+            /// it reads `(pdf_path, pdf_sha256)` per paper.
+            fn sync_pdfs(&self, rel: &str) {
+                let a = file_hash(&self.a_papers().join(rel));
+                let b = file_hash(&self.b_papers().join(rel));
+                self.ea
+                    .export_pdf(&self.a_papers(), rel, a.as_deref())
+                    .unwrap();
+                self.eb
+                    .export_pdf(&self.b_papers(), rel, b.as_deref())
+                    .unwrap();
+                self.ea
+                    .import_pdf(&self.a_papers(), rel, a.as_deref())
+                    .unwrap();
+                self.eb
+                    .import_pdf(&self.b_papers(), rel, b.as_deref())
+                    .unwrap();
+            }
+
+            /// A tick after a row has synced: both devices name the same file.
+            fn sync_pdfs_agreeing_on(&self, rel: &str, sha256: &str) {
+                self.ea
+                    .export_pdf(&self.a_papers(), rel, Some(sha256))
+                    .unwrap();
+                self.eb
+                    .export_pdf(&self.b_papers(), rel, Some(sha256))
+                    .unwrap();
+                self.ea
+                    .import_pdf(&self.a_papers(), rel, Some(sha256))
+                    .unwrap();
+                self.eb
+                    .import_pdf(&self.b_papers(), rel, Some(sha256))
+                    .unwrap();
+            }
+        }
+
+        /// Write a PDF into a library's papers directory, as an import would.
+        fn place_pdf(papers_dir: &Path, rel: &str, body: &[u8]) {
+            let path = papers_dir.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let mut bytes = b"%PDF-1.7\n".to_vec();
+            bytes.extend_from_slice(body);
+            std::fs::write(&path, bytes).unwrap();
+        }
+
+        fn read_pdf(papers_dir: &Path, rel: &str) -> Vec<u8> {
+            std::fs::read(papers_dir.join(rel)).unwrap()
+        }
+
+        /// Two devices that add the same paper must not overwrite each other's
+        /// file.
+        ///
+        /// `import_pdf_bytes` derives the filename from `(year, title,
+        /// first_author)` alone, and its `while dest.exists()` counter only
+        /// looks at the *local* disk. Two devices that add the same paper
+        /// therefore both compute `2024/Same Paper - Author.pdf`. `export_pdf`
+        /// then skips when the shared destination exists, so the first device
+        /// to publish wins the slot and the second's bytes never leave. The
+        /// second device keeps its own copy, but a third device — and the
+        /// shared folder itself — hold the wrong document under that name, with
+        /// no error anywhere.
+        #[tokio::test]
+        async fn two_devices_adding_the_same_paper_do_not_overwrite_each_other() {
+            let p = Pair::new().await;
+            let rel = "2024/Same Paper - Author.pdf";
+
+            place_pdf(&p.a_papers(), rel, b"device A's copy");
+            place_pdf(&p.b_papers(), rel, b"device B's copy");
+
+            let a_bytes = read_pdf(&p.a_papers(), rel);
+            let b_bytes = read_pdf(&p.b_papers(), rel);
+
+            p.sync_pdfs(rel);
+
+            // Each device must still serve its own bytes.
+            assert_eq!(
+                read_pdf(&p.a_papers(), rel),
+                a_bytes,
+                "device A lost its own PDF"
+            );
+            assert_eq!(
+                read_pdf(&p.b_papers(), rel),
+                b_bytes,
+                "device B's PDF was replaced by A's"
+            );
+
+            // And both documents must be published, under separate names, so
+            // neither device's row resolves to the other's bytes.
+            for (label, bytes) in [("A", &a_bytes), ("B", &b_bytes)] {
+                let blob = p
+                    .shared
+                    .path()
+                    .join("papers")
+                    .join("by-hash")
+                    .join(format!("{}.pdf", rotero_db::snapshot::checksum(bytes)));
+                assert_eq!(
+                    std::fs::read(&blob).ok().as_ref(),
+                    Some(bytes),
+                    "device {label}'s PDF was not published under its own name"
+                );
+            }
+        }
+
+        /// A PDF replaced on one device must reach the other.
+        ///
+        /// Both transfer functions return early when the destination exists,
+        /// and `exists()` is their only idempotency check — no size, mtime, or
+        /// content comparison. Re-scanning a paper, flattening annotations, or
+        /// swapping in a better copy therefore never propagates.
+        #[tokio::test]
+        async fn a_pdf_replaced_on_one_device_reaches_the_other() {
+            let p = Pair::new().await;
+            let rel = "2024/Revised - Author.pdf";
+
+            place_pdf(&p.a_papers(), rel, b"first edition");
+            let first = file_hash(&p.a_papers().join(rel)).unwrap();
+            p.sync_pdfs_agreeing_on(rel, &first);
+            assert!(
+                read_pdf(&p.b_papers(), rel).ends_with(b"first edition"),
+                "the original must arrive first"
+            );
+
+            place_pdf(&p.a_papers(), rel, b"second edition, rescanned");
+            let second = file_hash(&p.a_papers().join(rel)).unwrap();
+            assert_ne!(first, second, "the replacement must hash differently");
+
+            // The row's hash now names the new bytes, as it would once A's
+            // metadata edit merged.
+            p.sync_pdfs_agreeing_on(rel, &second);
+
+            assert!(
+                read_pdf(&p.b_papers(), rel).ends_with(b"second edition, rescanned"),
+                "the replacement never reached device B"
+            );
+        }
+
+        /// A half-uploaded PDF must never be installed as if it were complete.
+        ///
+        /// Cloud providers expose partly-downloaded and zero-byte placeholder
+        /// files routinely — the snapshot path guards against exactly this with
+        /// a checksum sidecar, and says so. The PDF path has no such check, so
+        /// a truncated blob is copied in and then, because the local
+        /// destination exists, is never corrected.
+        #[tokio::test]
+        async fn a_truncated_shared_pdf_is_not_installed() {
+            let p = Pair::new().await;
+            let rel = "2024/Truncated - Author.pdf";
+
+            place_pdf(&p.a_papers(), rel, b"the complete document body");
+            let sha = file_hash(&p.a_papers().join(rel)).unwrap();
+            p.ea.export_pdf(&p.a_papers(), rel, Some(&sha)).unwrap();
+
+            // The shared copy is still uploading: truncate it.
+            let blob = p
+                .shared
+                .path()
+                .join("papers")
+                .join("by-hash")
+                .join(format!("{sha}.pdf"));
+            let full = std::fs::read(&blob).unwrap();
+            std::fs::write(&blob, &full[..full.len() / 2]).unwrap();
+
+            p.eb.import_pdf(&p.b_papers(), rel, Some(&sha)).unwrap();
+            assert!(
+                !p.b_papers().join(rel).exists(),
+                "a partly-written PDF must be skipped, not installed"
+            );
+
+            // Once the upload finishes, it must arrive.
+            std::fs::write(&blob, &full).unwrap();
+            p.eb.import_pdf(&p.b_papers(), rel, Some(&sha)).unwrap();
+            assert_eq!(
+                read_pdf(&p.b_papers(), rel),
+                full,
+                "the complete file must arrive once it lands"
+            );
+        }
+
+        /// A zero-byte placeholder must not become the library's copy.
+        ///
+        /// The same hazard as truncation, in the shape iCloud Drive actually
+        /// produces: the file exists and is readable, but holds nothing.
+        #[tokio::test]
+        async fn a_placeholder_shared_pdf_is_not_installed() {
+            let p = Pair::new().await;
+            let rel = "2024/Placeholder - Author.pdf";
+
+            // A blob whose name promises real content, holding nothing — what a
+            // not-yet-downloaded iCloud file looks like.
+            let sha = rotero_db::snapshot::checksum(b"%PDF-1.7\nthe real document");
+            let blob = p
+                .shared
+                .path()
+                .join("papers")
+                .join("by-hash")
+                .join(format!("{sha}.pdf"));
+            std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+            std::fs::write(&blob, b"").unwrap();
+
+            p.eb.import_pdf(&p.b_papers(), rel, Some(&sha)).unwrap();
+            assert!(
+                !p.b_papers().join(rel).exists(),
+                "an empty placeholder must not be installed as the PDF"
+            );
+        }
+
+        /// An exported PDF must appear at its final path complete, or not at
+        /// all.
+        ///
+        /// The shared folder is watched by a cloud daemon, and a peer that
+        /// observes a half-written PDF keeps it permanently — nothing ever
+        /// re-copies over an existing destination. Snapshots in this same file
+        /// go through `write_atomic` for precisely this reason.
+        ///
+        /// This asserts the *observable* contract — the destination, once
+        /// present, holds the whole file — rather than the mechanism. A
+        /// direct `fs::copy` satisfies it here because a single-threaded test
+        /// cannot catch the copy mid-flight; only a concurrent reader could,
+        /// and racing one would make the test flaky rather than sharper. It
+        /// is a regression guard on the outcome, and deliberately not
+        /// evidence that the write is atomic. What pins the atomicity is the
+        /// temp-file assertion below, once `export_pdf` routes through
+        /// `write_atomic`.
+        #[tokio::test]
+        async fn an_exported_pdf_is_complete_or_absent() {
+            let p = Pair::new().await;
+            let rel = "2024/Atomic - Author.pdf";
+            let body = vec![b'x'; 4096];
+
+            place_pdf(&p.a_papers(), rel, &body);
+            let sha = file_hash(&p.a_papers().join(rel)).unwrap();
+            p.ea.export_pdf(&p.a_papers(), rel, Some(&sha)).unwrap();
+
+            let dir = p.shared.path().join("papers").join("by-hash");
+            assert_eq!(
+                std::fs::read(dir.join(format!("{sha}.pdf"))).unwrap(),
+                read_pdf(&p.a_papers(), rel),
+                "the published copy must match the source byte for byte"
+            );
+
+            // No `.tmp` sibling may outlive the export, or the cloud daemon
+            // uploads a file that is never cleaned up.
+            let strays: Vec<String> = std::fs::read_dir(&dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| *n != format!("{sha}.pdf"))
+                .collect();
+            assert!(strays.is_empty(), "stray temp files left behind: {strays:?}");
+        }
+
+        /// A blob two papers share must survive one of them being deleted.
+        ///
+        /// Content addressing means one file can back several papers — a
+        /// deduplicated import, or the survivor of a merged duplicate. Reaping
+        /// on behalf of the deleted paper alone would strand the other, whose
+        /// row still points at that hash. This is the failure mode content
+        /// addressing introduces, so it is guarded directly.
+        #[tokio::test]
+        async fn a_blob_two_papers_share_is_not_orphaned_by_one_deletion() {
+            let dir = tempfile::tempdir().unwrap();
+            let db = Database::open(dir.path().to_path_buf()).await.unwrap();
+
+            let bytes = b"%PDF-1.7\nshared between two records";
+            let sha = rotero_db::snapshot::checksum(bytes);
+
+            let mut ids = Vec::new();
+            for title in ["First record", "Second record"] {
+                let id = db
+                    .insert_paper(&rotero_models::Paper {
+                        title: title.into(),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap();
+                db.update_pdf_path(&id, "2024/Shared - Author.pdf", Some(&sha))
+                    .await
+                    .unwrap();
+                ids.push(id);
+            }
+
+            db.delete_paper(&ids[0]).await.unwrap();
+
+            assert!(
+                db.orphaned_pdf_hashes().await.unwrap().is_empty(),
+                "a blob the surviving paper still points at must not be reapable"
+            );
+            assert_eq!(
+                db.count_live_papers_with_pdf_hash(&sha).await.unwrap(),
+                1,
+                "one live paper must still claim the hash"
+            );
+
+            // Once the last claimant goes, it becomes reapable.
+            db.delete_paper(&ids[1]).await.unwrap();
+            assert_eq!(
+                db.orphaned_pdf_hashes().await.unwrap(),
+                vec![sha],
+                "with no live paper left, the blob must be reapable"
+            );
+        }
+
+        /// Reaping removes the shared copy and leaves the local one alone.
+        ///
+        /// The shared folder is a transport, and letting it grow forever was the
+        /// old behaviour. The device's own PDF is not a transport — it is the
+        /// user's data — so a deletion that syncs must never unlink it. Only the
+        /// published copy goes.
+        #[tokio::test]
+        async fn reaping_a_blob_leaves_the_local_pdf_untouched() {
+            let p = Pair::new().await;
+            let rel = "2024/Doomed - Author.pdf";
+
+            place_pdf(&p.a_papers(), rel, b"about to be deleted");
+            let sha = file_hash(&p.a_papers().join(rel)).unwrap();
+            p.ea.export_pdf(&p.a_papers(), rel, Some(&sha)).unwrap();
+
+            let blob = p
+                .shared
+                .path()
+                .join("papers")
+                .join("by-hash")
+                .join(format!("{sha}.pdf"));
+            assert!(blob.exists(), "the blob must be published first");
+
+            p.ea.reap_shared_pdf(&sha).unwrap();
+
+            assert!(!blob.exists(), "the shared copy must be removed");
+            assert!(
+                p.a_papers().join(rel).exists(),
+                "the device's own PDF must never be unlinked by sync"
+            );
+
+            // Reaping again is not an error — the blob may already be gone,
+            // reaped by whichever device got there first.
+            p.ea.reap_shared_pdf(&sha).unwrap();
+        }
+
+        /// A hash that is not a hash must never become a path component.
+        ///
+        /// `pdf_sha256` arrives over sync, so it is whatever another device
+        /// wrote, and it is interpolated straight into a filename. The traversal
+        /// guard covers `pdf_path`; this covers the other peer-supplied string.
+        #[test]
+        fn a_malformed_hash_is_refused_rather_than_used_as_a_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let lib = tempfile::tempdir().unwrap();
+            let e = engine(dir.path(), 1);
+
+            for bad in [
+                "../../../etc/passwd",
+                "",
+                "nothex!!",
+                "abc",
+                &"f".repeat(63),
+                &"f".repeat(65),
+            ] {
+                e.export_pdf(lib.path(), "2024/x.pdf", Some(bad)).unwrap();
+                e.import_pdf(lib.path(), "2024/x.pdf", Some(bad)).unwrap();
+                e.reap_shared_pdf(bad).unwrap();
+            }
+
+            let escaped = dir.path().parent().unwrap().join("etc");
+            assert!(!escaped.exists(), "a malformed hash escaped the sync folder");
         }
     }
 

--- a/src/ui/import_export.rs
+++ b/src/ui/import_export.rs
@@ -133,13 +133,13 @@ fn ImportButton() -> Element {
                                                 if let (Some(bib_dir), Some(rel_pdf)) = (&bib_dir, &source_pdf) {
                                                     let pdf_abs = bib_dir.join(rel_pdf);
                                                     if pdf_abs.exists()
-                                                        && let Ok(rel_path) = db.import_pdf(
+                                                        && let Ok((rel_path, sha256)) = db.import_pdf(
                                                             pdf_abs.to_str().unwrap_or_default(),
                                                             Some(paper.title.as_str()),
                                                             author_names.first().map(|a| a.as_str()),
                                                             paper.year,
                                                         ) {
-                                                            let _ = db.update_pdf_path(&id, &rel_path).await;
+                                                            let _ = db.update_pdf_path(&id, &rel_path, Some(&sha256)).await;
                                                             paper.links.pdf_path = Some(rel_path);
                                                             pdfs_found += 1;
                                                         }
@@ -232,10 +232,10 @@ fn OaPromptDialog(papers: Vec<OaPending>) -> Element {
                                 oa_state.set(Some(OaState::Downloading { done: i + 1, total, downloaded }));
                                 let urls = crate::metadata::pdf_download::resolve_pdf_urls(p.pdf_url.as_deref(), p.doi.as_deref(), &p.title).await;
                                 if cancelled.load(Ordering::Relaxed) { break; }
-                                if let Ok(rel_path) = crate::metadata::pdf_download::download_and_save_pdf(
+                                if let Ok((rel_path, sha256)) = crate::metadata::pdf_download::download_and_save_pdf(
                                     &db, &urls, &p.title, p.first_author.as_deref(), p.year,
                                 ).await {
-                                    let _ = db.update_pdf_path(&p.id, &rel_path).await;
+                                    let _ = db.update_pdf_path(&p.id, &rel_path, Some(&sha256)).await;
                                     let pid = p.id.clone();
                                     lib_state.with_mut(|s| {
                                         if let Some(paper) = s.papers.iter_mut().find(|paper| paper.id.as_deref() == Some(pid.as_str())) {

--- a/src/ui/keybindings/desktop.rs
+++ b/src/ui/keybindings/desktop.rs
@@ -673,14 +673,14 @@ fn action_import_bibtex(db: Database, mut lib_state: Signal<LibraryState>) {
                         let pdf_abs = bib_dir.join(rel_pdf);
                         let author_names = paper.author_names();
                         if pdf_abs.exists()
-                            && let Ok(rel_path) = db.import_pdf(
+                            && let Ok((rel_path, sha256)) = db.import_pdf(
                                 pdf_abs.to_str().unwrap_or_default(),
                                 Some(paper.title.as_str()),
                                 author_names.first().map(|a| a.as_str()),
                                 paper.year,
                             )
                         {
-                            let _ = db.update_pdf_path(&id, &rel_path).await;
+                            let _ = db.update_pdf_path(&id, &rel_path, Some(&sha256)).await;
                             paper.links.pdf_path = Some(rel_path);
                         }
                     }

--- a/src/ui/library/add_paper.rs
+++ b/src/ui/library/add_paper.rs
@@ -31,7 +31,7 @@ pub(crate) fn AddPaperButtons() -> Element {
                                 .unwrap_or_else(|| "Untitled".to_string());
 
                             match db.import_pdf(&path_str, Some(&filename), None, None) {
-                                Ok(rel_path) => {
+                                Ok((rel_path, sha256)) => {
                                     let mut paper = rotero_models::Paper {
                                         title: filename,
                                         links: rotero_models::PaperLinks {
@@ -47,6 +47,13 @@ pub(crate) fn AddPaperButtons() -> Element {
 
                                     match db.insert_paper(&paper).await {
                                         Ok(id) => {
+                                            // The model carries no hash field, so
+                                            // record it right after the insert —
+                                            // a synced `pdf_path` without one
+                                            // cannot be published to peers.
+                                            let _ = db
+                                                .update_pdf_path(&id, &rel_path, Some(&sha256))
+                                                .await;
                                             paper.id = Some(id.clone());
                                             lib_state.with_mut(|s| s.papers.insert(0, paper));
                                             error_msg.set(None);

--- a/src/ui/library/panel.rs
+++ b/src/ui/library/panel.rs
@@ -290,7 +290,7 @@ pub fn LibraryPanel() -> Element {
                                     .unwrap_or_else(|| "Untitled".to_string());
 
                                 match db.import_pdf(&file_path_str, Some(&title), None, None) {
-                                    Ok(rel_path) => {
+                                    Ok((rel_path, sha256)) => {
                                         let mut paper = rotero_models::Paper {
                                             title,
                                             links: rotero_models::PaperLinks {
@@ -301,6 +301,12 @@ pub fn LibraryPanel() -> Element {
                                         };
                                         let paper_id = match db.insert_paper(&paper).await {
                                             Ok(id) => {
+                                                // The model carries no hash
+                                                // field; record it here so the
+                                                // synced path has one.
+                                                let _ = db
+                                                    .update_pdf_path(&id, &rel_path, Some(&sha256))
+                                                    .await;
                                                 paper.id = Some(id.clone());
                                                 lib_state.with_mut(|s| s.papers.insert(0, paper));
                                                 Some(id)

--- a/src/ui/paper_detail/detail.rs
+++ b/src/ui/paper_detail/detail.rs
@@ -290,9 +290,9 @@ pub fn PaperDetail() -> Element {
                                                 oa_statuses.with_mut(|m| { m.insert(paper_id.clone(), "Downloading...".into()); });
                                                 let first_author = authors.first().map(|a| a.as_str());
                                                 match crate::metadata::pdf_download::download_and_save_pdf(&db, &urls, &title, first_author, year).await {
-                                                    Ok(rel_path) => {
+                                                    Ok((rel_path, sha256)) => {
                                                         let pid = paper_id.clone();
-                                                        let _ = db.update_pdf_path(&pid, &rel_path).await;
+                                                        let _ = db.update_pdf_path(&pid, &rel_path, Some(&sha256)).await;
                                                         let pid2 = pid.clone();
                                                         lib_state.with_mut(|s| {
                                                             if let Some(p) = s.papers.iter_mut().find(|p| p.id.as_deref() == Some(pid2.as_str())) {

--- a/src/ui/settings/sync.rs
+++ b/src/ui/settings/sync.rs
@@ -101,6 +101,13 @@ pub fn SyncSection() -> Element {
                     p { class: "settings-hint",
                         "Syncs via your iCloud account. No setup needed."
                     }
+                    // Say so here rather than letting a user discover it by
+                    // opening a paper on another device and finding no file.
+                    p { class: "settings-hint",
+                        "PDF files are not copied over iCloud sync — only your \
+                         library metadata. Choose a shared folder to sync the \
+                         files themselves."
+                    }
                 } else {
                     PathField {
                         label: "Sync folder",


### PR DESCRIPTION
The snapshot half of per-device sync is well covered — a property harness, five
fixed bugs, a guard that forces every table to declare whether it syncs. PDFs
were deferred out of that pass, and they are the part that was actually broken.

The database syncs a `pdf_path` *string*. The file it names travelled by a
separate path with no hash, no integrity check, no atomicity, no deletion, and
an enumeration that covered only part of the library. Four bugs followed. Each
is pinned by a test that **fails on `master`** before any fix exists.

## The bugs

1. **Two devices adding the same paper served each other the wrong PDF.**
   The filename comes from `(year, title, first_author)` alone, and the
   `while dest.exists()` counter only ever sees one device's disk — so both
   compute `2024/Same Paper - Author.pdf`. `export_pdf` then skipped when the
   shared destination existed, so the first device to publish won the slot and
   the second's bytes never left. Both rows named one file. No error anywhere.

   `sanitize_filename` truncates titles to 80 chars, so two genuinely different
   papers sharing a long prefix collide the same way.

2. **A replaced PDF never propagated.** `exists()` was the only idempotency
   check — no size, mtime, or content comparison — so re-scanning a paper,
   flattening annotations, or swapping in a better copy reached nobody.

3. **A truncated or zero-byte blob was installed permanently.** Cloud providers
   hand out partly-downloaded and placeholder files routinely; the snapshot path
   guards against exactly this with a checksum sidecar and says so in its doc
   comment. The PDF path copied them in, and then never corrected them, because
   the destination now existed.

4. **PDFs synced only for the newest 500 papers.** The loop read
   `lib_state.papers`, which is `list_papers()` — a UI query with `LIMIT 500`.
   Past that cap the rest of the library was excluded in *both* directions. Both
   results were discarded with `let _ =`, so a failure looked identical to
   having nothing to do. It also ran before the post-merge refresh, so newly
   arrived papers were a tick behind.

## The fix

**Shared copies are addressed by content**: `papers/by-hash/<sha256>.pdf`,
carried by a new synced `papers.pdf_sha256` (schema v18). A hash cannot collide
the way a derived name can, it detects a changed file, it stores identical bytes
once, and it is the integrity check the transport never had.
`snapshot::checksum` already was this function and `sha2` was already a
dependency. The local layout is untouched and stays human-readable.

Chosen over keying by paper UUID: a UUID is unique and already synced, but it
still cannot tell that a file's *contents* changed, so it would fix bug 1 and
leave bug 2 alive.

Both directions now go through `write_atomic`, and an import verifies the bytes
before installing them — the same contract `merge_peer` already applies to
snapshots. A malformed hash is refused rather than used as a path component,
since it arrives from a peer exactly like `pdf_path` does.

**Deletion reaps with the tombstone, never on merge.** `reap_tombstones` already
runs only past `peer_horizon()` **and** a 180-day TTL, which is precisely the
proof that every device has seen the deletion. Because one blob can back several
papers — a deduplicated import, or a merged duplicate — a blob is reapable only
when no live paper anywhere names its hash. **The device's own file is never
unlinked**: that is the user's data, not transport.

**Libraries predating the column** keep their paths and are hashed by a
background backfill that drains in batches and stops when a pass makes no
progress, so a permanently-missing file cannot spin it. Recording a hash for an
unchanged file deliberately does *not* stamp the sync clock — it repairs an old
row rather than editing it, and stamping would let a backfill outrank a real
metadata edit on another device. That is the same mistake the previous pass made
by retiring tags with a stamped rename.

## Compatibility

`SnapshotRow.v` is keyed by column name and the merge reads
`values.get(col).unwrap_or(&Null)` against the local build's manifest. So a new
client reading an old snapshot writes `NULL` (meaning "backfill me"), and an old
client reading a new one ignores the extra key. Mixed-version devices
interoperate; `NewerSchema` only blocks a same-machine downgrade.

## Verification

Every fix is mutation-checked — the bug is reapplied and the test must fail with
the right diagnosis. Five mutations, five caught, each failing **only** the tests
that own it:

| Mutation | Caught by |
|---|---|
| Address the shared copy by name again | collision test |
| Restore first-write-wins on import | replaced-PDF test |
| Skip verification of fetched bytes | both integrity tests |
| Drop the `NOT IN papers_live` refcount | dedup test |
| Stamp the clock on backfill | the repair-vs-edit pair |

The clock pair is checked in both directions, so it distinguishes a repair from
an edit rather than asserting only one half.

**385/385**, excluding `rotero-translate`'s import tests which need an
uninitialized `vendor/translators` submodule (pre-existing, unrelated).
`just proptest-deep` green in ~217s. Clippy clean with `--all-targets -D
warnings`.

## Scoped out, deliberately

**CloudKit syncs no PDFs at all** — it moves the database only, and always has.
Fixing that means CKAssets with their own upload lifecycle, which is separate
work from the shared-folder copy. What changes here is that it is no longer
*silent*: the gap is documented in the module and stated in the settings pane
where the transport is chosen.

**Per-row LWW is unchanged.** `pdf_sha256` lives in the `papers` row, so
attaching a PDF on one device while editing the title on another still loses one
of the two. That predates this work and fixing it means per-column clocks —
recorded so the new column is not later blamed for it.

## Notes for review

- `export_pdf`/`import_pdf` live in the app crate, so the transport tests extend
  the inline `mod two_device` harness rather than `crates/rotero-db/tests/`.
- The MCP server turned out to be a **third** independent PDF write path
  (`server/tools.rs`), with its own naming scheme and its own `fs::write`. It
  hashes now too.
- The `soft_delete_guard_test` allowlist caught the new orphan query reading
  `papers` rather than `papers_live`. That read is deliberate — tombstones are
  the only record of which hash a deleted paper named — so it is allowlisted
  with a reason, which is what the allowlist exists for.
- One test is deliberately **not** claimed as proof of atomicity: `fs::copy`
  leaves no temp file either, and a single-threaded test cannot observe a
  partially-copied destination. It asserts the observable contract and its doc
  comment says exactly that, rather than implying coverage it does not have.
