### PR TITLE
Release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## v0.2.4
+
+Sync was rebuilt. v0.2.3 fixed the sync bugs that were known; this release replaces the mechanism that kept producing them, then goes looking for the ones nobody had found — by generating multi-device schedules at random and running them against real databases. That search found six more bugs in shipped code, three of which could stop a device syncing permanently.
+
+PDFs now sync by their contents rather than by a filename built from the title, which fixes a case where two devices could quietly serve each other the wrong file.
+
+Conversations with the AI assistant are now attached to the paper, collection, or group of papers they are about, instead of sitting in one flat list. And you can finally rename a paper.
+
+Upgrading migrates the library through several schema versions. It happens once, on first launch, and older versions of Rotero will not open the library afterwards.
+
+### Added
+- **Conversations belong to what they are about.** A chat about a paper is reachable from that paper; opening the paper resumes it. Select several papers and ask about the set. The paper detail panel lists the conversations a paper appears in, beside its notes, and the graph gains a **Chats** mode linking papers discussed together. The chat panel follows what you are reading — but only while it is idle, so it never switches out from under a reply in progress.
+- **Rename a paper.** The title was read-only everywhere in the app: metadata enrichment, the browser connector, and the AI assistant could all rewrite it, but you could not. Click the title in the detail panel, or use Rename in the library context menu.
+
+### Fixed
+
+**Sync**
+- **The wrong PDF could be served for a paper.** Shared PDFs were stored under a filename built from year, title, and first author, so two devices adding the same paper — or two different papers sharing a long title prefix — collided on one file. The first device to write it won; the second silently skipped, and both papers then pointed at the same PDF. Files are now identified by their contents.
+- **A replaced PDF never reached other devices.** Whether a file needed sending was decided by whether a file of that name already existed, so re-scanning a paper or flattening annotations changed nothing anywhere else.
+- **A partly-downloaded or zero-byte PDF could be installed permanently.** Cloud storage hands those out routinely, and nothing checked that a file arrived intact — nor reconsidered it afterwards, because the destination existed. Transfers are now verified before being installed.
+- **Only the 500 most recently added papers ever synced their PDFs.** Past that cap the rest of the library was excluded in both directions.
+- **PDF transfer failures were discarded entirely** — no log, no message, nothing in the interface. They are now reported with other sync failures.
+- **Removing a paper from a tag or collection never propagated, and undid itself.** The removal was recorded in the wrong order, so nothing was sent to other devices, and the next sync restored what had been removed on the device that removed it.
+- **A second deleted tag could halt sync permanently.** Deleted tags shared one placeholder name under a uniqueness constraint, so the second to arrive failed — and a failed merge abandons the whole batch, so nothing from that device was accepted again.
+- **A tag deleted and then recreated by name could halt sync the same way.** The name was still held by the deleted row, which nothing was looking at.
+- **Deleting a tag or collection left its memberships behind on other devices.** Both operations documented a cascade they never performed. Locally the leftovers were invisible, which is why this went unnoticed; a peer still held the membership.
+- **Favouriting or marking a paper read through the AI assistant never left the machine** — and a peer's stale value would win the next merge and silently revert it. The assistant kept its own duplicate copy of every write; there is now one implementation shared with the app.
+- **A deleted paper could come back, one annotation at a time.** Deletions left nothing to publish, so a device still holding the row treated its own copy as news.
+- **Re-adding a tag you had removed silently did nothing.**
+- **One unreadable file from one device stopped every other device's changes from arriving.** A peer that cannot be read, verified, or parsed is now skipped rather than aborting the whole pass, and a half-uploaded snapshot is no longer merged.
+- **Clock skew of a few seconds between machines could bury a write.** Six places recorded change times; only one guarded against writing a time a peer had already passed. Such a write looked successful locally while already having lost.
+- Rotero re-uploaded the whole library every 30 seconds while you read. It now uploads only when something changed.
+
+**A library could be left missing a column it reported having.** One migration was skipped on libraries already at a particular version while still being stamped as complete, so the library reported itself up to date and every query touching that column failed. An older migration dropped `item_type` immediately after adding it. Both repair themselves on open.
+
+**The AI assistant**
+- **Every past conversation was listed as "/model", then as "Untitled chat".** Two separate causes: the list was reading the agent's own title for a synthetic startup message, and stored summaries were being written by an update that raced the row's creation and usually lost.
+- **Every paper showed another paper's conversations and notes** — in practice, every paper in the library appearing to share one chat. Both sections read the paper once and kept the copy, and the detail panel reuses the component when you change selection.
+- **One conversation appeared on every paper's detail panel.** Searching the library linked every paper the search returned to the conversation, as though the chat were about all of them.
+- **Every launch left an empty conversation behind.** One real library had eight rows for three actual conversations. The leftovers are cleared out on upgrade.
+- **A summary requested while a reply was still streaming was silently dropped.**
+- **Streamed replies could render as broken markdown** — headings falling back to body text, table rows running together — depending on where the network split the response, so which parts broke varied from reply to reply.
+
+### Changed
+- Deleted PDFs are cleaned out of the shared folder once every device has seen the deletion. Your own local copy is never removed.
+- iCloud sync transfers metadata only, not PDFs. That was already true and silent; the settings pane now says so.
+- 389 tests, up from 267.
+
+### Known limitations
+- **Two devices editing different fields of the same paper within one sync window will lose one of the edits.** Merging judges a whole paper at once, so the later write wins every field, including ones it did not change. Background work such as citation-count fetches and metadata extraction rewrites papers on its own schedule, which is usually what triggers this.
+- **Conversations do not sync between devices.** They are tied to the machine that created them.
+- **iCloud sync is untested against the real service and remains off by default.**
+- A device left offline for more than 180 days can restore data the others have finished deleting.
+
 ## v0.2.3
 
 If you run Rotero on more than one machine, this is the important one. Several bugs meant a device could stop syncing entirely — silently, while reporting success — and that tags, notes, and merged papers could be lost between devices. All of them are fixed, and libraries damaged by earlier versions repair themselves on first launch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,7 +6521,7 @@ checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "rotero"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "apple-utils",
  "arboard",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-bib"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "biblatex",
  "chrono",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-connector"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "axum",
  "chrono",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-db"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "flate2",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-graph"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "rotero-models",
  "serde",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-models"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "serde",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-pdf"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64 0.23.1",
  "image",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-search"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-translate"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "boa_engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
