### PR TITLE
Authenticate binstall so it finds the dioxus-cli binary that exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,16 @@ jobs:
           cache-on-failure: true
       - uses: cargo-bins/cargo-binstall@b629f84e79e8fbc4f76616a8efd340f3ea605cab # v1.21.1
       - name: Install Dioxus CLI
+        # binstall asks the GitHub API whether a prebuilt `dx` exists for this
+        # target. Unauthenticated, that request shares a per-IP rate limit with
+        # every other runner, and binstall reads the resulting 403 as "no
+        # prebuilt binary available" rather than as a failure -- so it silently
+        # falls back to `cargo install`, which currently cannot compile
+        # dioxus-cli at all (git2 dropped `Cred::credential_helper`). The token
+        # lifts the rate limit, so the artifact that has been published all
+        # along is actually found.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
       - name: Cache PDFium
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ jobs:
       # itself — and repeated in all three build jobs.
       - uses: cargo-bins/cargo-binstall@b629f84e79e8fbc4f76616a8efd340f3ea605cab # v1.21.1
       - name: Install Dioxus CLI
+        # binstall asks the GitHub API whether a prebuilt `dx` exists for this
+        # target. Unauthenticated, that request shares a per-IP rate limit with
+        # every other runner, and binstall reads the resulting 403 as "no
+        # prebuilt binary available" rather than as a failure -- so it silently
+        # falls back to `cargo install`, which currently cannot compile
+        # dioxus-cli at all (git2 dropped `Cred::credential_helper`). The token
+        # lifts the rate limit, so the artifact that has been published all
+        # along is actually found.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
       - name: Download PDFium
@@ -130,6 +140,16 @@ jobs:
       # itself — and repeated in all three build jobs.
       - uses: cargo-bins/cargo-binstall@b629f84e79e8fbc4f76616a8efd340f3ea605cab # v1.21.1
       - name: Install Dioxus CLI
+        # binstall asks the GitHub API whether a prebuilt `dx` exists for this
+        # target. Unauthenticated, that request shares a per-IP rate limit with
+        # every other runner, and binstall reads the resulting 403 as "no
+        # prebuilt binary available" rather than as a failure -- so it silently
+        # falls back to `cargo install`, which currently cannot compile
+        # dioxus-cli at all (git2 dropped `Cred::credential_helper`). The token
+        # lifts the rate limit, so the artifact that has been published all
+        # along is actually found.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
       - name: Download PDFium
@@ -193,6 +213,16 @@ jobs:
       # itself — and repeated in all three build jobs.
       - uses: cargo-bins/cargo-binstall@b629f84e79e8fbc4f76616a8efd340f3ea605cab # v1.21.1
       - name: Install Dioxus CLI
+        # binstall asks the GitHub API whether a prebuilt `dx` exists for this
+        # target. Unauthenticated, that request shares a per-IP rate limit with
+        # every other runner, and binstall reads the resulting 403 as "no
+        # prebuilt binary available" rather than as a failure -- so it silently
+        # falls back to `cargo install`, which currently cannot compile
+        # dioxus-cli at all (git2 dropped `Cred::credential_helper`). The token
+        # lifts the rate limit, so the artifact that has been published all
+        # along is actually found.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
       - name: Download PDFium


### PR DESCRIPTION
`Bundle smoke (macOS)` failed on master at #27 with what looks like upstream breakage:

```
error[E0599]: no associated function or constant named `credential_helper`
              found for struct `Cred` in the current scope
error: failed to compile `dioxus-cli v0.7.10`
```

I reported it that way at the time. **It isn't upstream's fault, and it's a release risk.**

## What's actually happening

Nothing should be compiling `dioxus-cli` at all. The point of `cargo binstall` here is to *download* a prebuilt `dx`, and `dx-aarch64-apple-darwin.zip` has been attached to the v0.7.10 release since it shipped — I checked, it's there.

Two minutes before the compile error, the log says:

```
has_release_artifact{...artifact_name="dx-aarch64-apple-darwin.zip"}:
  Received status code 403 Forbidden, will wait for 120s and retry
```

binstall asks the GitHub API whether the artifact exists. That request carried no credentials, so it shared the per-IP rate limit with every other runner on the host and got a **403**. binstall reads "I couldn't ask" as "there is no prebuilt binary", falls back to `cargo install`, and *there* meets a real `git2` API break.

The compile error is a symptom two steps removed from the cause.

## Why this is worth fixing now rather than later

**All three release build jobs make the same unauthenticated call.** A rate-limited tag build fails the release exactly this way — after the tag is already pushed.

The failure is intermittent by nature: the same call succeeded on the very next master run, which is why master is green again without anyone touching it. That's what makes it worth removing rather than waiting to be surprised by it during a release.

## The fix

Pass `GITHUB_TOKEN` to the four `binstall` steps (1 in CI, 3 in release). The token lifts the rate limit, the artifact is found, and the source fallback is never reached.

## Deliberately not done

**Pinning a different dioxus-cli version.** 0.7.10 is the current release, and the source fallback would be equally broken for whatever replaced it. The fallback shouldn't be reached at all — that's the bug.

## Verification

The smoke job is gated on `master` or a `bundle-smoke` label, so this PR carries the label to actually exercise the path it changes.
