### PR TITLE
Offer an update on the one error that asks for one, and release v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,7 +6521,7 @@ checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "rotero"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "apple-utils",
  "arboard",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-bib"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "biblatex",
  "chrono",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-connector"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "chrono",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-db"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "flate2",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-graph"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "rotero-models",
  "serde",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-mcp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-models"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "serde",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-pdf"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "image",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-search"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "rotero-translate"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "boa_engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 

--- a/crates/rotero-db/src/lib.rs
+++ b/crates/rotero-db/src/lib.rs
@@ -42,6 +42,8 @@ pub mod sync_test_helpers;
 /// Tag CRUD and paper-tag membership.
 pub mod tags;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 pub use rotero_models::queries;
 
 // Re-export so the app crate doesn't need a direct turso dependency.
@@ -60,6 +62,22 @@ pub enum DbError {
 
 /// Convenience alias for results in the db layer.
 pub type DbResult<T> = Result<T, DbError>;
+
+/// Whether the most recent [`Database::open`] failed because the library was
+/// written by a newer build.
+///
+/// A flag rather than a richer error type because `open` reports `String` to a
+/// large number of callers (mostly tests); widening that signature to carry one
+/// bit through every `.unwrap()` is a poor trade. Set on every failed open, so
+/// a later unrelated failure clears it.
+static LAST_OPEN_WAS_NEWER_SCHEMA: AtomicBool = AtomicBool::new(false);
+
+/// Whether the last failed [`Database::open`] was version skew.
+///
+/// Only meaningful immediately after `open` returns an error.
+pub fn last_open_was_newer_schema() -> bool {
+    LAST_OPEN_WAS_NEWER_SCHEMA.load(Ordering::Relaxed)
+}
 
 /// Trait for deserializing a turso Row into a domain model.
 /// Each implementation maps column indices to struct fields based on the
@@ -165,9 +183,13 @@ impl Database {
             .connect()
             .map_err(|e| format!("Failed to connect: {e}"))?;
 
-        schema::initialize_db(&conn)
-            .await
-            .map_err(|e| format!("Failed to initialize schema: {e}"))?;
+        schema::initialize_db(&conn).await.map_err(|e| {
+            // Record the kind before the error is flattened to a string: the
+            // UI offers an in-app update only for version skew, and matching
+            // on the rendered message would break the moment it is reworded.
+            LAST_OPEN_WAS_NEWER_SCHEMA.store(e.is_newer_schema(), Ordering::Relaxed);
+            format!("Failed to initialize schema: {e}")
+        })?;
 
         let device_id = read_device_id(&conn).await?;
 

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -31,6 +31,19 @@ pub enum SchemaError {
     },
 }
 
+impl SchemaError {
+    /// Whether this failure is version skew that a newer build would fix.
+    ///
+    /// The one schema failure the user can resolve without touching the
+    /// library: the data is intact, this binary is simply too old to read it.
+    /// Callers use it to offer an in-app update; every other variant means
+    /// something is wrong with the database itself, where an update button
+    /// would be misleading.
+    pub fn is_newer_schema(&self) -> bool {
+        matches!(self, Self::NewerSchema { .. })
+    }
+}
+
 /// Create the application tables and run pending migrations.
 ///
 /// CRR metadata tables are created separately by [`crate::Database::open`] via
@@ -908,4 +921,59 @@ async fn seed_from_timestamp(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_conn() -> Connection {
+        let db = turso::Builder::new_local(":memory:")
+            .experimental_index_method(true)
+            .build()
+            .await
+            .unwrap();
+        db.connect().unwrap()
+    }
+
+    /// A library from a newer build is refused, and refused as version skew.
+    ///
+    /// The shape that stranded a v0.2.3 install: the schema had moved ahead of
+    /// the binary, and the error screen's update button keys off this variant.
+    #[tokio::test]
+    async fn a_newer_library_is_refused_as_version_skew() {
+        let conn = open_conn().await;
+        initialize_db(&conn).await.unwrap();
+        conn.execute(
+            "UPDATE schema_version SET version = ?1",
+            [SCHEMA_VERSION + 4],
+        )
+        .await
+        .unwrap();
+
+        let err = run_migrations(&conn).await.unwrap_err();
+        assert!(err.is_newer_schema(), "got {err:?}");
+        assert!(matches!(
+            err,
+            SchemaError::NewerSchema { found, supported }
+                if found == SCHEMA_VERSION + 4 && supported == SCHEMA_VERSION
+        ));
+    }
+
+    /// The version this build wrote is not skew, so no update is offered.
+    #[tokio::test]
+    async fn a_current_library_opens() {
+        let conn = open_conn().await;
+        initialize_db(&conn).await.unwrap();
+        run_migrations(&conn).await.unwrap();
+        assert_eq!(get_schema_version(&conn).await.unwrap(), SCHEMA_VERSION);
+    }
+
+    /// Only version skew sets the flag — a driver error must not offer an
+    /// update, which would promise a fix it cannot deliver.
+    #[test]
+    fn driver_errors_are_not_version_skew() {
+        let err = SchemaError::Turso(turso::Error::NotAdb("not a database".into()));
+        assert!(!err.is_newer_schema());
+    }
 }

--- a/justfile
+++ b/justfile
@@ -85,7 +85,40 @@ run-release: setup-pdfium
 
 # Bundle the desktop app for distribution
 bundle: setup-pdfium
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # PDFIUM_DYNAMIC_LIB_PATH only points the *build* at PDFium; it is not baked
+    # into the bundle. The library is loaded by name at runtime from beside the
+    # executable (see `candidate_dirs` in rotero-pdf), so it has to be copied in
+    # or the bundled app opens no PDFs. release.yml does the same for the
+    # published artifact.
     PDFIUM_DYNAMIC_LIB_PATH="{{justfile_directory()}}/lib" dx bundle --release
+
+    case "$(uname -s)" in
+        Darwin) LIB_NAME="libpdfium.dylib" ;;
+        Linux)  LIB_NAME="libpdfium.so" ;;
+        *)      LIB_NAME="pdfium.dll" ;;
+    esac
+
+    SRC="{{justfile_directory()}}/lib/$LIB_NAME"
+    DX_DIR="{{justfile_directory()}}/target/dx/rotero"
+
+    # Every bundled copy of the executable needs the library beside it: `dx`
+    # emits the plain .app and any installer payload (DMG/deb/msi) separately,
+    # and only the former is what `just smoke` checks.
+    found=0
+    for exe in $(find "$DX_DIR" -type f -perm -u+x -name 'rotero' -o -type f -name 'rotero.exe'); do
+        exe_dir=$(dirname "$exe")
+        cp "$SRC" "$exe_dir/"
+        echo "PDFium -> $exe_dir/$LIB_NAME"
+        found=$((found + 1))
+    done
+
+    if [ "$found" -eq 0 ]; then
+        echo "error: no built executable found to place $LIB_NAME beside" >&2
+        exit 1
+    fi
 
 # Run the test suite (PDFium is downloaded first so the PDF tests don't skip).
 # Needs no network: provider tests run against a local stub.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -211,11 +211,14 @@ pub fn App() -> Element {
                 document::Style { {FONTS_CSS} }
                 document::Style { {TOKENS_CSS} }
                 document::Style { {BASE_CSS} }