Changelog, version bump, and lockfile for **v0.2.4**. No code changes — same three-file shape as the v0.2.3 release commit.

Twelve commits since v0.2.3, dominated by the sync rewrite. `recrr` is replaced by per-device snapshot files, and a proptest harness that generates multi-device schedules found six more bugs in shipped code — three of which halted sync permanently, one of which blanked real tag names.

## Reading the changelog

I wrote it around what a user would actually notice, so several large internal commits (#22 turso pin, #25 sync-status manifest, #26 DDL extraction, #28 proptest timeout) produce no changelog lines at all. The sync rewrite (#21) is likewise mostly invisible, but carries a number of real user-facing fixes that *are* listed.

Two claims I checked rather than took from the commit messages:

- **The iCloud PDF disclosure** is real — `src/ui/settings/sync.rs:107`.
- **Empty conversations are cleared on upgrade** — it's a migration, `schema/migrations.rs:377`.

One thing I deliberately did **not** repeat: `bb40391`'s rationale explains the title-only write as protecting a peer's newer DOI "when the CRR clocks merge". #21 removed per-column clocks, so that reasoning no longer holds and would be misleading in release notes.

## Known limitations section

This release adds one. Per-row merging means **two devices editing different fields of the same paper within one sync window lose one of the edits** — and background work (citation counts, metadata extraction) rewrites papers on its own schedule, so it isn't a contrived race.

There is a complete, verified fix for this on `worktree-per-column-lww` (schema v19, per-column clocks, 1287 lines). **It is not in this release**, because it forked at `0d8cb12` and needs rebasing over #28 — which touches the same two test files — and has never run through CI. Shipping it would mean rebasing, resolving, and reviewing a change of that size against a tag that is otherwise ready. Better as the first thing in v0.2.5.

If you'd rather hold the release for it, say so and I'll rebase it instead — the changelog would then lose that limitation and gain a headline fix.

## Migration

v13 → v18 on first launch. Older Rotero versions will not open the library afterwards, which the changelog states up front.

## Note on release safety

Tagging runs the release workflow, whose three build jobs each call `cargo binstall dioxus-cli`. That call is intermittently rate-limited into a broken source build — see #29, which should merge **before** this is tagged.
