### PR TITLE
Gate the release on the same test run CI enforces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
-      - run: cargo test --workspace
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --workspace
 
   build-macos:
     name: Build macOS


### PR DESCRIPTION
The release workflow's Test job was byte-identical to CI's Linux Test job except for its last line:

| | CI Linux Test | Release Test |
|---|---|---|
| runner | `ubuntu-latest` | `ubuntu-latest` |
| checkout | `submodules: recursive` | `submodules: recursive` |
| system deps | same four packages | same four packages |
| install | `taiki-e/install-action@nextest` | — |
| run | `cargo nextest run --workspace` | `cargo test --workspace` |

CI moved to nextest in #21. This job didn't.

## Why it matters

The job standing between a pushed tag and three published installers was not the job that had been proving master green all along. Two harnesses, two sets of results, nobody comparing them.

nextest runs each test in its own process. A test that passes under `cargo test`'s shared-process model and fails under isolation — or the reverse — would surface **only here**, at the one moment when the tag is already public and the fix means moving a published tag.

The ~90s → ~13s speedup is the least interesting part.

## Why not `just test`

It is the same command, so this looks like the obvious place to call the justfile. It isn't:

`setup-nextest` installs nextest through `cargo binstall`, and a justfile cannot see `secrets.GITHUB_TOKEN`. That is precisely the unauthenticated GitHub API call #29 just removed from this workflow — a 403 from the shared per-IP rate limit reads as "no prebuilt binary" and silently degrades to a source build. Routing the release gate through `just` would reintroduce it.

`taiki-e/install-action@nextest` is what CI uses and what this now uses: cached, authenticated, and not one rate limit away from compiling from source.

Two further reasons the workflows don't just call `just`, for the record:

- The macOS and Windows CI jobs deliberately split `--no-run` from the test run so clippy and codegen don't build the workspace twice. `just test` is one opaque step.
- `engine_or_skip` in `crates/rotero-pdf/tests/links.rs` panics only when `PDFIUM_DYNAMIC_LIB_PATH` is set, keyed that way *because* "the Linux and Windows jobs do not [provision it]". Running `just test` on Linux would set it and change which jobs are expected to have PDFium — a deliberate design, not drift.

## Not in scope

The three inline PDFium blocks duplicate `setup-pdfium`, including the Windows `bin/`-vs-`lib/` subtlety. They agree with the recipe today, so that is drift risk rather than a bug, and I did not fold it into a release-gate fix.

## Context

`v0.2.4` is tagged but **not released** — I cancelled the in-flight run in the Test gate, before any artifact was built or published. Once this merges I'll move the tag to include it and re-run.
