### PR TITLE
Show type-aware tool-call chips in chat

### DIFF
--- a/assets/chat.css
+++ b/assets/chat.css
@@ -216,6 +216,10 @@
     flex: 1;
 }
 
+.chat-tool-name--plain {
+    font-family: inherit;
+}
+
 .chat-tool-pill {
     display: inline-flex;
     align-items: center;
@@ -255,6 +259,71 @@
 
 .chat-tool-output {
     margin: var(--space-1) 0;
+}
+
+.chat-tool-confirm {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    line-height: var(--leading-snug);
+}
+
+.chat-tool-confirm--failed {
+    color: var(--destructive);
+}
+
+.chat-note-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.chat-note-card {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--space-2);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+}
+
+.chat-note-body {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    max-height: 8em;
+    overflow: auto;
+}
+
+.chat-name-list {
+    margin: 0;
+    padding-left: var(--space-4);
+    font-size: var(--text-xs);
+    color: var(--text-primary);
+}
+
+.chat-extract {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.chat-extract-text {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    padding: var(--space-2);
+    margin: 0;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .chat-tool-output pre {

--- a/assets/chat.css
+++ b/assets/chat.css
@@ -151,38 +151,106 @@
     white-space: pre-wrap;
 }
 
+.chat-tool {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin: var(--space-1) 0;
+    min-width: 0;
+}
+
 .chat-tool-call {
     display: flex;
     align-items: center;
     gap: var(--space-2);
+    width: 100%;
     padding: var(--space-1) var(--space-2);
-    margin: var(--space-1) 0;
     border-radius: var(--radius-md);
     background: var(--bg-main);
     font-size: var(--text-xs);
     color: var(--text-secondary);
     border: 1px solid var(--border-light);
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
 }
 
-.chat-tool-icon {
+.chat-tool-call:hover {
+    background: var(--bg-muted);
+}
+
+.chat-tool-icon,
+.chat-tool-kind-icon,
+.chat-tool-chevron {
     font-size: var(--text-xs);
     flex-shrink: 0;
 }
 
+.chat-tool-call--running .chat-tool-kind-icon,
 .chat-tool-call--running .chat-tool-icon {
     color: var(--accent);
 }
 
+.chat-tool-call--done .chat-tool-kind-icon,
 .chat-tool-call--done .chat-tool-icon {
     color: var(--success, #22c55e);
 }
 
+.chat-tool-call--failed .chat-tool-kind-icon,
 .chat-tool-call--failed .chat-tool-icon {
     color: var(--destructive);
 }
 
+.chat-tool-kind {
+    flex-shrink: 0;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
 .chat-tool-name {
     font-family: var(--font-mono);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+
+.chat-tool-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    padding: 0 6px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-light);
+    font-size: 10px;
+    color: var(--text-tertiary);
+    text-transform: lowercase;
+}
+
+.chat-tool-call--running .chat-tool-pill {
+    color: var(--accent);
+}
+
+.chat-tool-call--done .chat-tool-pill {
+    color: var(--success, #22c55e);
+}
+
+.chat-tool-call--failed .chat-tool-pill {
+    color: var(--destructive);
+}
+
+.chat-tool-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-main);
 }
 
 .chat-tool-output {
@@ -205,6 +273,199 @@
     white-space: pre-wrap;
     word-break: break-all;
 }
+
+.chat-paper-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.chat-paper-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    width: 100%;
+    padding: var(--space-2);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    text-align: left;
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.chat-paper-card:hover:not(:disabled) {
+    border-color: var(--accent);
+}
+
+.chat-paper-card:disabled {
+    cursor: default;
+    opacity: 1;
+}
+
+.chat-paper-title {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: var(--leading-snug);
+}
+
+.chat-paper-meta {
+    display: flex;
+    gap: var(--space-1);
+    font-size: 11px;
+    color: var(--text-tertiary);
+}
+
+.chat-paper-sep {
+    color: var(--text-quaternary);
+}
+
+.chat-resource-card {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--space-2);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+}
+
+.chat-resource-title {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.chat-resource-uri {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--accent);
+    word-break: break-all;
+}
+
+.chat-resource-mime {
+    font-size: 11px;
+    color: var(--text-tertiary);
+}
+
+.chat-resource-text {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    margin: var(--space-1) 0 0;
+    max-height: 120px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+.chat-tool-locations {
+    margin: 0;
+    padding-left: var(--space-4);
+    font-size: var(--text-xs);
+}
+
+.chat-tool-line {
+    color: var(--text-tertiary);
+}
+
+.chat-diff {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.chat-diff-path {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.chat-diff-lines {
+    max-height: 240px;
+    overflow: auto;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.45;
+}
+
+.chat-diff-line {
+    display: flex;
+    gap: var(--space-1);
+    padding: 0 var(--space-2);
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.chat-diff-prefix {
+    flex-shrink: 0;
+    width: 0.8em;
+    color: var(--text-quaternary);
+}
+
+.chat-diff-line--add {
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--success, #16a34a);
+}
+
+.chat-diff-line--del {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--destructive);
+}
+
+.chat-diff-line--eq {
+    color: var(--text-secondary);
+}
+
+.chat-json-box {
+    position: relative;
+}
+
+.chat-json-copy {
+    position: absolute;
+    top: var(--space-1);
+    right: var(--space-1);
+    z-index: 1;
+    height: 20px;
+    padding: 0 8px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: 10px;
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.chat-json-copy:hover {
+    color: var(--text-primary);
+}
+
+.chat-json {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: 1.45;
+    color: var(--text-secondary);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    padding: var(--space-2);
+    margin: 0;
+    overflow: auto;
+    max-height: 240px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.json-key { color: var(--accent); }
+.json-string { color: var(--success, #16a34a); }
+.json-number { color: var(--text-primary); }
+.json-literal { color: var(--destructive); }
+.json-punct, .json-space { color: var(--text-tertiary); }
 
 .chat-error {
     color: var(--destructive);

--- a/src/agent/helpers.rs
+++ b/src/agent/helpers.rs
@@ -2,14 +2,19 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
 use agent_client_protocol::schema::v1::{
-    AuthMethod, ContentBlock, McpServer, McpServerHttp, McpServerStdio, SessionConfigKind,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions, SessionUpdate,
-    ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate,
+    AuthMethod, ContentBlock, EmbeddedResourceResource, McpServer, McpServerHttp, McpServerStdio,
+    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOptions, SessionUpdate, ToolCall, ToolCallContent,
+    ToolCallLocation as AcpToolCallLocation, ToolCallStatus, ToolCallUpdate,
+    ToolKind as AcpToolKind,
 };
 
 use super::LoopResult;
 use super::install::{find_mcp_binary, find_pdfium_path};
-use super::types::{AgentAuthMethod, AgentModel, ChatEvent, ChatRequest, SlashCommand, ToolStatus};
+use super::types::{
+    AgentAuthMethod, AgentModel, ChatEvent, ChatRequest, SlashCommand, ToolContentBlock, ToolKind,
+    ToolLocation, ToolStatus, ToolUse,
+};
 
 /// Whether `program` is a Windows batch file, which `CreateProcess` refuses to
 /// execute directly. Defined on all platforms so it stays unit-testable;
@@ -186,6 +191,104 @@ fn tool_output_text(content: &[ToolCallContent]) -> Option<String> {
     }
 }
 
+fn raw_json_text(value: &Option<serde_json::Value>) -> Option<String> {
+    value.as_ref().map(|v| {
+        if let Some(s) = v.as_str() {
+            s.to_string()
+        } else {
+            serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string())
+        }
+    })
+}
+
+fn tool_kind(kind: AcpToolKind) -> ToolKind {
+    match kind {
+        AcpToolKind::Read => ToolKind::Read,
+        AcpToolKind::Edit => ToolKind::Edit,
+        AcpToolKind::Delete => ToolKind::Delete,
+        AcpToolKind::Move => ToolKind::Move,
+        AcpToolKind::Search => ToolKind::Search,
+        AcpToolKind::Execute => ToolKind::Execute,
+        AcpToolKind::Think => ToolKind::Think,
+        AcpToolKind::Fetch => ToolKind::Fetch,
+        AcpToolKind::SwitchMode => ToolKind::SwitchMode,
+        _ => ToolKind::Other,
+    }
+}
+
+fn map_locations(locations: &[AcpToolCallLocation]) -> Vec<ToolLocation> {
+    locations
+        .iter()
+        .map(|loc| ToolLocation {
+            path: loc.path.to_string_lossy().into_owned(),
+            line: loc.line,
+        })
+        .collect()
+}
+
+fn map_content(content: &[ToolCallContent]) -> Vec<ToolContentBlock> {
+    content.iter().filter_map(map_content_item).collect()
+}
+
+fn map_content_item(item: &ToolCallContent) -> Option<ToolContentBlock> {
+    match item {
+        ToolCallContent::Content(c) => match &c.content {
+            ContentBlock::Text(t) => Some(ToolContentBlock::Text(t.text.clone())),
+            ContentBlock::ResourceLink(link) => Some(ToolContentBlock::Resource {
+                title: link
+                    .title
+                    .clone()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| link.name.clone()),
+                uri: link.uri.clone(),
+                mime_type: link.mime_type.clone(),
+                text: link.description.clone(),
+            }),
+            ContentBlock::Resource(embedded) => match &embedded.resource {
+                EmbeddedResourceResource::TextResourceContents(text) => {
+                    Some(ToolContentBlock::Resource {
+                        title: text.uri.clone(),
+                        uri: text.uri.clone(),
+                        mime_type: text.mime_type.clone(),
+                        text: Some(text.text.clone()),
+                    })
+                }
+                EmbeddedResourceResource::BlobResourceContents(blob) => {
+                    Some(ToolContentBlock::Resource {
+                        title: blob.uri.clone(),
+                        uri: blob.uri.clone(),
+                        mime_type: blob.mime_type.clone(),
+                        text: None,
+                    })
+                }
+                _ => None,
+            },
+            _ => None,
+        },
+        ToolCallContent::Diff(diff) => Some(ToolContentBlock::Diff {
+            path: diff.path.to_string_lossy().into_owned(),
+            old_text: diff.old_text.clone(),
+            new_text: diff.new_text.clone(),
+        }),
+        _ => None,
+    }
+}
+
+fn tool_use_from_acp(call: &ToolCall) -> ToolUse {
+    let content = map_content(&call.content);
+    let output = tool_output_text(&call.content).or_else(|| raw_json_text(&call.raw_output));
+    ToolUse {
+        id: call.tool_call_id.0.to_string(),
+        title: call.title.clone(),
+        status: tool_status(call.status),
+        output,
+        kind: tool_kind(call.kind),
+        raw_input: call.raw_input.clone(),
+        locations: map_locations(&call.locations),
+        content,
+    }
+}
+
 pub(crate) fn session_update_to_events(update: &SessionUpdate) -> Vec<ChatEvent> {
     match update {
         SessionUpdate::UserMessageChunk(chunk) => {
@@ -214,26 +317,38 @@ pub(crate) fn session_update_to_events(update: &SessionUpdate) -> Vec<ChatEvent>
                 vec![ChatEvent::TextDelta(cleaned)]
             }
         }
-        SessionUpdate::ToolCall(ToolCall {
-            tool_call_id,
-            title,
-            ..
-        }) => vec![ChatEvent::ToolCallStarted {
-            id: tool_call_id.0.to_string(),
-            title: title.clone(),
-        }],
+        SessionUpdate::ToolCall(call) => {
+            vec![ChatEvent::ToolCallStarted(tool_use_from_acp(call))]
+        }
         SessionUpdate::ToolCallUpdate(ToolCallUpdate {
             tool_call_id,
             fields,
             ..
         }) => {
-            let Some(status) = fields.status else {
+            let output = fields
+                .content
+                .as_deref()
+                .and_then(tool_output_text)
+                .or_else(|| raw_json_text(&fields.raw_output));
+            if fields.status.is_none()
+                && fields.title.is_none()
+                && fields.kind.is_none()
+                && fields.content.is_none()
+                && fields.locations.is_none()
+                && fields.raw_input.is_none()
+                && fields.raw_output.is_none()
+            {
                 return vec![];
-            };
+            }
             vec![ChatEvent::ToolCallUpdated {
                 id: tool_call_id.0.to_string(),
-                status: tool_status(status),
-                output: fields.content.as_deref().and_then(tool_output_text),
+                title: fields.title.clone(),
+                status: fields.status.map(tool_status),
+                output,
+                kind: fields.kind.map(tool_kind),
+                raw_input: fields.raw_input.clone(),
+                locations: fields.locations.as_deref().map(map_locations),
+                content: fields.content.as_deref().map(map_content),
             }]
         }
         SessionUpdate::AvailableCommandsUpdate(update) => {
@@ -422,6 +537,56 @@ mod tests {
             api_key_env_for_method("gemini-api-key").as_deref(),
             Some("GEMINI_API_KEY")
         );
+    }
+
+    #[test]
+    fn tool_call_keeps_kind_and_raw_input() {
+        let call = ToolCall::new("tc-1", "search_papers")
+            .kind(AcpToolKind::Search)
+            .raw_input(serde_json::json!({"query": "attention"}));
+        let events = session_update_to_events(&SessionUpdate::ToolCall(call));
+        match &events[..] {
+            [ChatEvent::ToolCallStarted(tool)] => {
+                assert_eq!(tool.id, "tc-1");
+                assert_eq!(tool.title, "search_papers");
+                assert_eq!(tool.kind, ToolKind::Search);
+                assert_eq!(
+                    tool.raw_input,
+                    Some(serde_json::json!({"query": "attention"}))
+                );
+            }
+            other => panic!("expected ToolCallStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_update_without_status_still_forwards_content() {
+        use agent_client_protocol::schema::v1::{Diff, ToolCallUpdateFields};
+
+        let update = ToolCallUpdate::new(
+            "tc-1",
+            ToolCallUpdateFields::new().content(vec![Diff::new("/tmp/note.md", "hello").into()]),
+        );
+        let events = session_update_to_events(&SessionUpdate::ToolCallUpdate(update));
+        match &events[..] {
+            [
+                ChatEvent::ToolCallUpdated {
+                    id,
+                    status,
+                    content,
+                    ..
+                },
+            ] => {
+                assert_eq!(id, "tc-1");
+                assert!(status.is_none());
+                assert!(matches!(
+                    content.as_deref(),
+                    Some([ToolContentBlock::Diff { path, new_text, .. }])
+                        if path == "/tmp/note.md" && new_text == "hello"
+                ));
+            }
+            other => panic!("expected ToolCallUpdated, got {other:?}"),
+        }
     }
 }
 

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -9,18 +9,68 @@ pub enum ChatRole {
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageContent {
     Text(String),
-    ToolUse {
-        id: String,
-        title: String,
-        status: ToolStatus,
-        output: Option<String>,
-    },
+    ToolUse(ToolUse),
     Error(String),
     Permission {
         request_id: serde_json::Value,
         tool_title: String,
         options: Vec<(String, String)>, // (optionId, label)
         responded: bool,
+    },
+}
+
+/// One agent tool call, as shown in the transcript.
+///
+/// Extra ACP fields (`kind`, `raw_input`, `locations`, typed `content`) are
+/// optional so an older event that only had title + status still renders.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolUse {
+    pub id: String,
+    pub title: String,
+    pub status: ToolStatus,
+    pub output: Option<String>,
+    pub kind: ToolKind,
+    pub raw_input: Option<serde_json::Value>,
+    pub locations: Vec<ToolLocation>,
+    pub content: Vec<ToolContentBlock>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolKind {
+    Read,
+    Edit,
+    Delete,
+    Move,
+    Search,
+    Execute,
+    Think,
+    Fetch,
+    SwitchMode,
+    #[default]
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolLocation {
+    pub path: String,
+    pub line: Option<u32>,
+}
+
+/// Displayable pieces of a tool call, copied out of ACP so the UI crate
+/// does not depend on the protocol types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolContentBlock {
+    Text(String),
+    Diff {
+        path: String,
+        old_text: Option<String>,
+        new_text: String,
+    },
+    Resource {
+        title: String,
+        uri: String,
+        mime_type: Option<String>,
+        text: Option<String>,
     },
 }
 
@@ -212,10 +262,7 @@ pub enum ChatEvent {
         context_paper_ids: Vec<String>,
     },
     TextDelta(String),
-    ToolCallStarted {
-        id: String,
-        title: String,
-    },
+    ToolCallStarted(ToolUse),
     PermissionRequest {
         request_id: serde_json::Value,
         tool_title: String,
@@ -223,8 +270,13 @@ pub enum ChatEvent {
     },
     ToolCallUpdated {
         id: String,
-        status: ToolStatus,
+        title: Option<String>,
+        status: Option<ToolStatus>,
         output: Option<String>,
+        kind: Option<ToolKind>,
+        raw_input: Option<serde_json::Value>,
+        locations: Option<Vec<ToolLocation>>,
+        content: Option<Vec<ToolContentBlock>>,
     },
     TurnCompleted,
     CommandsAvailable(Vec<SlashCommand>),

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -4,7 +4,7 @@ use rotero_db::chat_sessions::ChatSessionRow;
 
 use super::chat_papers::paper_ids_from_tool_output;
 use crate::agent::types::{
-    AgentStatus, ChatEvent, ChatMessage, ChatRole, ChatState, MessageContent,
+    AgentStatus, ChatEvent, ChatMessage, ChatRole, ChatState, MessageContent, ToolUse,
 };
 use crate::state::app_state::LibraryState;
 
@@ -203,26 +203,30 @@ pub fn handle_chat_event(
                     .push(ChatMessage::assistant(vec![MessageContent::Text(text)]));
             });
         }
-        ChatEvent::ToolCallStarted { id, title } => {
+        ChatEvent::ToolCallStarted(tool) => {
             chat_state.with_mut(|s| {
-                s.status = AgentStatus::ToolCall(title.clone());
+                s.status = AgentStatus::ToolCall(tool.title.clone());
                 if s.messages.last().map(|m| &m.role) != Some(&ChatRole::Assistant) {
                     s.messages.push(ChatMessage::assistant(vec![]));
                 }
                 if let Some(last) = s.messages.last_mut() {
-                    last.content.push(MessageContent::ToolUse {
-                        id,
-                        title,
-                        status: crate::agent::types::ToolStatus::InProgress,
-                        output: None,
-                    });
+                    last.content.push(MessageContent::ToolUse(tool));
                 }
             });
         }
-        ChatEvent::ToolCallUpdated { id, status, output } => {
+        ChatEvent::ToolCallUpdated {
+            id,
+            title,
+            status,
+            output,
+            kind,
+            raw_input,
+            locations,
+            content,
+        } => {
             // Only once the call has finished: an in-progress update repeats,
             // and the papers it names are not settled until it completes.
-            if status == crate::agent::types::ToolStatus::Completed
+            if status == Some(crate::agent::types::ToolStatus::Completed)
                 && let Some(text) = output.as_deref()
             {
                 // Papers the agent read while answering, not what the
@@ -238,18 +242,39 @@ pub fn handle_chat_event(
             }
             chat_state.with_mut(|s| {
                 if let Some(last) = s.messages.last_mut() {
-                    for content in &mut last.content {
-                        if let MessageContent::ToolUse {
+                    for block in &mut last.content {
+                        if let MessageContent::ToolUse(ToolUse {
                             id: tool_id,
+                            title: tool_title,
                             status: tool_status,
                             output: tool_output,
-                            ..
-                        } = content
+                            kind: tool_kind,
+                            raw_input: tool_input,
+                            locations: tool_locations,
+                            content: tool_content,
+                        }) = block
                             && *tool_id == id
                         {
-                            *tool_status = status.clone();
+                            if let Some(title) = title {
+                                *tool_title = title;
+                            }
+                            if let Some(status) = status {
+                                *tool_status = status;
+                            }
                             if output.is_some() {
-                                *tool_output = output.clone();
+                                *tool_output = output;
+                            }
+                            if let Some(kind) = kind {
+                                *tool_kind = kind;
+                            }
+                            if raw_input.is_some() {
+                                *tool_input = raw_input;
+                            }
+                            if let Some(locations) = locations {
+                                *tool_locations = locations;
+                            }
+                            if let Some(content) = content {
+                                *tool_content = content;
                             }
                             break;
                         }
@@ -269,14 +294,14 @@ pub fn handle_chat_event(
                 s.status = AgentStatus::Idle;
                 for msg in &mut s.messages {
                     for content in &mut msg.content {
-                        if let MessageContent::ToolUse { status, .. } = content
+                        if let MessageContent::ToolUse(tool) = content
                             && matches!(
-                                status,
+                                tool.status,
                                 crate::agent::types::ToolStatus::Pending
                                     | crate::agent::types::ToolStatus::InProgress
                             )
                         {
-                            *status = crate::agent::types::ToolStatus::Completed;
+                            tool.status = crate::agent::types::ToolStatus::Completed;
                         }
                     }
                 }

--- a/src/app/chat_papers.rs
+++ b/src/app/chat_papers.rs
@@ -5,6 +5,8 @@
 //! stripped for display), and the results of the rotero MCP tools it calls.
 //! This module reads the second.
 
+use rotero_models::Paper;
+
 /// Library paper ids appearing in an MCP tool result.
 ///
 /// Tool results are pretty-printed JSON from the rotero MCP server, so a paper
@@ -53,10 +55,62 @@ fn push_unique(ids: &mut Vec<String>, id: &str) {
     }
 }
 
+/// Title/authors/year extracted from the same MCP JSON `paper_ids_from_tool_output` walks.
+///
+/// Used by the chat tool-call chip so a search result can render as a paper
+/// card without a second library round-trip. Ids are still best-effort: the
+/// paper may not be in the library yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaperSnippet {
+    pub id: Option<String>,
+    pub title: String,
+    pub authors: String,
+    pub year: Option<i32>,
+}
+
+pub fn papers_from_tool_output(output: &str) -> Vec<PaperSnippet> {
+    let mut papers = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        collect_papers(&value, &mut papers);
+    }
+    papers
+}
+
+fn collect_papers(value: &serde_json::Value, papers: &mut Vec<PaperSnippet>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let looks_like_paper = map.contains_key("title") && map.contains_key("creators");
+            if looks_like_paper && let Ok(paper) = serde_json::from_value::<Paper>(value.clone()) {
+                let snippet = PaperSnippet {
+                    id: paper.id.clone(),
+                    authors: paper.formatted_authors(),
+                    year: paper.year,
+                    title: paper.title,
+                };
+                let seen = snippet
+                    .id
+                    .as_ref()
+                    .is_some_and(|id| papers.iter().any(|p| p.id.as_deref() == Some(id)));
+                if !seen {
+                    papers.push(snippet);
+                }
+            }
+            for nested in map.values() {
+                collect_papers(nested, papers);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_papers(item, papers);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rotero_models::Paper;
 
     fn paper(id: &str, title: &str) -> Paper {
         Paper {
@@ -144,5 +198,21 @@ mod tests {
         assert!(paper_ids_from_tool_output("").is_empty());
         assert!(paper_ids_from_tool_output("No paper found with ID abc").is_empty());
         assert!(paper_ids_from_tool_output(r#"[{"id": "trunc"#).is_empty());
+    }
+
+    #[test]
+    fn papers_from_tool_output_keeps_title_authors_year() {
+        let mut p = paper(
+            "11111111-1111-7111-8111-111111111111",
+            "Attention Is All You Need",
+        );
+        p.year = Some(2017);
+        p.creators = vec![rotero_models::Creator::author("Ashish", "Vaswani")];
+        let json = serde_json::to_string_pretty(&vec![p]).unwrap();
+        let cards = papers_from_tool_output(&json);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].title, "Attention Is All You Need");
+        assert_eq!(cards[0].authors, "Ashish Vaswani");
+        assert_eq!(cards[0].year, Some(2017));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 pub mod chat_handler;
-mod chat_papers;
+pub(crate) mod chat_papers;
 mod library_loader;
 // Poses the UI for documentation screenshots. Debug builds only.
 #[cfg(all(feature = "desktop", debug_assertions))]

--- a/src/ui/chat_panel/message.rs
+++ b/src/ui/chat_panel/message.rs
@@ -1,8 +1,7 @@
 use dioxus::prelude::*;
 
-use crate::agent::types::{
-    ChatMessage, ChatRequest, ChatRole, ChatState, MessageContent, ToolStatus,
-};
+use super::tool_call::ToolCallView;
+use crate::agent::types::{ChatMessage, ChatRequest, ChatRole, ChatState, MessageContent};
 use crate::ui::chat_panel::AgentChannel;
 
 #[component]
@@ -31,26 +30,8 @@ pub(crate) fn ChatMessageBubble(message: ChatMessage) -> Element {
                             }
                         }
                     },
-                    MessageContent::ToolUse { id: _, title, status, output } => {
-                        let (icon_class, status_class) = match status {
-                            ToolStatus::Pending | ToolStatus::InProgress =>
-                                ("bi bi-clock", "chat-tool-call--running"),
-                            ToolStatus::Completed =>
-                                ("bi bi-check2", "chat-tool-call--done"),
-                            ToolStatus::Failed =>
-                                ("bi bi-x-lg", "chat-tool-call--failed"),
-                        };
-                        rsx! {
-                            div { key: "c{i}", class: "chat-tool-call {status_class}",
-                                i { class: "{icon_class} chat-tool-icon" }
-                                span { class: "chat-tool-name", "{title}" }
-                            }
-                            if let Some(out) = output {
-                                div { key: "c{i}-out", class: "chat-tool-output",
-                                    pre { "{out}" }
-                                }
-                            }
-                        }
+                    MessageContent::ToolUse(tool) => rsx! {
+                        ToolCallView { key: "{tool.id}", tool: tool.clone() }
                     },
                     MessageContent::Error(err) => rsx! {
                         div { key: "c{i}", class: "chat-error",

--- a/src/ui/chat_panel/message.rs
+++ b/src/ui/chat_panel/message.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 
+use super::rotero_tools::{humanize_tool_title, permission_prompt};
 use super::tool_call::ToolCallView;
 use crate::agent::types::{ChatMessage, ChatRequest, ChatRole, ChatState, MessageContent};
 use crate::ui::chat_panel::AgentChannel;
@@ -40,11 +41,13 @@ pub(crate) fn ChatMessageBubble(message: ChatMessage) -> Element {
                         }
                     },
                     MessageContent::Permission { request_id, tool_title, options, responded } => {
+                        let chip_title = humanize_tool_title(tool_title);
+                        let prompt = permission_prompt(tool_title);
                         if *responded {
                             rsx! {
                                 div { key: "c{i}", class: "chat-tool-call chat-tool-call--done",
                                     i { class: "bi bi-check2 chat-tool-icon" }
-                                    span { class: "chat-tool-name", "{tool_title}" }
+                                    span { class: "chat-tool-name chat-tool-name--plain", "{chip_title}" }
                                 }
                             }
                         } else {
@@ -52,7 +55,7 @@ pub(crate) fn ChatMessageBubble(message: ChatMessage) -> Element {
                             let opts = options.clone();
                             rsx! {
                                 div { key: "c{i}", class: "chat-permission",
-                                    span { class: "chat-permission-title", "Allow {tool_title}?" }
+                                    span { class: "chat-permission-title", "{prompt}" }
                                     div { class: "chat-permission-buttons",
                                         for (opt_id, label) in opts.iter() {
                                             {

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -3,6 +3,7 @@ mod panel;
 mod resize_handle;
 mod resume;
 mod toggle;
+mod tool_call;
 
 use dioxus::prelude::*;
 

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -2,6 +2,7 @@ mod message;
 mod panel;
 mod resize_handle;
 mod resume;
+mod rotero_tools;
 mod toggle;
 mod tool_call;
 

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -111,11 +111,15 @@ pub fn ChatPanel() -> Element {
 
     let hidden_count = past_sessions.len().saturating_sub(visible_sessions.len());
 
+    let tool_status = match &status {
+        AgentStatus::ToolCall(name) => Some(super::rotero_tools::humanize_tool_title(name)),
+        _ => None,
+    };
     let status_text = match &status {
         AgentStatus::Idle => "Ready",
         AgentStatus::Connecting => "Connecting...",
         AgentStatus::Streaming => "Thinking...",
-        AgentStatus::ToolCall(name) => name.as_str(),
+        AgentStatus::ToolCall(_) => tool_status.as_deref().unwrap_or("Working"),
         AgentStatus::NeedsAuth => "Sign in required",
         AgentStatus::Error(_) => "Error",
     };

--- a/src/ui/chat_panel/panel.rs
+++ b/src/ui/chat_panel/panel.rs
@@ -24,12 +24,21 @@ pub fn ChatPanel() -> Element {
             let _ = dioxus::document::eval(
                 r#"
                 (function() {
-                    let el = document.querySelector('.chat-messages');
-                    if (!el || el._autoScroll) return;
-                    el._autoScroll = true;
-                    new MutationObserver(() => {
-                        el.scrollTop = el.scrollHeight;
-                    }).observe(el, { childList: true, subtree: true, characterData: true });
+                    const el = document.querySelector('.chat-messages');
+                    if (!el || el._autoScroll === 2) return;
+                    if (el._autoScrollObs) {
+                        try { el._autoScrollObs.disconnect(); } catch (e) {}
+                    }
+                    el._autoScroll = 2;
+                    const THRESHOLD = 40;
+                    const gap = () => el.scrollHeight - el.scrollTop - el.clientHeight;
+                    let pinned = gap() < THRESHOLD;
+                    el.addEventListener('scroll', () => { pinned = gap() < THRESHOLD; }, { passive: true });
+                    const obs = new MutationObserver(() => {
+                        if (pinned) el.scrollTop = el.scrollHeight;
+                    });
+                    obs.observe(el, { childList: true, subtree: true, characterData: true });
+                    el._autoScrollObs = obs;
                 })()
             "#,
             );

--- a/src/ui/chat_panel/rotero_tools.rs
+++ b/src/ui/chat_panel/rotero_tools.rs
@@ -1,0 +1,1112 @@
+//! Friendly descriptors for Rotero's finite MCP tool set.
+//!
+//! Incoming ACP titles look like `mcp__rotero__get_paper`. The registry
+//! matches on the bare function name and never shows hashes, ids, or the
+//! `mcp__` prefix. Unknown tools fall through to the generic chip.
+
+use crate::app::chat_papers::{PaperSnippet, papers_from_tool_output};
+use rotero_models::{Collection, Paper, Tag};
+
+/// How a known Rotero tool's result should render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultKind {
+    Papers,
+    Notes,
+    Annotations,
+    Names,
+    Confirmation,
+    Graph,
+    Relationships,
+    PdfUrls,
+    ExtractedText,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolMeta {
+    pub label: &'static str,
+    pub icon: &'static str,
+    pub result: ResultKind,
+}
+
+/// Owned chip copy for a known Rotero tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoteroChip {
+    pub icon: &'static str,
+    pub label: String,
+    pub summary: String,
+    pub result: ResultKind,
+}
+
+pub struct ToolLookups<'a> {
+    pub papers: &'a [Paper],
+    pub collections: &'a [Collection],
+    pub tags: &'a [Tag],
+}
+
+impl<'a> ToolLookups<'a> {
+    fn paper_title(&self, id: &str) -> Option<&'a str> {
+        self.papers
+            .iter()
+            .find(|p| p.id.as_deref() == Some(id))
+            .map(|p| p.title.as_str())
+            .filter(|t| !t.is_empty())
+    }
+
+    fn collection_name(&self, id: &str) -> Option<&'a str> {
+        self.collections
+            .iter()
+            .find(|c| c.id.as_deref() == Some(id))
+            .map(|c| c.name.as_str())
+            .filter(|t| !t.is_empty())
+    }
+
+    fn tag_name(&self, id: &str) -> Option<&'a str> {
+        self.tags
+            .iter()
+            .find(|t| t.id.as_deref() == Some(id))
+            .map(|t| t.name.as_str())
+            .filter(|t| !t.is_empty())
+    }
+}
+
+/// Strip `mcp__rotero__` (and similar) so the registry keys on the fn name.
+pub fn bare_tool_name(title: &str) -> &str {
+    title
+        .rsplit("__")
+        .next()
+        .unwrap_or(title)
+        .rsplit(['/', ':'])
+        .next()
+        .unwrap_or(title)
+        .trim()
+}
+
+pub fn descriptor(name: &str) -> Option<ToolMeta> {
+    Some(match name {
+        "search_papers" => ToolMeta {
+            label: "Searched papers",
+            icon: "bi bi-search",
+            result: ResultKind::Papers,
+        },
+        "search_online" => ToolMeta {
+            label: "Searched online",
+            icon: "bi bi-globe",
+            result: ResultKind::Papers,
+        },
+        "find_pdf" => ToolMeta {
+            label: "Found PDF",
+            icon: "bi bi-file-earmark-pdf",
+            result: ResultKind::PdfUrls,
+        },
+        "get_paper" => ToolMeta {
+            label: "Opened paper",
+            icon: "bi bi-file-text",
+            result: ResultKind::Papers,
+        },
+        "list_papers" => ToolMeta {
+            label: "Listed papers",
+            icon: "bi bi-list-ul",
+            result: ResultKind::Papers,
+        },
+        "get_paper_annotations" => ToolMeta {
+            label: "Read annotations",
+            icon: "bi bi-highlighter",
+            result: ResultKind::Annotations,
+        },
+        "get_paper_notes" => ToolMeta {
+            label: "Read notes",
+            icon: "bi bi-journal-text",
+            result: ResultKind::Notes,
+        },
+        "list_collections" => ToolMeta {
+            label: "Listed collections",
+            icon: "bi bi-folder",
+            result: ResultKind::Names,
+        },
+        "list_tags" => ToolMeta {
+            label: "Listed tags",
+            icon: "bi bi-tags",
+            result: ResultKind::Names,
+        },
+        "get_papers_in_collection" => ToolMeta {
+            label: "Listed collection",
+            icon: "bi bi-folder2-open",
+            result: ResultKind::Papers,
+        },
+        "get_papers_by_tag" => ToolMeta {
+            label: "Listed tagged papers",
+            icon: "bi bi-tag",
+            result: ResultKind::Papers,
+        },
+        "extract_pdf_text" => ToolMeta {
+            label: "Read PDF",
+            icon: "bi bi-file-text",
+            result: ResultKind::ExtractedText,
+        },
+        "add_note" => ToolMeta {
+            label: "Added note",
+            icon: "bi bi-journal-plus",
+            result: ResultKind::Confirmation,
+        },
+        "update_note" => ToolMeta {
+            label: "Updated note",
+            icon: "bi bi-pencil",
+            result: ResultKind::Confirmation,
+        },
+        "add_tag_to_paper" => ToolMeta {
+            label: "Tagged paper",
+            icon: "bi bi-tag",
+            result: ResultKind::Confirmation,
+        },
+        "set_paper_read" => ToolMeta {
+            label: "Marked as read",
+            icon: "bi bi-check2-circle",
+            result: ResultKind::Confirmation,
+        },
+        "set_paper_favorite" => ToolMeta {
+            label: "Favorited",
+            icon: "bi bi-star",
+            result: ResultKind::Confirmation,
+        },
+        "add_paper" => ToolMeta {
+            label: "Added paper",
+            icon: "bi bi-plus-circle",
+            result: ResultKind::Confirmation,
+        },
+        "update_paper" => ToolMeta {
+            label: "Updated paper",
+            icon: "bi bi-pencil",
+            result: ResultKind::Confirmation,
+        },
+        "delete_paper" => ToolMeta {
+            label: "Deleted paper",
+            icon: "bi bi-trash",
+            result: ResultKind::Confirmation,
+        },
+        "remove_tag_from_paper" => ToolMeta {
+            label: "Removed tag",
+            icon: "bi bi-tag",
+            result: ResultKind::Confirmation,
+        },
+        "create_collection" => ToolMeta {
+            label: "Created collection",
+            icon: "bi bi-folder-plus",
+            result: ResultKind::Confirmation,
+        },
+        "add_paper_to_collection" => ToolMeta {
+            label: "Added to collection",
+            icon: "bi bi-folder-plus",
+            result: ResultKind::Confirmation,
+        },
+        "remove_paper_from_collection" => ToolMeta {
+            label: "Removed from collection",
+            icon: "bi bi-folder-minus",
+            result: ResultKind::Confirmation,
+        },
+        "delete_collection" => ToolMeta {
+            label: "Deleted collection",
+            icon: "bi bi-trash",
+            result: ResultKind::Confirmation,
+        },
+        "rename_collection" => ToolMeta {
+            label: "Renamed collection",
+            icon: "bi bi-pencil",
+            result: ResultKind::Confirmation,
+        },
+        "rename_tag" => ToolMeta {
+            label: "Renamed tag",
+            icon: "bi bi-pencil",
+            result: ResultKind::Confirmation,
+        },
+        "delete_tag" => ToolMeta {
+            label: "Deleted tag",
+            icon: "bi bi-trash",
+            result: ResultKind::Confirmation,
+        },
+        "delete_note" => ToolMeta {
+            label: "Deleted note",
+            icon: "bi bi-trash",
+            result: ResultKind::Confirmation,
+        },
+        "download_pdf" => ToolMeta {
+            label: "Downloaded PDF",
+            icon: "bi bi-download",
+            result: ResultKind::Confirmation,
+        },
+        "get_paper_relationships" => ToolMeta {
+            label: "Found related papers",
+            icon: "bi bi-diagram-3",
+            result: ResultKind::Relationships,
+        },
+        "get_library_graph" => ToolMeta {
+            label: "Built citation graph",
+            icon: "bi bi-share",
+            result: ResultKind::Graph,
+        },
+        _ => return None,
+    })
+}
+
+pub fn describe_tool(
+    title: &str,
+    raw_input: &Option<serde_json::Value>,
+    output: Option<&str>,
+    lookups: &ToolLookups<'_>,
+) -> Option<RoteroChip> {
+    let name = bare_tool_name(title);
+    let meta = descriptor(name)?;
+    let input = raw_input.as_ref();
+    let label = dynamic_label(name, input, meta.label);
+    let summary = tool_summary(name, input, output, lookups);
+    Some(RoteroChip {
+        icon: meta.icon,
+        label,
+        summary,
+        result: meta.result,
+    })
+}
+
+fn dynamic_label(name: &str, input: Option<&serde_json::Value>, fallback: &'static str) -> String {
+    match name {
+        "set_paper_read" => {
+            if input
+                .and_then(|v| v.get("is_read"))
+                .and_then(|v| v.as_bool())
+                == Some(false)
+            {
+                "Marked as unread".into()
+            } else {
+                fallback.into()
+            }
+        }
+        "set_paper_favorite" => {
+            if input
+                .and_then(|v| v.get("is_favorite"))
+                .and_then(|v| v.as_bool())
+                == Some(false)
+            {
+                "Removed favorite".into()
+            } else {
+                fallback.into()
+            }
+        }
+        _ => fallback.into(),
+    }
+}
+
+fn tool_summary(
+    name: &str,
+    input: Option<&serde_json::Value>,
+    output: Option<&str>,
+    lookups: &ToolLookups<'_>,
+) -> String {
+    match name {
+        "search_papers" | "search_online" => input_str(input, &["query", "q"])
+            .map(|q| truncate(&q, 60))
+            .unwrap_or_default(),
+        "find_pdf" => input_str(input, &["title"])
+            .filter(|s| !looks_like_id(s))
+            .map(|t| quote(&t))
+            .or_else(|| input_str(input, &["doi"]).map(|d| truncate(&d, 40)))
+            .unwrap_or_default(),
+        "get_paper"
+        | "get_paper_annotations"
+        | "get_paper_notes"
+        | "extract_pdf_text"
+        | "set_paper_read"
+        | "set_paper_favorite"
+        | "update_paper"
+        | "delete_paper"
+        | "download_pdf"
+        | "get_paper_relationships" => named_paper(input, output, lookups),
+        "list_papers" => output.and_then(paper_count_hint).unwrap_or_default(),
+        "get_papers_in_collection" => named_collection(input, lookups),
+        "get_papers_by_tag" => named_tag(input, lookups),
+        "add_note" => {
+            let paper = named_paper(input, output, lookups);
+            match input_str(input, &["title"]) {
+                Some(note) if !paper.is_empty() => format!("{paper} — {note}"),
+                Some(note) => note,
+                None => paper,
+            }
+        }
+        "update_note" | "delete_note" => input_str(input, &["title"]).unwrap_or_default(),
+        "add_tag_to_paper" => {
+            let papers = named_papers(input, output, lookups);
+            let tags = input_string_list(input, "tag_names");
+            match (papers.is_empty(), tags.is_empty()) {
+                (false, false) => format!("{papers} as {tags}"),
+                (false, true) => papers,
+                (true, false) => tags,
+                (true, true) => String::new(),
+            }
+        }
+        "remove_tag_from_paper" => {
+            let papers = named_papers(input, output, lookups);
+            let tags = named_tags(input, lookups);
+            match (papers.is_empty(), tags.is_empty()) {
+                (false, false) => format!("{tags} from {papers}"),
+                (false, true) => papers,
+                (true, false) => tags,
+                (true, true) => String::new(),
+            }
+        }
+        "add_paper" => input_str(input, &["title"])
+            .filter(|s| !looks_like_id(s))
+            .map(|t| quote(&t))
+            .unwrap_or_else(|| named_paper(input, output, lookups)),
+        "create_collection" | "rename_collection" => input_str(input, &["name"])
+            .filter(|s| !looks_like_id(s))
+            .map(|n| quote(&n))
+            .unwrap_or_else(|| named_collection(input, lookups)),
+        "add_paper_to_collection" | "remove_paper_from_collection" => {
+            let papers = named_papers(input, output, lookups);
+            let colls = named_collections(input, lookups);
+            match (papers.is_empty(), colls.is_empty()) {
+                (false, false) => format!("{papers} → {colls}"),
+                (false, true) => papers,
+                (true, false) => colls,
+                (true, true) => String::new(),
+            }
+        }
+        "delete_collection" => named_collection(input, lookups),
+        "rename_tag" => input_str(input, &["name"])
+            .filter(|s| !looks_like_id(s))
+            .map(|n| quote(&n))
+            .unwrap_or_else(|| named_tag(input, lookups)),
+        "delete_tag" => named_tag(input, lookups),
+        "get_library_graph" => graph_summary(output).unwrap_or_default(),
+        "list_collections" | "list_tags" => String::new(),
+        _ => String::new(),
+    }
+}
+
+/// One-line confirmation for mutation tools. Never includes ids or `success`.
+pub fn confirmation_line(chip: &RoteroChip) -> String {
+    if chip.summary.is_empty() {
+        chip.label.clone()
+    } else {
+        format!("{} {}", chip.label, chip.summary)
+    }
+}
+
+fn named_paper(
+    input: Option<&serde_json::Value>,
+    output: Option<&str>,
+    lookups: &ToolLookups<'_>,
+) -> String {
+    if let Some(title) = input_str(input, &["title"]).filter(|s| !looks_like_id(s)) {
+        return quote(&title);
+    }
+    let Some(id) = first_paper_id(input) else {
+        if let Some(title) = title_from_output(output) {
+            return quote(&title);
+        }
+        return String::new();
+    };
+    quote_or(resolve_paper_title(&id, output, lookups), "a paper")
+}
+
+fn named_papers(
+    input: Option<&serde_json::Value>,
+    output: Option<&str>,
+    lookups: &ToolLookups<'_>,
+) -> String {
+    let ids = paper_ids(input);
+    if ids.is_empty() {
+        return named_paper(input, output, lookups);
+    }
+    let titles: Vec<String> = ids
+        .iter()
+        .filter_map(|id| resolve_paper_title(id, output, lookups))
+        .collect();
+    join_quoted(&titles, ids.len(), "paper", "papers")
+}
+
+fn named_collection(input: Option<&serde_json::Value>, lookups: &ToolLookups<'_>) -> String {
+    if let Some(name) = input_str(input, &["name"]).filter(|s| !looks_like_id(s)) {
+        return quote(&name);
+    }
+    let Some(id) = input_str(input, &["collection_id"]) else {
+        return String::new();
+    };
+    quote_or(
+        lookups.collection_name(&id).map(str::to_string),
+        "a collection",
+    )
+}
+
+fn named_collections(input: Option<&serde_json::Value>, lookups: &ToolLookups<'_>) -> String {
+    let ids = string_list(input, "collection_ids");
+    if ids.is_empty() {
+        return named_collection(input, lookups);
+    }
+    let names: Vec<String> = ids
+        .iter()
+        .filter_map(|id| lookups.collection_name(id).map(str::to_string))
+        .collect();
+    join_quoted(&names, ids.len(), "collection", "collections")
+}
+
+fn named_tag(input: Option<&serde_json::Value>, lookups: &ToolLookups<'_>) -> String {
+    if let Some(name) = input_str(input, &["name"]).filter(|s| !looks_like_id(s)) {
+        return quote(&name);
+    }
+    let Some(id) = input_str(input, &["tag_id"]) else {
+        return String::new();
+    };
+    quote_or(lookups.tag_name(&id).map(str::to_string), "a tag")
+}
+
+fn named_tags(input: Option<&serde_json::Value>, lookups: &ToolLookups<'_>) -> String {
+    let names = input_string_list(input, "tag_names");
+    if !names.is_empty() {
+        return names;
+    }
+    let ids = string_list(input, "tag_ids");
+    if ids.is_empty() {
+        return named_tag(input, lookups);
+    }
+    let names: Vec<String> = ids
+        .iter()
+        .filter_map(|id| lookups.tag_name(id).map(str::to_string))
+        .collect();
+    join_quoted(&names, ids.len(), "tag", "tags")
+}
+
+fn resolve_paper_title(
+    id: &str,
+    output: Option<&str>,
+    lookups: &ToolLookups<'_>,
+) -> Option<String> {
+    if let Some(title) = lookups.paper_title(id) {
+        return Some(title.to_string());
+    }
+    let papers = output.map(papers_from_tool_output).unwrap_or_default();
+    papers
+        .into_iter()
+        .find(|p| p.id.as_deref() == Some(id))
+        .map(|p| p.title)
+        .filter(|t| !t.is_empty())
+}
+
+fn title_from_output(output: Option<&str>) -> Option<String> {
+    let mut papers = output.map(papers_from_tool_output).unwrap_or_default();
+    if papers.len() == 1 {
+        let title = papers.remove(0).title;
+        if title.is_empty() { None } else { Some(title) }
+    } else {
+        None
+    }
+}
+
+fn quote_or(title: Option<String>, fallback: &str) -> String {
+    match title {
+        Some(t) => quote(&t),
+        None => fallback.into(),
+    }
+}
+
+fn join_quoted(names: &[String], total: usize, singular: &str, plural: &str) -> String {
+    match (total, names) {
+        (0, _) => String::new(),
+        (1, [n]) => quote(n),
+        (1, []) => format!("a {singular}"),
+        (2, [a, b]) => format!("{} and {}", quote(a), quote(b)),
+        (_, names) if names.len() == total && total <= 2 => names
+            .iter()
+            .map(|n| quote(n))
+            .collect::<Vec<_>>()
+            .join(" and "),
+        (n, _) => format!("{n} {plural}"),
+    }
+}
+
+fn quote(s: &str) -> String {
+    format!("\"{}\"", truncate(s, 60))
+}
+
+fn first_paper_id(input: Option<&serde_json::Value>) -> Option<String> {
+    paper_ids(input).into_iter().next()
+}
+
+fn paper_ids(input: Option<&serde_json::Value>) -> Vec<String> {
+    let mut ids = string_list(input, "paper_ids");
+    if ids.is_empty()
+        && let Some(id) = input_str(input, &["paper_id"])
+    {
+        ids.push(id);
+    }
+    ids
+}
+
+fn input_str(input: Option<&serde_json::Value>, keys: &[&str]) -> Option<String> {
+    let map = input.and_then(|v| v.as_object())?;
+    for key in keys {
+        if let Some(s) = map
+            .get(*key)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn string_list(input: Option<&serde_json::Value>, key: &str) -> Vec<String> {
+    input
+        .and_then(|v| v.get(key))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn input_string_list(input: Option<&serde_json::Value>, key: &str) -> String {
+    let names: Vec<String> = string_list(input, key)
+        .into_iter()
+        .filter(|s| !looks_like_id(s))
+        .collect();
+    match names.as_slice() {
+        [] => String::new(),
+        [one] => one.clone(),
+        [a, b] => format!("{a} and {b}"),
+        rest => rest.join(", "),
+    }
+}
+
+pub fn looks_like_id(s: &str) -> bool {
+    let s = s.trim();
+    if s.len() < 16 {
+        return false;
+    }
+    if !s.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+        return false;
+    }
+    s.chars().filter(|c| c.is_ascii_hexdigit()).count() >= 16
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let head: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+fn paper_count_hint(output: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(output).ok()?;
+    let total = value.get("total").and_then(|v| v.as_u64());
+    let n = papers_from_tool_output(output).len();
+    match (total, n) {
+        (Some(t), _) => Some(format!("{t} in library")),
+        (None, 0) => None,
+        (None, 1) => Some("1 paper".into()),
+        (None, n) => Some(format!("{n} papers")),
+    }
+}
+
+pub fn graph_summary(output: Option<&str>) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(output?).ok()?;
+    let nodes = value
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .map(Vec::len)?;
+    let edges = value
+        .get("edges")
+        .and_then(|v| v.as_array())
+        .map(Vec::len)?;
+    Some(format!(
+        "{nodes} {} · {edges} {}",
+        if nodes == 1 { "paper" } else { "papers" },
+        if edges == 1 {
+            "connection"
+        } else {
+            "connections"
+        }
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteSnippet {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnotationSnippet {
+    pub page: i32,
+    pub kind: String,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelSnippet {
+    pub title: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedText {
+    pub text: String,
+    pub page_start: u32,
+    pub page_end: u32,
+    pub total_pages: u32,
+}
+
+pub fn notes_from_output(output: &str) -> Vec<NoteSnippet> {
+    let mut notes = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        collect_notes(&value, &mut notes);
+    }
+    notes
+}
+
+fn collect_notes(value: &serde_json::Value, notes: &mut Vec<NoteSnippet>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let is_note = map.contains_key("body")
+                && map.contains_key("title")
+                && !map.contains_key("creators");
+            if is_note {
+                let title = map
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let body = map
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !title.is_empty() || !body.is_empty() {
+                    notes.push(NoteSnippet { title, body });
+                }
+            } else {
+                for nested in map.values() {
+                    collect_notes(nested, notes);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_notes(item, notes);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn annotations_from_output(output: &str) -> Vec<AnnotationSnippet> {
+    let mut anns = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        collect_annotations(&value, &mut anns);
+    }
+    anns
+}
+
+fn collect_annotations(value: &serde_json::Value, anns: &mut Vec<AnnotationSnippet>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let is_ann = map.contains_key("ann_type")
+                || (map.contains_key("page") && map.contains_key("geometry"));
+            if is_ann {
+                let page = map.get("page").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                let kind = map
+                    .get("ann_type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Annotation")
+                    .to_string();
+                let content = map
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                anns.push(AnnotationSnippet {
+                    page,
+                    kind,
+                    content,
+                });
+            } else {
+                for nested in map.values() {
+                    collect_annotations(nested, anns);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_annotations(item, anns);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn names_from_output(output: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        collect_names(&value, &mut names);
+    }
+    names
+}
+
+fn collect_names(value: &serde_json::Value, names: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(name) = map.get("name").and_then(|v| v.as_str())
+                && !name.is_empty()
+                && !map.contains_key("creators")
+                && !map.contains_key("title")
+            {
+                if !names.iter().any(|seen| seen == name) {
+                    names.push(name.to_string());
+                }
+                return;
+            }
+            for nested in map.values() {
+                collect_names(nested, names);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_names(item, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn relationships_from_output(output: &str) -> Vec<RelSnippet> {
+    let mut rels = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output) {
+        collect_rels(&value, &mut rels);
+    }
+    rels
+}
+
+fn collect_rels(value: &serde_json::Value, rels: &mut Vec<RelSnippet>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(title) = map
+                .get("related_paper_title")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                let label = map
+                    .get("label")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| map.get("relationship_type").and_then(|v| v.as_str()))
+                    .unwrap_or("")
+                    .to_string();
+                rels.push(RelSnippet {
+                    title: title.to_string(),
+                    label,
+                });
+            } else {
+                for nested in map.values() {
+                    collect_rels(nested, rels);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_rels(item, rels);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn urls_from_output(output: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(output) else {
+        return Vec::new();
+    };
+    match value {
+        serde_json::Value::Array(items) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                serde_json::Value::String(s) if !s.is_empty() => Some(s),
+                serde_json::Value::Object(map) => map
+                    .get("url")
+                    .or_else(|| map.get("pdf_url"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+                _ => None,
+            })
+            .collect(),
+        serde_json::Value::String(s) if s.starts_with("http") => vec![s],
+        _ => Vec::new(),
+    }
+}
+
+pub fn extracted_text_from_output(output: &str) -> Option<ExtractedText> {
+    let value = serde_json::from_str::<serde_json::Value>(output).ok()?;
+    let text = value.get("text").and_then(|v| v.as_str())?.to_string();
+    Some(ExtractedText {
+        text,
+        page_start: value
+            .get("page_start")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1) as u32,
+        page_end: value.get("page_end").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+        total_pages: value
+            .get("total_pages")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32,
+    })
+}
+
+pub fn papers_for_result(output: Option<&str>) -> Vec<PaperSnippet> {
+    output.map(papers_from_tool_output).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paper(id: &str, title: &str) -> Paper {
+        Paper {
+            id: Some(id.to_string()),
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn lookups<'a>(
+        papers: &'a [Paper],
+        collections: &'a [Collection],
+        tags: &'a [Tag],
+    ) -> ToolLookups<'a> {
+        ToolLookups {
+            papers,
+            collections,
+            tags,
+        }
+    }
+
+    fn empty_lookups<'a>() -> ToolLookups<'a> {
+        ToolLookups {
+            papers: &[],
+            collections: &[],
+            tags: &[],
+        }
+    }
+
+    const ROTERO_TOOL_NAMES: &[&str] = &[
+        "search_papers",
+        "search_online",
+        "find_pdf",
+        "get_paper",
+        "list_papers",
+        "get_paper_annotations",
+        "get_paper_notes",
+        "list_collections",
+        "list_tags",
+        "get_papers_in_collection",
+        "get_papers_by_tag",
+        "extract_pdf_text",
+        "add_note",
+        "update_note",
+        "add_tag_to_paper",
+        "set_paper_read",
+        "set_paper_favorite",
+        "add_paper",
+        "update_paper",
+        "delete_paper",
+        "remove_tag_from_paper",
+        "create_collection",
+        "add_paper_to_collection",
+        "remove_paper_from_collection",
+        "delete_collection",
+        "rename_collection",
+        "rename_tag",
+        "delete_tag",
+        "delete_note",
+        "download_pdf",
+        "get_paper_relationships",
+        "get_library_graph",
+    ];
+
+    const PAPER_ID: &str = "11111111-1111-7111-8111-111111111111";
+
+    #[test]
+    fn strips_mcp_prefix() {
+        assert_eq!(bare_tool_name("mcp__rotero__get_paper"), "get_paper");
+        assert_eq!(bare_tool_name("get_paper"), "get_paper");
+        assert_eq!(bare_tool_name("rotero__search_papers"), "search_papers");
+    }
+
+    #[test]
+    fn every_known_tool_has_a_descriptor() {
+        for name in ROTERO_TOOL_NAMES {
+            assert!(descriptor(name).is_some(), "missing descriptor for {name}");
+        }
+        assert_eq!(ROTERO_TOOL_NAMES.len(), 32);
+        assert!(descriptor("web_search").is_none());
+        assert!(descriptor("mcp__rotero__nope").is_none());
+        assert!(descriptor(bare_tool_name("mcp__rotero__get_paper")).is_some());
+    }
+
+    #[test]
+    fn get_paper_uses_library_title_not_id() {
+        let papers = vec![paper(PAPER_ID, "Attention Is All You Need")];
+        let chip = describe_tool(
+            "mcp__rotero__get_paper",
+            &Some(serde_json::json!({ "paper_id": PAPER_ID })),
+            None,
+            &lookups(&papers, &[], &[]),
+        )
+        .unwrap();
+        assert_eq!(chip.label, "Opened paper");
+        assert_eq!(chip.summary, "\"Attention Is All You Need\"");
+        assert!(!chip.summary.contains(PAPER_ID));
+        assert_eq!(chip.result, ResultKind::Papers);
+        assert!(!chip.icon.is_empty());
+    }
+
+    #[test]
+    fn unresolved_paper_id_falls_back_without_the_hash() {
+        let chip = describe_tool(
+            "get_paper",
+            &Some(serde_json::json!({ "paper_id": PAPER_ID })),
+            None,
+            &empty_lookups(),
+        )
+        .unwrap();
+        assert_eq!(chip.summary, "a paper");
+        assert!(!chip.summary.contains(PAPER_ID));
+        assert!(!looks_like_id(&chip.summary));
+    }
+
+    #[test]
+    fn get_paper_title_from_tool_output_when_library_is_empty() {
+        let output = serde_json::to_string(&paper(PAPER_ID, "Attention Is All You Need")).unwrap();
+        let chip = describe_tool(
+            "get_paper",
+            &Some(serde_json::json!({ "paper_id": PAPER_ID })),
+            Some(&output),
+            &empty_lookups(),
+        )
+        .unwrap();
+        assert_eq!(chip.summary, "\"Attention Is All You Need\"");
+    }
+
+    #[test]
+    fn search_summary_is_the_query() {
+        let chip = describe_tool(
+            "search_papers",
+            &Some(serde_json::json!({ "query": "attention transformers" })),
+            None,
+            &empty_lookups(),
+        )
+        .unwrap();
+        assert_eq!(chip.label, "Searched papers");
+        assert_eq!(chip.summary, "attention transformers");
+        assert_eq!(chip.result, ResultKind::Papers);
+    }
+
+    #[test]
+    fn add_tag_summary_uses_title_and_tag_name() {
+        let papers = vec![paper(PAPER_ID, "Attention Is All You Need")];
+        let chip = describe_tool(
+            "add_tag_to_paper",
+            &Some(serde_json::json!({
+                "paper_ids": [PAPER_ID],
+                "tag_names": ["transformers"]
+            })),
+            None,
+            &lookups(&papers, &[], &[]),
+        )
+        .unwrap();
+        assert_eq!(
+            chip.summary,
+            "\"Attention Is All You Need\" as transformers"
+        );
+        assert!(!chip.summary.contains(PAPER_ID));
+        assert_eq!(chip.result, ResultKind::Confirmation);
+        assert_eq!(
+            confirmation_line(&chip),
+            "Tagged paper \"Attention Is All You Need\" as transformers"
+        );
+    }
+
+    #[test]
+    fn set_paper_read_label_tracks_the_flag() {
+        let papers = vec![paper(PAPER_ID, "Attention Is All You Need")];
+        let read = describe_tool(
+            "set_paper_read",
+            &Some(serde_json::json!({ "paper_id": PAPER_ID, "is_read": true })),
+            None,
+            &lookups(&papers, &[], &[]),
+        )
+        .unwrap();
+        assert_eq!(read.label, "Marked as read");
+        assert_eq!(read.summary, "\"Attention Is All You Need\"");
+        assert_eq!(
+            confirmation_line(&read),
+            "Marked as read \"Attention Is All You Need\""
+        );
+
+        let unread = describe_tool(
+            "set_paper_read",
+            &Some(serde_json::json!({ "paper_id": PAPER_ID, "is_read": false })),
+            None,
+            &lookups(&papers, &[], &[]),
+        )
+        .unwrap();
+        assert_eq!(unread.label, "Marked as unread");
+    }
+
+    #[test]
+    fn unknown_tools_have_no_descriptor() {
+        assert!(describe_tool("bash", &None, None, &empty_lookups()).is_none());
+        assert!(describe_tool("mcp__other__search", &None, None, &empty_lookups()).is_none());
+    }
+
+    #[test]
+    fn graph_summary_counts_nodes_and_edges() {
+        let json = r#"{"nodes":[{"title":"A"},{"title":"B"}],"edges":[{},{},{}]}"#;
+        assert_eq!(
+            graph_summary(Some(json)).as_deref(),
+            Some("2 papers · 3 connections")
+        );
+        let chip = describe_tool("get_library_graph", &None, Some(json), &empty_lookups()).unwrap();
+        assert_eq!(chip.summary, "2 papers · 3 connections");
+        assert_eq!(chip.result, ResultKind::Graph);
+    }
+
+    #[test]
+    fn notes_and_annotations_hide_ids() {
+        let notes = notes_from_output(
+            r#"[{"id":"aaaaaaaa-aaaa-7aaa-8aaa-aaaaaaaaaaaa","paper_id":"11111111-1111-7111-8111-111111111111","title":"Idea","body":"Compare to BERT"}]"#,
+        );
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].title, "Idea");
+        assert_eq!(notes[0].body, "Compare to BERT");
+
+        let anns = annotations_from_output(
+            r#"[{"id":"bbbbbbbb-bbbb-7bbb-8bbb-bbbbbbbbbbbb","page":3,"ann_type":"Highlight","content":"attention","geometry":{"x":1}}]"#,
+        );
+        assert_eq!(anns.len(), 1);
+        assert_eq!(anns[0].page, 3);
+        assert_eq!(anns[0].kind, "Highlight");
+        assert_eq!(anns[0].content.as_deref(), Some("attention"));
+    }
+
+    #[test]
+    fn looks_like_id_catches_uuids_only() {
+        assert!(looks_like_id(PAPER_ID));
+        assert!(!looks_like_id("attention"));
+        assert!(!looks_like_id("10.1234/abc"));
+    }
+}

--- a/src/ui/chat_panel/rotero_tools.rs
+++ b/src/ui/chat_panel/rotero_tools.rs
@@ -247,6 +247,74 @@ pub fn descriptor(name: &str) -> Option<ToolMeta> {
     })
 }
 
+/// Chip / responded-permission label. Never contains `mcp__`.
+pub fn humanize_tool_title(title: &str) -> String {
+    let name = bare_tool_name(title);
+    let label = descriptor(name)
+        .map(|m| m.label.to_string())
+        .unwrap_or_else(|| {
+            if name.is_empty() {
+                "a tool".into()
+            } else {
+                name.to_string()
+            }
+        });
+    if label.contains("mcp__") {
+        "a tool".into()
+    } else {
+        label
+    }
+}
+
+/// Present-tense action for the allow prompt, e.g. `open a paper`.
+pub fn permission_action(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "search_papers" => "search your papers",
+        "search_online" => "search online for papers",
+        "find_pdf" => "find a PDF",
+        "get_paper" => "open a paper",
+        "list_papers" => "list your papers",
+        "get_paper_annotations" => "read annotations",
+        "get_paper_notes" => "read notes",
+        "list_collections" => "list collections",
+        "list_tags" => "list tags",
+        "get_papers_in_collection" => "list papers in a collection",
+        "get_papers_by_tag" => "list tagged papers",
+        "extract_pdf_text" => "read a PDF",
+        "add_note" => "add a note",
+        "update_note" => "update a note",
+        "add_tag_to_paper" => "tag a paper",
+        "set_paper_read" => "mark a paper as read",
+        "set_paper_favorite" => "favorite a paper",
+        "add_paper" => "add a paper",
+        "update_paper" => "update a paper",
+        "delete_paper" => "delete a paper",
+        "remove_tag_from_paper" => "remove a tag",
+        "create_collection" => "create a collection",
+        "add_paper_to_collection" => "add a paper to a collection",
+        "remove_paper_from_collection" => "remove a paper from a collection",
+        "delete_collection" => "delete a collection",
+        "rename_collection" => "rename a collection",
+        "rename_tag" => "rename a tag",
+        "delete_tag" => "delete a tag",
+        "delete_note" => "delete a note",
+        "download_pdf" => "download a PDF",
+        "get_paper_relationships" => "find related papers",
+        "get_library_graph" => "build the citation graph",
+        _ => return None,
+    })
+}
+
+/// Allow-prompt copy. Known Rotero tools read as `Allow Rotero to …?`.
+pub fn permission_prompt(title: &str) -> String {
+    let name = bare_tool_name(title);
+    if let Some(action) = permission_action(name) {
+        format!("Allow Rotero to {action}?")
+    } else {
+        format!("Allow {}?", humanize_tool_title(title))
+    }
+}
+
 pub fn describe_tool(
     title: &str,
     raw_input: &Option<serde_json::Value>,
@@ -955,6 +1023,46 @@ mod tests {
         assert!(descriptor("web_search").is_none());
         assert!(descriptor("mcp__rotero__nope").is_none());
         assert!(descriptor(bare_tool_name("mcp__rotero__get_paper")).is_some());
+    }
+
+    #[test]
+    fn permission_titles_never_show_mcp_prefix() {
+        for name in ROTERO_TOOL_NAMES {
+            let raw = format!("mcp__rotero__{name}");
+            let chip = humanize_tool_title(&raw);
+            let prompt = permission_prompt(&raw);
+            assert!(
+                !chip.contains("mcp__"),
+                "chip leaked mcp__ for {raw}: {chip}"
+            );
+            assert!(
+                !prompt.contains("mcp__"),
+                "prompt leaked mcp__ for {raw}: {prompt}"
+            );
+            assert_eq!(chip, descriptor(name).unwrap().label);
+            assert!(
+                permission_action(name).is_some(),
+                "missing permission action for {name}"
+            );
+            assert_eq!(
+                prompt,
+                format!("Allow Rotero to {}?", permission_action(name).unwrap())
+            );
+        }
+        assert_eq!(
+            humanize_tool_title("mcp__rotero__get_paper"),
+            "Opened paper"
+        );
+        assert_eq!(
+            permission_prompt("mcp__rotero__get_paper"),
+            "Allow Rotero to open a paper?"
+        );
+        assert_eq!(humanize_tool_title("mcp__other__web_search"), "web_search");
+        assert_eq!(
+            permission_prompt("mcp__other__web_search"),
+            "Allow web_search?"
+        );
+        assert!(!permission_prompt("mcp__other__web_search").contains("mcp__"));
     }
 
     #[test]

--- a/src/ui/chat_panel/tool_call.rs
+++ b/src/ui/chat_panel/tool_call.rs
@@ -1,13 +1,19 @@
 use dioxus::prelude::*;
 
+use super::rotero_tools::{
+    ResultKind, RoteroChip, ToolLookups, annotations_from_output, confirmation_line, describe_tool,
+    extracted_text_from_output, graph_summary, looks_like_id, names_from_output, notes_from_output,
+    papers_for_result, relationships_from_output, urls_from_output,
+};
 use crate::agent::types::{ToolContentBlock, ToolKind, ToolStatus, ToolUse};
-use crate::app::chat_papers::{PaperSnippet, papers_from_tool_output};
+use crate::app::chat_papers::PaperSnippet;
 use crate::state::app_state::LibraryState;
 
 #[component]
 pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
     let mut expanded = use_signal(|| false);
     let mut copied = use_signal(|| false);
+    let lib_state = use_context::<Signal<LibraryState>>();
 
     let (status_icon, status_class, status_label) = match tool.status {
         ToolStatus::Pending => ("bi bi-clock", "chat-tool-call--running", "pending"),
@@ -15,9 +21,36 @@ pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
         ToolStatus::Completed => ("bi bi-check2", "chat-tool-call--done", "done"),
         ToolStatus::Failed => ("bi bi-x-lg", "chat-tool-call--failed", "failed"),
     };
-    let kind_icon = kind_icon(tool.kind);
-    let kind_label = kind_label(tool.kind);
-    let summary = input_summary(&tool.title, &tool.raw_input);
+    let rotero = {
+        let lib = lib_state.read();
+        describe_tool(
+            &tool.title,
+            &tool.raw_input,
+            tool.output.as_deref(),
+            &ToolLookups {
+                papers: &lib.papers,
+                collections: &lib.collections,
+                tags: &lib.tags,
+            },
+        )
+    };
+    let icon_class = rotero
+        .as_ref()
+        .map(|r| r.icon)
+        .unwrap_or_else(|| kind_icon(tool.kind));
+    let label_text = rotero
+        .as_ref()
+        .map(|r| r.label.clone())
+        .unwrap_or_else(|| kind_label(tool.kind).to_string());
+    let summary = rotero
+        .as_ref()
+        .map(|r| r.summary.clone())
+        .unwrap_or_else(|| input_summary(&tool.title, &tool.raw_input));
+    let name_class = if rotero.is_some() {
+        "chat-tool-name chat-tool-name--plain"
+    } else {
+        "chat-tool-name"
+    };
     let chevron = if expanded() {
         "bi bi-chevron-down"
     } else {
@@ -57,19 +90,22 @@ pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
     let papers = tool
         .output
         .as_deref()
-        .map(papers_from_tool_output)
+        .map(crate::app::chat_papers::papers_from_tool_output)
         .unwrap_or_default();
     let json_value = tool
         .output
         .as_deref()
         .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
-    let has_typed_body = !diffs.is_empty() || !resources.is_empty() || !papers.is_empty();
+    let rotero_body = rotero.is_some();
+    let has_typed_body =
+        !diffs.is_empty() || !resources.is_empty() || !papers.is_empty() || rotero_body;
     let output_text = tool.output.clone();
     let copy_text = tool.output.clone().or_else(|| {
         json_value
             .as_ref()
             .map(|v| serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string()))
     });
+    let failed = tool.status == ToolStatus::Failed;
 
     rsx! {
         div { class: "chat-tool",
@@ -77,9 +113,11 @@ pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
                 class: "chat-tool-call {status_class} {open_class}",
                 r#type: "button",
                 onclick: move |_| expanded.set(!expanded()),
-                i { class: "{kind_icon} chat-tool-kind-icon", title: "{kind_label}" }
-                span { class: "chat-tool-kind", "{kind_label}" }
-                span { class: "chat-tool-name", "{summary}" }
+                i { class: "{icon_class} chat-tool-kind-icon", title: "{label_text}" }
+                span { class: "chat-tool-kind", "{label_text}" }
+                if !summary.is_empty() {
+                    span { class: "{name_class}", "{summary}" }
+                }
                 span { class: "chat-tool-pill",
                     i { class: "{status_icon}" }
                     "{status_label}"
@@ -109,7 +147,14 @@ pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
                             }
                         }
                     }
-                    if !papers.is_empty() {
+                    if let Some(chip) = rotero.clone() {
+                        RoteroResult {
+                            chip,
+                            output: tool.output.clone(),
+                            papers: papers.clone(),
+                            failed,
+                        }
+                    } else if !papers.is_empty() {
                         div { class: "chat-paper-list",
                             for paper in papers.iter() {
                                 ChatPaperCard { key: "{paper.id.as_deref().unwrap_or(paper.title.as_str())}", paper: paper.clone() }
@@ -155,6 +200,196 @@ pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
             }
         }
     }
+}
+
+#[component]
+fn RoteroResult(
+    chip: RoteroChip,
+    output: Option<String>,
+    papers: Vec<PaperSnippet>,
+    failed: bool,
+) -> Element {
+    if failed {
+        let msg = output
+            .as_deref()
+            .map(redact_ids)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "Something went wrong.".into());
+        return rsx! {
+            p { class: "chat-tool-confirm chat-tool-confirm--failed", "{msg}" }
+        };
+    }
+
+    match chip.result {
+        ResultKind::Papers => {
+            let cards = if papers.is_empty() {
+                papers_for_result(output.as_deref())
+            } else {
+                papers
+            };
+            if cards.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "No papers found." } }
+            } else {
+                rsx! {
+                    div { class: "chat-paper-list",
+                        for paper in cards.iter() {
+                            ChatPaperCard {
+                                key: "{paper.id.as_deref().unwrap_or(paper.title.as_str())}",
+                                paper: paper.clone(),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::Notes => {
+            let notes = output.as_deref().map(notes_from_output).unwrap_or_default();
+            if notes.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "No notes." } }
+            } else {
+                rsx! {
+                    div { class: "chat-note-list",
+                        for (i, note) in notes.iter().enumerate() {
+                            div { key: "{i}", class: "chat-note-card",
+                                if !note.title.is_empty() {
+                                    div { class: "chat-paper-title", "{note.title}" }
+                                }
+                                if !note.body.is_empty() {
+                                    p { class: "chat-note-body", "{note.body}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::Annotations => {
+            let anns = output
+                .as_deref()
+                .map(annotations_from_output)
+                .unwrap_or_default();
+            if anns.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "No annotations." } }
+            } else {
+                rsx! {
+                    div { class: "chat-note-list",
+                        for (i, ann) in anns.iter().enumerate() {
+                            div { key: "{i}", class: "chat-note-card",
+                                div { class: "chat-paper-meta",
+                                    span { "Page {ann.page}" }
+                                    span { class: "chat-paper-sep", "\u{00b7}" }
+                                    span { "{ann.kind}" }
+                                }
+                                if let Some(content) = ann.content.as_ref() {
+                                    p { class: "chat-note-body", "{content}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::Names => {
+            let names = output.as_deref().map(names_from_output).unwrap_or_default();
+            if names.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "Nothing listed." } }
+            } else {
+                rsx! {
+                    ul { class: "chat-name-list",
+                        for (i, name) in names.iter().enumerate() {
+                            li { key: "{i}", "{name}" }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::Confirmation => {
+            let line = confirmation_line(&chip);
+            rsx! { p { class: "chat-tool-confirm", "{line}" } }
+        }
+        ResultKind::Graph => {
+            let line = output
+                .as_deref()
+                .and_then(|s| graph_summary(Some(s)))
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| {
+                    if chip.summary.is_empty() {
+                        "No connections.".into()
+                    } else {
+                        chip.summary.clone()
+                    }
+                });
+            rsx! { p { class: "chat-tool-confirm", "{line}" } }
+        }
+        ResultKind::Relationships => {
+            let rels = output
+                .as_deref()
+                .map(relationships_from_output)
+                .unwrap_or_default();
+            if rels.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "No related papers." } }
+            } else {
+                rsx! {
+                    ul { class: "chat-name-list",
+                        for (i, rel) in rels.iter().enumerate() {
+                            li { key: "{i}",
+                                span { class: "chat-paper-title", "{rel.title}" }
+                                if !rel.label.is_empty() {
+                                    span { class: "chat-paper-meta", " · {rel.label}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::PdfUrls => {
+            let urls = output.as_deref().map(urls_from_output).unwrap_or_default();
+            if urls.is_empty() {
+                rsx! { p { class: "chat-tool-confirm", "No PDF found." } }
+            } else {
+                rsx! {
+                    ul { class: "chat-name-list",
+                        for (i, url) in urls.iter().enumerate() {
+                            li { key: "{i}", class: "chat-resource-uri", "{url}" }
+                        }
+                    }
+                }
+            }
+        }
+        ResultKind::ExtractedText => {
+            if let Some(extracted) = output.as_deref().and_then(extracted_text_from_output) {
+                let pages = if extracted.total_pages > 0 {
+                    format!(
+                        "Pages {start}–{end} of {total}",
+                        start = extracted.page_start,
+                        end = extracted.page_end.max(extracted.page_start),
+                        total = extracted.total_pages
+                    )
+                } else {
+                    "Extracted text".into()
+                };
+                rsx! {
+                    div { class: "chat-extract",
+                        div { class: "chat-paper-meta", "{pages}" }
+                        pre { class: "chat-extract-text", "{extracted.text}" }
+                    }
+                }
+            } else {
+                rsx! { p { class: "chat-tool-confirm", "No extracted text." } }
+            }
+        }
+    }
+}
+
+fn redact_ids(text: &str) -> String {
+    text.split_whitespace()
+        .map(|tok| {
+            let trimmed = tok.trim_matches(|c: char| !c.is_ascii_hexdigit() && c != '-');
+            if looks_like_id(trimmed) { "…" } else { tok }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[component]

--- a/src/ui/chat_panel/tool_call.rs
+++ b/src/ui/chat_panel/tool_call.rs
@@ -1,0 +1,545 @@
+use dioxus::prelude::*;
+
+use crate::agent::types::{ToolContentBlock, ToolKind, ToolStatus, ToolUse};
+use crate::app::chat_papers::{PaperSnippet, papers_from_tool_output};
+use crate::state::app_state::LibraryState;
+
+#[component]
+pub(crate) fn ToolCallView(tool: ToolUse) -> Element {
+    let mut expanded = use_signal(|| false);
+    let mut copied = use_signal(|| false);
+
+    let (status_icon, status_class, status_label) = match tool.status {
+        ToolStatus::Pending => ("bi bi-clock", "chat-tool-call--running", "pending"),
+        ToolStatus::InProgress => ("bi bi-clock", "chat-tool-call--running", "running"),
+        ToolStatus::Completed => ("bi bi-check2", "chat-tool-call--done", "done"),
+        ToolStatus::Failed => ("bi bi-x-lg", "chat-tool-call--failed", "failed"),
+    };
+    let kind_icon = kind_icon(tool.kind);
+    let kind_label = kind_label(tool.kind);
+    let summary = input_summary(&tool.title, &tool.raw_input);
+    let chevron = if expanded() {
+        "bi bi-chevron-down"
+    } else {
+        "bi bi-chevron-right"
+    };
+    let open_class = if expanded() {
+        "chat-tool-call--open"
+    } else {
+        ""
+    };
+
+    let diffs: Vec<(String, Option<String>, String)> = tool
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ToolContentBlock::Diff {
+                path,
+                old_text,
+                new_text,
+            } => Some((path.clone(), old_text.clone(), new_text.clone())),
+            _ => None,
+        })
+        .collect();
+    let resources: Vec<(String, String, Option<String>, Option<String>)> = tool
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ToolContentBlock::Resource {
+                title,
+                uri,
+                mime_type,
+                text,
+            } => Some((title.clone(), uri.clone(), mime_type.clone(), text.clone())),
+            _ => None,
+        })
+        .collect();
+    let papers = tool
+        .output
+        .as_deref()
+        .map(papers_from_tool_output)
+        .unwrap_or_default();
+    let json_value = tool
+        .output
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+    let has_typed_body = !diffs.is_empty() || !resources.is_empty() || !papers.is_empty();
+    let output_text = tool.output.clone();
+    let copy_text = tool.output.clone().or_else(|| {
+        json_value
+            .as_ref()
+            .map(|v| serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string()))
+    });
+
+    rsx! {
+        div { class: "chat-tool",
+            button {
+                class: "chat-tool-call {status_class} {open_class}",
+                r#type: "button",
+                onclick: move |_| expanded.set(!expanded()),
+                i { class: "{kind_icon} chat-tool-kind-icon", title: "{kind_label}" }
+                span { class: "chat-tool-kind", "{kind_label}" }
+                span { class: "chat-tool-name", "{summary}" }
+                span { class: "chat-tool-pill",
+                    i { class: "{status_icon}" }
+                    "{status_label}"
+                }
+                i { class: "{chevron} chat-tool-chevron" }
+            }
+            if expanded() {
+                div { class: "chat-tool-body",
+                    if !diffs.is_empty() {
+                        for (path, old_text, new_text) in diffs.iter() {
+                            DiffView {
+                                key: "{path}",
+                                path: path.clone(),
+                                old_text: old_text.clone(),
+                                new_text: new_text.clone(),
+                            }
+                        }
+                    }
+                    if !resources.is_empty() {
+                        for (title, uri, mime, text) in resources.iter() {
+                            ResourceCard {
+                                key: "{uri}",
+                                title: title.clone(),
+                                uri: uri.clone(),
+                                mime_type: mime.clone(),
+                                text: text.clone(),
+                            }
+                        }
+                    }
+                    if !papers.is_empty() {
+                        div { class: "chat-paper-list",
+                            for paper in papers.iter() {
+                                ChatPaperCard { key: "{paper.id.as_deref().unwrap_or(paper.title.as_str())}", paper: paper.clone() }
+                            }
+                        }
+                    }
+                    if !has_typed_body {
+                        if let Some(value) = json_value.clone() {
+                            JsonBlock {
+                                value,
+                                copied: copied(),
+                                on_copy: move |()| {
+                                    if let Some(text) = copy_text.clone()
+                                        && let Ok(mut clip) = arboard::Clipboard::new()
+                                    {
+                                        let _ = clip.set_text(text);
+                                        copied.set(true);
+                                        spawn(async move {
+                                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                                            copied.set(false);
+                                        });
+                                    }
+                                },
+                            }
+                        } else if let Some(text) = output_text.clone() {
+                            div { class: "chat-tool-output",
+                                pre { "{text}" }
+                            }
+                        } else if !tool.locations.is_empty() {
+                            ul { class: "chat-tool-locations",
+                                for loc in tool.locations.iter() {
+                                    li {
+                                        span { class: "chat-resource-uri", "{loc.path}" }
+                                        if let Some(line) = loc.line {
+                                            span { class: "chat-tool-line", ":{line}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ChatPaperCard(paper: PaperSnippet) -> Element {
+    let mut lib_state = use_context::<Signal<LibraryState>>();
+    let title = paper.title.clone();
+    let authors = paper.authors.clone();
+    let year = paper.year;
+    let id = paper.id.clone();
+    let in_library = id.as_ref().is_some_and(|id| {
+        lib_state
+            .read()
+            .papers
+            .iter()
+            .any(|p| p.id.as_deref() == Some(id.as_str()))
+    });
+
+    rsx! {
+        button {
+            class: "chat-paper-card",
+            r#type: "button",
+            disabled: !in_library,
+            onclick: move |_| {
+                if let Some(id) = id.clone() {
+                    lib_state.with_mut(|s| {
+                        if s.papers.iter().any(|p| p.id.as_deref() == Some(id.as_str())) {
+                            s.select_one(id);
+                        }
+                    });
+                }
+            },
+            div { class: "chat-paper-title", "{title}" }
+            div { class: "chat-paper-meta",
+                span { "{authors}" }
+                if let Some(year) = year {
+                    span { class: "chat-paper-sep", "\u{00b7}" }
+                    span { "{year}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ResourceCard(
+    title: String,
+    uri: String,
+    mime_type: Option<String>,
+    text: Option<String>,
+) -> Element {
+    rsx! {
+        div { class: "chat-resource-card",
+            div { class: "chat-resource-title", "{title}" }
+            div { class: "chat-resource-uri", "{uri}" }
+            if let Some(mime) = mime_type {
+                span { class: "chat-resource-mime", "{mime}" }
+            }
+            if let Some(text) = text {
+                pre { class: "chat-resource-text", "{text}" }
+            }
+        }
+    }
+}
+
+#[component]
+fn DiffView(path: String, old_text: Option<String>, new_text: String) -> Element {
+    let lines = line_diff(old_text.as_deref().unwrap_or(""), &new_text);
+    rsx! {
+        div { class: "chat-diff",
+            div { class: "chat-diff-path", "{path}" }
+            div { class: "chat-diff-lines",
+                for (i, line) in lines.iter().enumerate() {
+                    {
+                        let (class, prefix, text) = match line {
+                            DiffLine::Equal(t) => ("chat-diff-line chat-diff-line--eq", " ", t.as_str()),
+                            DiffLine::Delete(t) => ("chat-diff-line chat-diff-line--del", "-", t.as_str()),
+                            DiffLine::Insert(t) => ("chat-diff-line chat-diff-line--add", "+", t.as_str()),
+                        };
+                        rsx! {
+                            div { key: "{i}", class: "{class}",
+                                span { class: "chat-diff-prefix", "{prefix}" }
+                                span { "{text}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn JsonBlock(value: serde_json::Value, copied: bool, on_copy: EventHandler<()>) -> Element {
+    let pretty = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    let tokens = tokenize_json(&pretty);
+    rsx! {
+        div { class: "chat-json-box",
+            button {
+                class: "chat-json-copy",
+                r#type: "button",
+                onclick: move |_| on_copy.call(()),
+                if copied { "Copied" } else { "Copy" }
+            }
+            pre { class: "chat-json",
+                for (i, (class, text)) in tokens.iter().enumerate() {
+                    span { key: "{i}", class: "{class}", "{text}" }
+                }
+            }
+        }
+    }
+}
+
+fn kind_icon(kind: ToolKind) -> &'static str {
+    match kind {
+        ToolKind::Read => "bi bi-file-text",
+        ToolKind::Edit => "bi bi-pencil",
+        ToolKind::Delete => "bi bi-trash",
+        ToolKind::Move => "bi bi-arrow-left-right",
+        ToolKind::Search => "bi bi-search",
+        ToolKind::Execute => "bi bi-terminal",
+        ToolKind::Think => "bi bi-lightbulb",
+        ToolKind::Fetch => "bi bi-cloud-arrow-down",
+        ToolKind::SwitchMode => "bi bi-toggles",
+        ToolKind::Other => "bi bi-wrench",
+    }
+}
+
+fn kind_label(kind: ToolKind) -> &'static str {
+    match kind {
+        ToolKind::Read => "Read",
+        ToolKind::Edit => "Edit",
+        ToolKind::Delete => "Delete",
+        ToolKind::Move => "Move",
+        ToolKind::Search => "Search",
+        ToolKind::Execute => "Run",
+        ToolKind::Think => "Think",
+        ToolKind::Fetch => "Fetch",
+        ToolKind::SwitchMode => "Mode",
+        ToolKind::Other => "Tool",
+    }
+}
+
+pub(crate) fn input_summary(title: &str, raw_input: &Option<serde_json::Value>) -> String {
+    let arg = raw_input.as_ref().and_then(first_summary_arg);
+    match arg {
+        Some(s) => {
+            let clipped = truncate(&s, 40);
+            if title
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+            {
+                format!("{title}(\"{clipped}\")")
+            } else {
+                format!("{title}  \"{clipped}\"")
+            }
+        }
+        None => title.to_string(),
+    }
+}
+
+fn first_summary_arg(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+        serde_json::Value::Object(map) => {
+            const KEYS: &[&str] = &[
+                "query", "q", "path", "uri", "url", "id", "paper_id", "command", "name", "title",
+                "text", "prompt",
+            ];
+            for key in KEYS {
+                if let Some(s) = map
+                    .get(*key)
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                {
+                    return Some(s.to_string());
+                }
+            }
+            map.values()
+                .find_map(|v| v.as_str().filter(|s| !s.is_empty()).map(str::to_string))
+        }
+        _ => None,
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let mut chars = s.chars();
+    let head: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+fn tokenize_json(s: &str) -> Vec<(&'static str, String)> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c.is_whitespace() {
+            let start = i;
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            out.push(("json-space", chars[start..i].iter().collect()));
+        } else if c == '"' {
+            let start = i;
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == '\\' {
+                    i = (i + 2).min(chars.len());
+                    continue;
+                }
+                if chars[i] == '"' {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            let string: String = chars[start..i].iter().collect();
+            let mut j = i;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            let class = if j < chars.len() && chars[j] == ':' {
+                "json-key"
+            } else {
+                "json-string"
+            };
+            out.push((class, string));
+        } else if c.is_ascii_digit()
+            || (c == '-' && chars.get(i + 1).is_some_and(|n| n.is_ascii_digit()))
+        {
+            let start = i;
+            i += 1;
+            while i < chars.len()
+                && (chars[i].is_ascii_digit() || matches!(chars[i], '.' | 'e' | 'E' | '+' | '-'))
+            {
+                i += 1;
+            }
+            out.push(("json-number", chars[start..i].iter().collect()));
+        } else if starts_with(&chars, i, "true") {
+            out.push(("json-literal", "true".into()));
+            i += 4;
+        } else if starts_with(&chars, i, "false") {
+            out.push(("json-literal", "false".into()));
+            i += 5;
+        } else if starts_with(&chars, i, "null") {
+            out.push(("json-literal", "null".into()));
+            i += 4;
+        } else {
+            out.push(("json-punct", c.to_string()));
+            i += 1;
+        }
+    }
+    out
+}
+
+fn starts_with(chars: &[char], at: usize, word: &str) -> bool {
+    let end = at + word.len();
+    if end > chars.len() {
+        return false;
+    }
+    chars[at..end].iter().copied().eq(word.chars())
+        && chars.get(end).is_none_or(|c| !c.is_ascii_alphanumeric())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DiffLine {
+    Equal(String),
+    Delete(String),
+    Insert(String),
+}
+
+fn line_diff(old: &str, new: &str) -> Vec<DiffLine> {
+    let a: Vec<&str> = if old.is_empty() {
+        Vec::new()
+    } else {
+        old.lines().collect()
+    };
+    let b: Vec<&str> = if new.is_empty() {
+        Vec::new()
+    } else {
+        new.lines().collect()
+    };
+    if a.is_empty() {
+        return b
+            .into_iter()
+            .map(|l| DiffLine::Insert(l.to_string()))
+            .collect();
+    }
+    if b.is_empty() {
+        return a
+            .into_iter()
+            .map(|l| DiffLine::Delete(l.to_string()))
+            .collect();
+    }
+    if a.len().saturating_mul(b.len()) > 160_000 {
+        let mut out: Vec<DiffLine> = a
+            .iter()
+            .map(|l| DiffLine::Delete((*l).to_string()))
+            .collect();
+        out.extend(b.iter().map(|l| DiffLine::Insert((*l).to_string())));
+        return out;
+    }
+    let n = a.len();
+    let m = b.len();
+    let mut dp = vec![vec![0u32; m + 1]; n + 1];
+    for i in 0..n {
+        for j in 0..m {
+            dp[i + 1][j + 1] = if a[i] == b[j] {
+                dp[i][j] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+    let mut rev = Vec::new();
+    let mut i = n;
+    let mut j = m;
+    while i > 0 && j > 0 {
+        if a[i - 1] == b[j - 1] {
+            rev.push(DiffLine::Equal(a[i - 1].to_string()));
+            i -= 1;
+            j -= 1;
+        } else if dp[i][j - 1] >= dp[i - 1][j] {
+            rev.push(DiffLine::Insert(b[j - 1].to_string()));
+            j -= 1;
+        } else {
+            rev.push(DiffLine::Delete(a[i - 1].to_string()));
+            i -= 1;
+        }
+    }
+    while i > 0 {
+        rev.push(DiffLine::Delete(a[i - 1].to_string()));
+        i -= 1;
+    }
+    while j > 0 {
+        rev.push(DiffLine::Insert(b[j - 1].to_string()));
+        j -= 1;
+    }
+    rev.reverse();
+    rev
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_summary_formats_search_query() {
+        assert_eq!(
+            input_summary(
+                "search_papers",
+                &Some(serde_json::json!({"query": "attention"}))
+            ),
+            "search_papers(\"attention\")"
+        );
+    }
+
+    #[test]
+    fn input_summary_falls_back_to_title() {
+        assert_eq!(input_summary("search_papers", &None), "search_papers");
+    }
+
+    #[test]
+    fn line_diff_marks_inserts_and_deletes() {
+        let lines = line_diff("a\nb\nc", "a\nx\nc");
+        assert_eq!(
+            lines,
+            vec![
+                DiffLine::Equal("a".into()),
+                DiffLine::Delete("b".into()),
+                DiffLine::Insert("x".into()),
+                DiffLine::Equal("c".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_json_marks_keys_and_strings() {
+        let tokens = tokenize_json("{\"a\": \"b\"}");
+        let classes: Vec<_> = tokens.iter().map(|(c, _)| *c).collect();
+        assert!(classes.contains(&"json-key"));
+        assert!(classes.contains(&"json-string"));
+    }
+}


### PR DESCRIPTION
## Summary

Chat tool calls currently dump as raw protocol. This makes them readable:

- Type-aware chips for tool calls (search, read, write, etc.)
- Rotero-specific tool descriptors so in-app agent tools show a human label
- Fix the scroll jump when a tool chip expands
- Humanize Rotero permission prompts instead of exposing ACP jargon

## Test plan

- [x] `just test` on this branch
- [ ] Open a paper, ask the agent to search/read/annotate, confirm chips render by type
- [ ] Confirm permission prompts read as Rotero actions, not ACP protocol
- [ ] Expand a tool chip and confirm the transcript does not jump