### PR TITLE
Download PDFium from the recipe that already knows how

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,19 +200,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: lib
-          # Keyed on the workflow too: the download URL lives here, not in the
-          # justfile, so a version change there would otherwise reuse a stale binary.
-          key: pdfium-macos-${{ hashFiles('justfile', '.github/workflows/ci.yml') }}
+          # The download URL lives in the justfile, so its hash alone tracks a
+          # version change; a stale binary cannot outlive an edit to the recipe.
+          key: pdfium-macos-${{ hashFiles('justfile') }}
+      - uses: taiki-e/install-action@just
       - name: Download PDFium
-        run: |
-          mkdir -p lib
-          if [ ! -f lib/libpdfium.dylib ]; then
-            TMP=$(mktemp -d)
-            curl -sL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-arm64.tgz" -o "$TMP/pdfium.tgz"
-            tar -xzf "$TMP/pdfium.tgz" -C "$TMP"
-            cp "$TMP/lib/libpdfium.dylib" lib/libpdfium.dylib
-            rm -rf "$TMP"
-          fi
+        run: just setup-pdfium
       - uses: taiki-e/install-action@nextest
       # `clippy --all-targets` and the test build cannot share artifacts —
       # clippy stops at metadata while tests need real codegen. Same ordering as
@@ -267,17 +260,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: lib
-          key: pdfium-macos-${{ hashFiles('justfile', '.github/workflows/ci.yml') }}
+          key: pdfium-macos-${{ hashFiles('justfile') }}
+      - uses: taiki-e/install-action@just
       - name: Download PDFium
-        run: |
-          mkdir -p lib
-          if [ ! -f lib/libpdfium.dylib ]; then
-            TMP=$(mktemp -d)
-            curl -sL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-arm64.tgz" -o "$TMP/pdfium.tgz"
-            tar -xzf "$TMP/pdfium.tgz" -C "$TMP"
-            cp "$TMP/lib/libpdfium.dylib" lib/libpdfium.dylib
-            rm -rf "$TMP"
-          fi
+        run: just setup-pdfium
       - name: Bundle
         run: PDFIUM_DYNAMIC_LIB_PATH="$PWD/lib" dx bundle --release
       # Mirrors release.yml: PDFium ships beside the executable, where the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
+      - uses: taiki-e/install-action@just
       - name: Download PDFium
-        run: |
-          mkdir -p lib
-          TMP=$(mktemp -d)
-          curl -sL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-arm64.tgz" -o "$TMP/pdfium.tgz"
-          tar -xzf "$TMP/pdfium.tgz" -C "$TMP"
-          cp "$TMP/lib/libpdfium.dylib" lib/libpdfium.dylib
-          rm -rf "$TMP"
+        run: just setup-pdfium
 
       - name: Bundle app
         run: PDFIUM_DYNAMIC_LIB_PATH="$PWD/lib" dx bundle --release
@@ -153,16 +148,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
+      - uses: taiki-e/install-action@just
       - name: Download PDFium
         shell: bash
-        run: |
-          mkdir -p lib
-          TMP=$(mktemp -d)
-          curl -sL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-win-x64.tgz" -o "$TMP/pdfium.tgz"
-          tar -xzf "$TMP/pdfium.tgz" -C "$TMP"
-          # Windows ships the DLL under bin/; lib/ holds only the import library.
-          cp "$TMP/bin/pdfium.dll" lib/pdfium.dll
-          rm -rf "$TMP"
+        run: just setup-pdfium
 
       - name: Build
         shell: bash
@@ -226,14 +215,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo binstall dioxus-cli --version 0.7.10 -y --force
 
+      - uses: taiki-e/install-action@just
       - name: Download PDFium
-        run: |
-          mkdir -p lib
-          TMP=$(mktemp -d)
-          curl -sL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz" -o "$TMP/pdfium.tgz"
-          tar -xzf "$TMP/pdfium.tgz" -C "$TMP"
-          cp "$TMP/lib/libpdfium.so" lib/libpdfium.so
-          rm -rf "$TMP"
+        run: just setup-pdfium
 
       - name: Build
         run: PDFIUM_DYNAMIC_LIB_PATH="$PWD/lib" dx bundle --release --package-types deb


### PR DESCRIPTION
Follow-up to #31, which noted this as the next thing likely to drift.

Five inline blocks across the two workflows re-implemented `setup-pdfium`:

| Workflow | Job | Platform |
|---|---|---|
| `ci.yml` | Test macOS | macOS arm64 |
| `ci.yml` | Bundle smoke | macOS arm64 |
| `release.yml` | Build macOS | macOS arm64 |
| `release.yml` | Build Windows | Windows x64 |
| `release.yml` | Build Linux | Linux x64 |

Each carried its own hardcoded URL, its own archive layout, and its own copy of the detail that **Windows ships the DLL under `bin/`** while every other platform uses `lib/`.

## What this does and doesn't fix

They agreed with the recipe, so **this fixes no bug today**. It removes the opportunity for one.

Seven `pdfium-binaries` URLs now live in exactly one place. Before, a version bump meant editing four files and hoping. The Windows `bin/` special case is precisely the kind of thing that gets fixed in one copy and not another — and that failure mode is a DLL that is *present but wrong*, surfacing at bundle time rather than at the edit.

```
$ grep -c 'pdfium-binaries' .github/workflows/ci.yml .github/workflows/release.yml justfile
.github/workflows/ci.yml:0
.github/workflows/release.yml:0
justfile:7
```

## Why `just` here, when #31 rejected it for tests

Worth being explicit, since these look contradictory.

`just test` was rejected in #31 because `setup-nextest` shells out to `cargo binstall`, and a justfile cannot see `secrets.GITHUB_TOKEN` — that is exactly the unauthenticated call #29 removed from this workflow.

**`setup-pdfium` has no such dependency.** It is `curl` and `tar` against a public release, so the recipe and a workflow step do the same thing with the same failure modes. The reason not to use `just` there simply does not apply here.

`just` itself is installed with `taiki-e/install-action@just` — the same action already used for nextest, a prebuilt from GitHub Releases, seconds per job, no compilation.

## Details worth flagging

- **The Windows step keeps `shell: bash`.** That selects the shell for the *step*; the default there is PowerShell. What `just` runs internally is the recipe's own shebang either way.
- **The CI cache key drops the workflow hash.** Its comment justified hashing `ci.yml` "because the download URL lives here, not in the justfile" — now false. Keying on the justfile alone also stops an unrelated edit to `ci.yml` from evicting a good 7 MB binary.

## Verification

Ran the recipe on a clean tree (no `lib/`):

- downloads to the same `lib/libpdfium.dylib` the removed blocks wrote
- `file` reports `Mach-O 64-bit dynamically linked shared library arm64`
- a second run short-circuits — the behaviour the `actions/cache` path depends on
- **`rotero-pdf`: 6 tests run, 6 passed, 0 skipped**

That last one is the one that matters. `engine_or_skip` silently returns when PDFium is missing, so a green run proves nothing by itself — the three `links` tests passing rather than skipping is what shows the library was actually bound.

Carries the `bundle-smoke` label so the macOS bundle path this touches is exercised here rather than discovered on master.
