### PR TITLE
Scale the proptest case timeout with the budget it runs under

### DIFF
--- a/crates/rotero-db/tests/common/sync_model.rs
+++ b/crates/rotero-db/tests/common/sync_model.rs
@@ -186,6 +186,14 @@ pub struct Budget {
     pub events: std::ops::RangeInclusive<usize>,
     /// The ceiling on papers, which is what actually bounds the runtime.
     pub max_papers: usize,
+    /// How long one generated scenario may take before it is called
+    /// pathological, in milliseconds.
+    ///
+    /// Part of the budget rather than a constant beside it: a heavy case runs up
+    /// to four devices over twenty-four events, so it is several times the work
+    /// of a default one and cannot share the same ceiling. A single number for
+    /// both tiers is only ever right for one of them.
+    pub case_timeout_ms: u32,
 }
 
 /// The active budget.
@@ -200,12 +208,20 @@ pub fn budget() -> Budget {
             devices: 2..=4,
             events: 8..=24,
             max_papers: 16,
+            case_timeout_ms: 300_000,
         },
         _ => Budget {
             cases: 48,
             devices: 2..=3,
             events: 4..=14,
             max_papers: 12,
+            // Generous against the observed worst case rather than tight around
+            // it. This exists to stop a pathological scenario holding CI open,
+            // not to police performance: a case that is merely slow is a slow
+            // case, and failing it teaches nobody anything. Windows runners are
+            // roughly 2.5x slower than macOS here, and a 30s ceiling turned that
+            // into a red build the first time a column was added to `papers`.
+            case_timeout_ms: 120_000,
         },
     }
 }

--- a/crates/rotero-db/tests/sync_props.rs
+++ b/crates/rotero-db/tests/sync_props.rs
@@ -31,8 +31,10 @@ fn config() -> ProptestConfig {
         // ceiling costs nothing on a green run.
         max_shrink_iters: 2048,
         // A generated scenario that somehow becomes pathological should fail
-        // loudly rather than hold a CI job open.
-        timeout: 30_000,
+        // loudly rather than hold a CI job open. Scaled with the budget: the
+        // heavy tier's cases are several times the work of the default tier's,
+        // so one fixed ceiling cannot suit both.
+        timeout: budget().case_timeout_ms,
         ..ProptestConfig::default()
     }
 }


### PR DESCRIPTION
`master` has been red on **`Check Windows`** since #27. The two sync property
tests fail with:

```
Test failed: Timeout of 30000 ms exceeded: test took 40712 ms.
```

Not a wrong answer — a slow one. Windows runners are roughly 2.5× slower than
macOS here, and #27 added `pdf_sha256` to `papers`, which widens every row in
every snapshot the harness exchanges. That was enough to cross a ceiling the
sync-property pass had already flagged as tight (*"Windows CI runs ~2.5× slower
here"*).

**This is a latent flake, not a regression.** `Check Windows` *did* run on #27
and passed — the same two tests took **over 180 seconds each** there and were
fine, because the 30s ceiling bounds a single generated *case*, not the test.
The PR run happened to have no individual case cross 30s; the master run did.
Identical code, opposite outcome, decided by runner variance. The margin has
been thin for a while and #27's extra column was what finally exposed it.

## The actual defect

The ceiling never scaled with the work it was bounding.

| | default | `ROTERO_PROPTEST=heavy` |
|---|---|---|
| devices | 2..=3 | 2..=**4** |
| events | 4..=14 | 8..=**24** |
| max papers | 12 | **16** |
| **case timeout** | **30s** | **30s** |

A heavy case is several times the work of a default one, and both shared one
hardcoded number. That number is only ever right for one of them.

So it moves into `Budget`, beside the knobs that determine the cost: **120s**
default, **300s** heavy.

The values are generous against the observed worst case rather than tight around
it. This ceiling exists to stop a *pathological* scenario holding CI open, not to
police performance — a case that is merely slow is a slow case, and failing the
build over it teaches nobody anything.

Nothing else bounds these tests, so the ceiling is the only backstop and can
afford to be loose: there is no `.config/nextest.toml`, so nextest's
`slow-timeout` only warns (the `SLOW >60s` lines in the log are not kills), and
no CI job sets `timeout-minutes`.

## What this deliberately does *not* do

**Shrink the tier.** The obvious alternative is fewer cases or fewer events. The
harness found five bugs on shipped code, and one more in the per-column merge
currently being written — making it generate less would trade real coverage for
a green tick.

## Verification

- Set the ceiling to `1ms`: both tests fail immediately. This **raises** the
  limit, it does not remove it.
- 385/385 locally. The four `rotero-translate` import tests need an
  uninitialized `vendor/translators` submodule; CI populates it.
- Runtime is unchanged — this only raises a limit.

## Unrelated, and not fixed here

The same run also fails **`Bundle smoke (macOS)`**, for a reason outside this
repository. `cargo binstall dioxus-cli` finds no prebuilt binary, falls back to
building from source, and hits:

```
error[E0599]: no associated function or constant named `credential_helper`
              found for struct `Cred` in the current scope
```

That is `git2`/libgit2 API drift inside the Dioxus CLI's own dependency tree.
Nothing here causes or fixes it, so it is left alone rather than papered over.

For completeness: **#26 was also red**, on a third and different job (`Website`,
a timeout). `master` has been failing for three commits with three unrelated
causes; this PR addresses the one that is ours.