+                document::Style { {BUTTONS_CSS} }
                 document::Style { {LAYOUT_CSS} }
+                document::Style { {DIALOGS_CSS} }
                 document::Style { {THEME_CSS} }
                 div { class: "db-error",
                     h1 { "Database Error" }
                     p { "{err}" }
+                    {db_error_update_element()}
                 }
             }
         }
@@ -241,6 +244,40 @@ fn update_checker_element() -> Element {
 
 #[cfg(not(feature = "desktop"))]
 fn update_checker_element() -> Element {
+    rsx! {}
+}
+
+/// The update affordance on the Database Error screen.
+///
+/// Shown only for a library written by a newer build: that error tells the user
+/// to update, and the normal updater mounts on the success path only, so this
+/// was the one state where the app asked for something it had disabled. Every
+/// other open failure means a damaged or unreadable library, where an update
+/// button would promise a fix it cannot deliver.
+#[cfg(feature = "desktop")]
+fn db_error_update_element() -> Element {
+    use crate::init::database::DB_INIT_NEEDS_UPDATE;
+
+    if !DB_INIT_NEEDS_UPDATE.load(std::sync::atomic::Ordering::Relaxed) {
+        return rsx! {};
+    }
+
+    // The dialog needs its own state here: the provider above is on the
+    // success path, which by definition did not run.
+    let update_state = use_context_provider(|| Signal::new(crate::updates::UpdateState::default()));
+
+    rsx! {
+        button {
+            class: "btn btn-primary",
+            onclick: move |_| crate::updates::run_interactive_check(update_state),
+            "Check for Update"
+        }
+        super::ui::update_dialog::UpdateDialog {}
+    }
+}
+
+#[cfg(not(feature = "desktop"))]
+fn db_error_update_element() -> Element {
     rsx! {}
 }
 

--- a/src/init/database.rs
+++ b/src/init/database.rs
@@ -16,6 +16,16 @@ pub static SHARED_DB: std::sync::OnceLock<rotero_db::Database> = std::sync::Once
 #[cfg(feature = "desktop")]
 pub static DB_INIT_ERROR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
+/// Whether [`DB_INIT_ERROR`] is version skew rather than a damaged library.
+///
+/// Captured at startup because it is only readable immediately after the failed
+/// open. The error screen uses it to offer an in-app update — the message tells
+/// the user to update, and until this existed that was the one state in which
+/// the updater never ran, because it mounts only on the success path.
+#[cfg(feature = "desktop")]
+pub static DB_INIT_NEEDS_UPDATE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Open the library database, creating and migrating it if needed.
 ///
 /// Delegates to [`rotero_db::Database::open`] so the desktop app and the tests

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,11 @@ fn main() {
                 // only log failures of their own.
                 tracing::error!("Failed to initialize database: {e}");
                 init::preflight::record(|p| p.db = Some(e.clone()));
+                // Read before anything else can open a database and reset it.
+                init::database::DB_INIT_NEEDS_UPDATE.store(
+                    rotero_db::last_open_was_newer_schema(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
                 let _ = init::database::DB_INIT_ERROR.set(e);
             }
         }


### PR DESCRIPTION
A library written by a newer build refuses to open with *"Update Rotero to
open it"* — and that was the single state in which updating from inside the
app was impossible. `update_checker_element()` mounts only in the
`Some(Ok(db))` arm of the app root, so the error screen rendered no updater
and no dialog. The instruction on screen named the fix and the app had just
disabled it; the only way out was replacing the bundle by hand.

This is not hypothetical. v0.2.4 shipped yesterday with schema v18 and would
have opened the library fine — a perfectly good release sitting there, with
the mechanism to reach it disabled by the very error telling the user to use
it. Every v0.2.3 install is in that position today.

This cannot rescue them; a shipped binary has no button. It stops the *next*
schema bump from stranding v0.2.4 and v0.2.5 users the same way, and that
window closes the moment `SCHEMA_VERSION` reaches 19.

## Offer an update on version skew, and only on version skew

The error screen now offers **Check for Update** when the library was written
by a newer build. Every other open failure means a damaged or unreadable
library, where an update button would promise a fix it cannot deliver.

Telling the two apart needs the error's kind, and `Database::open` reports
`String` — the variant is gone by the time the UI sees it. Rather than widen
that signature through its callers (most of them tests that `.unwrap()`),
`open` records whether the failure was `NewerSchema` in a flag the app reads
at startup. Matching on the rendered message would work today and break
silently the first time anyone rewords it.

The dialog needs its own `UpdateState` here: the provider lives on the
success branch, which by definition did not run.

## Ship PDFium in the bundle `just bundle` builds

Found while building a fixed bundle to install. `PDFIUM_DYNAMIC_LIB_PATH`
points the *build* at PDFium; it is not baked into the artifact. The library
is `dlopen`ed by name at runtime from beside the executable
(`candidate_dirs` in rotero-pdf), so a bundle without it renders no pages,
writes no annotations, and draws no thumbnails.

`release.yml` has always copied it in, so published builds were never
affected — the gap was local only, and `just bundle` produced an app that
could not open a PDF.

## Verification

- 59 test suites, 0 failures; clippy clean
- 3 new tests: the v17-library-on-a-v13-build case, a current library, and a
  driver error that must *not* offer an update
- `just bundle` from a clean tree produces `Rotero_0.2.5_aarch64.dmg`
- `just smoke` passes all 13 assertions against the real bundle
- The PDFium fix is load-bearing, not assumed: deleting the library from a
  bundled app makes smoke report *"PDFium failed to bind (PDF viewing,
  annotations, and thumbnails are dead)"*; restoring it gives *"PDF engine
  bound"*

Note `Cargo.toml` still read `0.2.3` after v0.2.4 shipped — the workflow
patches the plist from the git tag, so the in-repo version drifts. It matters
beyond cosmetics: `check_for_update` compares against
`env!("CARGO_PKG_VERSION")`, so a stale value is what the updater reasons
about. Bumped to 0.2.5 here.

https://claude.ai/code/session_01TpSTKwHWu9e7rTCgvsF4C4