### PR TITLE
Keep chat memory across provider switches

### DIFF
--- a/crates/rotero-db/src/chat_sessions.rs
+++ b/crates/rotero-db/src/chat_sessions.rs
@@ -99,6 +99,30 @@ fn row_to_session(row: &turso::Row) -> ChatSessionRow {
     }
 }
 
+/// One message in a stored conversation transcript.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ChatMessageRecord {
+    pub id: String,
+    pub session_id: String,
+    pub seq: i64,
+    pub role: String,
+    pub content_json: String,
+    pub created_at: String,
+}
+
+const SELECT_MSG_COLS: &str = "id, session_id, seq, role, content_json, created_at";
+
+fn row_to_message(row: &turso::Row) -> ChatMessageRecord {
+    ChatMessageRecord {
+        id: crate::get_text(row, 0),
+        session_id: crate::get_text(row, 1),
+        seq: crate::get_opt_i64(row, 2).unwrap_or(0),
+        role: crate::get_text(row, 3),
+        content_json: crate::get_text(row, 4),
+        created_at: crate::get_text(row, 5),
+    }
+}
+
 impl Database {
     /// The live conversation for a subject, if one exists.
     ///
@@ -363,5 +387,164 @@ impl Database {
             out.push(crate::get_text(&row, 0));
         }
         Ok(out)
+    }
+
+    /// Messages in a conversation, in chronological order.
+    pub async fn chat_messages_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<ChatMessageRecord>, crate::DbError> {
+        let conn = self.conn();
+        let sql = format!(
+            "SELECT {SELECT_MSG_COLS} FROM chat_messages \
+             WHERE session_id = ?1 ORDER BY seq ASC"
+        );
+        let mut rows = conn
+            .query(&sql, [Value::Text(session_id.to_string())])
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            out.push(row_to_message(&row));
+        }
+        Ok(out)
+    }
+
+    /// Append or update a single message in a conversation.
+    pub async fn append_chat_message(
+        &self,
+        record: &ChatMessageRecord,
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO chat_messages (id, session_id, seq, role, content_json, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(id) DO UPDATE SET \
+                 seq = excluded.seq, \
+                 role = excluded.role, \
+                 content_json = excluded.content_json, \
+                 created_at = excluded.created_at",
+            turso::params::Params::Positional(vec![
+                Value::Text(record.id.clone()),
+                Value::Text(record.session_id.clone()),
+                Value::Integer(record.seq),
+                Value::Text(record.role.clone()),
+                Value::Text(record.content_json.clone()),
+                Value::Text(record.created_at.clone()),
+            ]),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Save multiple messages for a conversation, preserving order.
+    pub async fn save_chat_messages(
+        &self,
+        session_id: &str,
+        records: &[ChatMessageRecord],
+    ) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        for rec in records {
+            conn.execute(
+                "INSERT INTO chat_messages (id, session_id, seq, role, content_json, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT(id) DO UPDATE SET \
+                     seq = excluded.seq, \
+                     role = excluded.role, \
+                     content_json = excluded.content_json, \
+                     created_at = excluded.created_at",
+                turso::params::Params::Positional(vec![
+                    Value::Text(rec.id.clone()),
+                    Value::Text(session_id.to_string()),
+                    Value::Integer(rec.seq),
+                    Value::Text(rec.role.clone()),
+                    Value::Text(rec.content_json.clone()),
+                    Value::Text(rec.created_at.clone()),
+                ]),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Clear all messages for a session.
+    pub async fn clear_chat_messages(&self, session_id: &str) -> Result<(), crate::DbError> {
+        let conn = self.conn();
+        conn.execute(
+            "DELETE FROM chat_messages WHERE session_id = ?1",
+            [Value::Text(session_id.to_string())],
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_db() -> Database {
+        let dir = tempfile::tempdir().unwrap();
+        Database::open(dir.path().to_path_buf()).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn chat_messages_round_trip() {
+        let db = test_db().await;
+
+        let session = ChatSessionRow {
+            session_id: "sess-1".into(),
+            provider_id: "claude".into(),
+            subject_kind: "paper".into(),
+            subject_id: Some("p1".into()),
+            summary: Some("Discussion on attention mechanisms".into()),
+            created_at: "2026-08-31T10:00:00Z".into(),
+            last_used_at: "2026-08-31T10:05:00Z".into(),
+            is_dead: false,
+        };
+        db.upsert_chat_session(&session, &[]).await.unwrap();
+
+        let msg1 = ChatMessageRecord {
+            id: "msg-1".into(),
+            session_id: "sess-1".into(),
+            seq: 1,
+            role: "user".into(),
+            content_json: r#"[{"Text":"What is multi-head attention?"}]"#.into(),
+            created_at: "2026-08-31T10:00:05Z".into(),
+        };
+        let msg2 = ChatMessageRecord {
+            id: "msg-2".into(),
+            session_id: "sess-1".into(),
+            seq: 2,
+            role: "assistant".into(),
+            content_json: r#"[{"Text":"Multi-head attention allows the model to jointly attend to information..."}]"#.into(),
+            created_at: "2026-08-31T10:00:15Z".into(),
+        };
+
+        db.append_chat_message(&msg1).await.unwrap();
+        db.append_chat_message(&msg2).await.unwrap();
+
+        let loaded = db.chat_messages_for_session("sess-1").await.unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0], msg1);
+        assert_eq!(loaded[1], msg2);
+        assert_eq!(loaded[0].seq, 1);
+        assert_eq!(loaded[1].seq, 2);
+
+        // Update an existing message by ID
+        let mut msg2_updated = msg2.clone();
+        msg2_updated.content_json = r#"[{"Text":"Updated explanation"}]"#.into();
+        db.append_chat_message(&msg2_updated).await.unwrap();
+
+        let reloaded = db.chat_messages_for_session("sess-1").await.unwrap();
+        assert_eq!(reloaded.len(), 2);
+        assert_eq!(
+            reloaded[1].content_json,
+            r#"[{"Text":"Updated explanation"}]"#
+        );
+
+        // Clear messages
+        db.clear_chat_messages("sess-1").await.unwrap();
+        let cleared = db.chat_messages_for_session("sess-1").await.unwrap();
+        assert!(cleared.is_empty());
     }
 }

--- a/crates/rotero-db/src/schema/migrations.rs
+++ b/crates/rotero-db/src/schema/migrations.rs
@@ -5,7 +5,7 @@ use turso::Connection;
 use super::tables::{CREATE_FTS_INDEX, CREATE_LIVE_VIEWS, CREATE_TABLES};
 
 /// Current schema version; incremented with each migration.
-pub const SCHEMA_VERSION: i64 = 18;
+pub const SCHEMA_VERSION: i64 = 19;
 
 /// Why a database could not be prepared for use.
 #[derive(Debug, thiserror::Error)]
@@ -408,6 +408,31 @@ async fn run_migrations(conn: &Connection) -> Result<(), SchemaError> {
     let _ = conn
         .execute("ALTER TABLE papers ADD COLUMN pdf_sha256 TEXT", ())
         .await;
+
+    if current_version < 19 {
+        // Individual messages belonging to a conversation, ordered by seq.
+        // Local-only, not synced.
+        let _ = conn
+            .execute(
+                "CREATE TABLE IF NOT EXISTS chat_messages (
+                    id           TEXT PRIMARY KEY,
+                    session_id   TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+                    seq          INTEGER NOT NULL,
+                    role         TEXT NOT NULL,
+                    content_json TEXT NOT NULL,
+                    created_at   TEXT NOT NULL
+                )",
+                (),
+            )
+            .await;
+        let _ = conn
+            .execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_messages_session_seq \
+                 ON chat_messages (session_id, seq)",
+                (),
+            )
+            .await;
+    }
 
     if current_version < SCHEMA_VERSION {
         conn.execute("UPDATE schema_version SET version = ?1", [SCHEMA_VERSION])

--- a/crates/rotero-db/src/schema/sql/tables.sql
+++ b/crates/rotero-db/src/schema/sql/tables.sql
@@ -127,6 +127,19 @@ CREATE TABLE IF NOT EXISTS chat_session_papers (
 CREATE INDEX IF NOT EXISTS idx_chat_sessions_subject ON chat_sessions (subject_kind, subject_id);
 CREATE INDEX IF NOT EXISTS idx_chat_session_papers_paper ON chat_session_papers (paper_id);
 
+-- Individual messages belonging to a conversation. Local-only, ordered by seq.
+-- content_json holds the serialized message content (text, tool calls, errors).
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id           TEXT PRIMARY KEY,
+    session_id   TEXT NOT NULL REFERENCES chat_sessions(session_id) ON DELETE CASCADE,
+    seq          INTEGER NOT NULL,
+    role         TEXT NOT NULL,
+    content_json TEXT NOT NULL,
+    created_at   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_session_seq ON chat_messages (session_id, seq);
+
 CREATE TABLE IF NOT EXISTS annotations (
     id          TEXT PRIMARY KEY,
     paper_id    TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,

--- a/crates/rotero-db/tests/chat_sessions_test.rs
+++ b/crates/rotero-db/tests/chat_sessions_test.rs
@@ -251,7 +251,82 @@ async fn chat_tables_are_not_synced() {
     for table in rotero_db::sync_schema::SYNCED_TABLES {
         assert_ne!(table.name, "chat_sessions");
         assert_ne!(table.name, "chat_session_papers");
+        assert_ne!(table.name, "chat_messages");
     }
+}
+
+/// Transcripts survive and can be retrieved across sessions and providers.
+#[tokio::test]
+async fn transcript_persists_across_sessions_and_providers() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = common::open_test_db(dir.path()).await;
+    let paper = insert(&db, "Deep Residual Learning").await;
+    let subject = ChatSubject::Paper(paper);
+
+    // Initial session with Claude
+    let claude_row = row("sess-claude", &subject);
+    db.upsert_chat_session(&claude_row, &subject.paper_ids())
+        .await
+        .unwrap();
+
+    let msg1 = rotero_db::chat_sessions::ChatMessageRecord {
+        id: "sess-claude:1".into(),
+        session_id: "sess-claude".into(),
+        seq: 1,
+        role: "user".into(),
+        content_json: r#"[{"Text":"Explain residual connections"}]"#.into(),
+        created_at: "2026-08-31T12:00:00Z".into(),
+    };
+    let msg2 = rotero_db::chat_sessions::ChatMessageRecord {
+        id: "sess-claude:2".into(),
+        session_id: "sess-claude".into(),
+        seq: 2,
+        role: "assistant".into(),
+        content_json: r#"[{"Text":"Residual connections allow gradients to flow directly..."}]"#
+            .into(),
+        created_at: "2026-08-31T12:00:10Z".into(),
+    };
+
+    db.append_chat_message(&msg1).await.unwrap();
+    db.append_chat_message(&msg2).await.unwrap();
+
+    // Query conversation for subject
+    let session = db
+        .chat_session_for_subject(&subject)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.session_id, "sess-claude");
+
+    let messages = db
+        .chat_messages_for_session(&session.session_id)
+        .await
+        .unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, "user");
+    assert_eq!(messages[1].role, "assistant");
+
+    // Switch provider to Grok: update the session with new provider and append message
+    let mut grok_row = session.clone();
+    grok_row.provider_id = "grok".into();
+    grok_row.last_used_at = "2026-08-31T12:05:00Z".into();
+    db.upsert_chat_session(&grok_row, &subject.paper_ids())
+        .await
+        .unwrap();
+
+    let msg3 = rotero_db::chat_sessions::ChatMessageRecord {
+        id: "sess-claude:3".into(),
+        session_id: "sess-claude".into(),
+        seq: 3,
+        role: "user".into(),
+        content_json: r#"[{"Text":"How does it compare to Highway Networks?"}]"#.into(),
+        created_at: "2026-08-31T12:05:05Z".into(),
+    };
+    db.append_chat_message(&msg3).await.unwrap();
+
+    let updated_messages = db.chat_messages_for_session("sess-claude").await.unwrap();
+    assert_eq!(updated_messages.len(), 3);
+    assert_eq!(updated_messages[2].seq, 3);
 }
 
 /// The bug this guards: the row is created when the agent announces the session

--- a/crates/rotero-db/tests/sync_schema_test.rs
+++ b/crates/rotero-db/tests/sync_schema_test.rs
@@ -121,6 +121,10 @@ async fn every_table_either_syncs_or_is_declared_local() {
         // These carry none of the bookkeeping columns and have no `_live` view.
         ("chat_sessions", "agent session ids are machine-local"),
         ("chat_session_papers", "child of chat_sessions"),
+        (
+            "chat_messages",
+            "chat transcript is machine-local; child of local-only chat_sessions",
+        ),
     ];
 
     let dir = tempfile::tempdir().unwrap();

--- a/src/agent/helpers.rs
+++ b/src/agent/helpers.rs
@@ -408,6 +408,7 @@ pub(crate) fn strip_protocol_tags(text: &str) -> String {
         "status",
         "summary",
         "rotero-context",
+        "rotero-conversation-history",
     ];
 
     let mut result = text.to_string();
@@ -430,6 +431,62 @@ pub(crate) fn strip_protocol_tags(text: &str) -> String {
     }
 
     result
+}
+
+/// Format prior chat messages into a structured `<rotero-conversation-history>` block
+/// to prime an ACP agent when resuming across providers or on fresh sessions.
+pub(crate) fn format_conversation_history(messages: &[crate::agent::types::ChatMessage]) -> String {
+    let visible_msgs: Vec<_> = messages.iter().filter(|m| !m.hidden).collect();
+    if visible_msgs.is_empty() {
+        return String::new();
+    }
+    // Limit to the most recent 20 messages to avoid token limit overflow while preserving recent context
+    let window_start = visible_msgs.len().saturating_sub(20);
+    let mut lines = Vec::new();
+
+    for msg in &visible_msgs[window_start..] {
+        let role_label = match msg.role {
+            crate::agent::types::ChatRole::User => "User",
+            crate::agent::types::ChatRole::Assistant => "Assistant",
+        };
+        let mut parts = Vec::new();
+        for content in &msg.content {
+            match content {
+                crate::agent::types::MessageContent::Text(t) => {
+                    let cleaned = strip_protocol_tags(t).trim().to_string();
+                    if !cleaned.is_empty() {
+                        parts.push(cleaned);
+                    }
+                }
+                crate::agent::types::MessageContent::ToolUse(tool) => {
+                    if let Some(out) = &tool.output {
+                        let snippet: String = out.chars().take(150).collect();
+                        parts.push(format!("[Tool '{}': {snippet}]", tool.title));
+                    } else {
+                        parts.push(format!("[Tool '{}']", tool.title));
+                    }
+                }
+                crate::agent::types::MessageContent::Error(e) => {
+                    parts.push(format!("[Error: {e}]"));
+                }
+                crate::agent::types::MessageContent::Permission { tool_title, .. } => {
+                    parts.push(format!("[Permitted: {tool_title}]"));
+                }
+            }
+        }
+        if !parts.is_empty() {
+            lines.push(format!("{role_label}: {}", parts.join(" ")));
+        }
+    }
+
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "\n<rotero-conversation-history>\nPrior conversation history:\n{}\n</rotero-conversation-history>",
+        lines.join("\n")
+    )
 }
 
 /// Paper ids named in a message's `<rotero-context>` blocks, in order.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,4 +1,4 @@
-mod helpers;
+pub(crate) mod helpers;
 pub(crate) mod install;
 pub(crate) mod launch;
 pub(crate) mod node;

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ChatRole {
     User,
     Assistant,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MessageContent {
     Text(String),
     ToolUse(ToolUse),
@@ -23,7 +23,7 @@ pub enum MessageContent {
 ///
 /// Extra ACP fields (`kind`, `raw_input`, `locations`, typed `content`) are
 /// optional so an older event that only had title + status still renders.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ToolUse {
     pub id: String,
     pub title: String,
@@ -35,7 +35,7 @@ pub struct ToolUse {
     pub content: Vec<ToolContentBlock>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum ToolKind {
     Read,
     Edit,
@@ -50,7 +50,7 @@ pub enum ToolKind {
     Other,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ToolLocation {
     pub path: String,
     pub line: Option<u32>,
@@ -58,7 +58,7 @@ pub struct ToolLocation {
 
 /// Displayable pieces of a tool call, copied out of ACP so the UI crate
 /// does not depend on the protocol types.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ToolContentBlock {
     Text(String),
     Diff {
@@ -74,7 +74,7 @@ pub enum ToolContentBlock {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ToolStatus {
     Pending,
     InProgress,
@@ -82,7 +82,7 @@ pub enum ToolStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChatMessage {
     pub role: ChatRole,
     pub content: Vec<MessageContent>,

--- a/src/app/chat_handler.rs
+++ b/src/app/chat_handler.rs
@@ -127,6 +127,78 @@ pub fn record_session(
     });
 }
 
+/// Persist a single chat message to the database.
+pub fn persist_chat_message(db: &Database, session_id: &str, seq: i64, message: &ChatMessage) {
+    if message.hidden {
+        return;
+    }
+    let role = match message.role {
+        ChatRole::User => "user",
+        ChatRole::Assistant => "assistant",
+    };
+    let content_json = match serde_json::to_string(&message.content) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::warn!("chat: failed to serialize message content: {e}");
+            return;
+        }
+    };
+    let record = rotero_db::chat_sessions::ChatMessageRecord {
+        id: format!("{session_id}:{seq}"),
+        session_id: session_id.to_string(),
+        seq,
+        role: role.to_string(),
+        content_json,
+        created_at: message.timestamp.to_rfc3339(),
+    };
+    let db = db.clone();
+    spawn(async move {
+        if let Err(e) = db.append_chat_message(&record).await {
+            tracing::debug!("chat: persisting message failed: {e}");
+        }
+    });
+}
+
+/// Persist all visible messages in the transcript for a session.
+pub fn persist_chat_transcript(db: &Database, session_id: &str, messages: &[ChatMessage]) {
+    let mut records = Vec::new();
+    for (i, msg) in messages.iter().enumerate() {
+        if msg.hidden {
+            continue;
+        }
+        let seq = (i + 1) as i64;
+        let role = match msg.role {
+            ChatRole::User => "user",
+            ChatRole::Assistant => "assistant",
+        };
+        let content_json = match serde_json::to_string(&msg.content) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::warn!("chat: failed to serialize message content: {e}");
+                continue;
+            }
+        };
+        records.push(rotero_db::chat_sessions::ChatMessageRecord {
+            id: format!("{session_id}:{seq}"),
+            session_id: session_id.to_string(),
+            seq,
+            role: role.to_string(),
+            content_json,
+            created_at: msg.timestamp.to_rfc3339(),
+        });
+    }
+    if records.is_empty() {
+        return;
+    }
+    let db = db.clone();
+    let session_id = session_id.to_string();
+    spawn(async move {
+        if let Err(e) = db.save_chat_messages(&session_id, &records).await {
+            tracing::debug!("chat: persisting transcript failed: {e}");
+        }
+    });
+}
+
 pub fn handle_chat_event(
     chat_state: &mut Signal<ChatState>,
     lib_state: &Signal<LibraryState>,
@@ -184,6 +256,12 @@ pub fn handle_chat_event(
                         vec![MessageContent::Text(text)],
                     ));
                 });
+                if let Some(session_id) = chat_state.read().current_session_id.clone() {
+                    let seq = chat_state.read().messages.len() as i64;
+                    if let Some(last) = chat_state.read().messages.last() {
+                        persist_chat_message(db, &session_id, seq, last);
+                    }
+                }
             }
         }
         ChatEvent::TextDelta(text) => {
@@ -286,8 +364,10 @@ pub fn handle_chat_event(
             if let Some(session_id) = chat_state.read().current_session_id.clone() {
                 let db = db.clone();
                 let now = chrono::Utc::now().to_rfc3339();
+                let messages = chat_state.read().messages.clone();
                 spawn(async move {
                     let _ = db.touch_chat_session(&session_id, &now).await;
+                    persist_chat_transcript(&db, &session_id, &messages);
                 });
             }
             chat_state.with_mut(|s| {
@@ -335,12 +415,9 @@ pub fn handle_chat_event(
             });
         }
         ChatEvent::SessionLoadFailed { session_id } => {
-            // Nothing to tell the user: they asked for this subject's
-            // conversation and they get one, it just starts empty.
+            // Retain stored messages so user can continue conversation across providers
             chat_state.with_mut(|s| {
                 s.status = AgentStatus::Idle;
-                s.messages.clear();
-                s.current_session_id = None;
             });
             let db = db.clone();
             spawn(async move {

--- a/src/ui/chat_panel/mod.rs
+++ b/src/ui/chat_panel/mod.rs
@@ -102,13 +102,16 @@ fn build_paper_context(
     lib_state: &LibraryState,
     tab_mgr: &PdfTabManager,
     subject: Option<&ChatSubject>,
+    prior_messages: &[ChatMessage],
 ) -> Option<String> {
+    let history_block = crate::agent::helpers::format_conversation_history(prior_messages);
+
     // A conversation about several papers has to name them all, or the agent
     // only ever sees whichever one happens to be open.
     if let Some(ChatSubject::Group(ids)) = subject {
         let block = group_context(lib_state, ids);
         return Some(format!(
-            "<rotero-context>\n{SEARCH_GUIDANCE}{block}\n</rotero-context>"
+            "<rotero-context>\n{SEARCH_GUIDANCE}{block}{history_block}\n</rotero-context>"
         ));
     }
 
@@ -136,7 +139,7 @@ fn build_paper_context(
         .unwrap_or_default();
 
     Some(format!(
-        "<rotero-context>\n{SEARCH_GUIDANCE}{paper_block}\n</rotero-context>"
+        "<rotero-context>\n{SEARCH_GUIDANCE}{paper_block}{history_block}\n</rotero-context>"
     ))
 }
 
@@ -183,6 +186,9 @@ fn do_send(
         return;
     }
 
+    // Extract prior messages before the new user message for context replay
+    let prior_messages: Vec<ChatMessage> = chat_state.read().messages.clone();
+
     // The subject is known now but the session id is not, so hold it until
     // `SessionCreated` arrives with something to key it to.
     let subject = current_subject(&lib_state.read(), &tab_mgr.read());
@@ -212,6 +218,16 @@ fn do_send(
     // below, which needs a row to attach to.
     crate::app::chat_handler::record_session(chat_state, db, context_subject.clone());
 
+    let session_id = chat_state.read().current_session_id.clone();
+
+    // Persist the user message to the DB
+    if let Some(session_id) = session_id.clone() {
+        let seq = chat_state.read().messages.len() as i64;
+        if let Some(last_msg) = chat_state.read().messages.last() {
+            crate::app::chat_handler::persist_chat_message(db, &session_id, seq, last_msg);
+        }
+    }
+
     // A cheap label immediately, so a conversation is never nameless: the agent
     // summary is better but costs a round trip, and may not arrive at all.
     let first_message = chat_state
@@ -221,7 +237,6 @@ fn do_send(
         .filter(|m| m.role == ChatRole::User)
         .count()
         == 1;
-    let session_id = chat_state.read().current_session_id.clone();
     if first_message && let Some(session_id) = session_id.clone() {
         let fallback: String = input.chars().take(120).collect();
         let db = db.clone();
@@ -230,8 +245,12 @@ fn do_send(
         });
     }
 
-    let paper_context =
-        build_paper_context(&lib_state.read(), &tab_mgr.read(), context_subject.as_ref());
+    let paper_context = build_paper_context(
+        &lib_state.read(),
+        &tab_mgr.read(),
+        context_subject.as_ref(),
+        &prior_messages,
+    );
 
     agent_channel.send(ChatRequest::SendMessage {
         prompt: input,
@@ -353,8 +372,31 @@ mod tests {
         tabs.open_tab(tab);
 
         let group = ChatSubject::Group(vec!["p1".into(), "p2".into()]);
-        let context = build_paper_context(&lib, &tabs, Some(&group)).unwrap();
+        let context = build_paper_context(&lib, &tabs, Some(&group), &[]).unwrap();
         assert!(context.contains("Paper ID: p2"));
         assert!(context.contains("asking about these papers together"));
+    }
+
+    /// When prior messages exist, the context block contains the formatted conversation history.
+    #[test]
+    fn context_includes_conversation_history_when_present() {
+        let lib = library();
+        let tabs = PdfTabManager::default();
+        let group = ChatSubject::Group(vec!["p1".into()]);
+        let history = vec![
+            ChatMessage::new(
+                ChatRole::User,
+                vec![MessageContent::Text(
+                    "What is the primary contribution?".into(),
+                )],
+            ),
+            ChatMessage::assistant(vec![MessageContent::Text(
+                "The paper proposes a new architecture.".into(),
+            )]),
+        ];
+        let context = build_paper_context(&lib, &tabs, Some(&group), &history).unwrap();
+        assert!(context.contains("<rotero-conversation-history>"));
+        assert!(context.contains("User: What is the primary contribution?"));
+        assert!(context.contains("Assistant: The paper proposes a new architecture."));
     }
 }

--- a/src/ui/chat_panel/resume.rs
+++ b/src/ui/chat_panel/resume.rs
@@ -107,11 +107,48 @@ pub fn switch_to(
     spawn(async move {
         match db.chat_session_for_subject(&subject).await {
             Ok(Some(existing)) => {
-                chat_state.with_mut(|s| s.status = AgentStatus::Connecting);
-                agent_channel.send(ChatRequest::LoadSession {
-                    session_id: existing.session_id,
-                    cwd: String::new(),
+                let records = db
+                    .chat_messages_for_session(&existing.session_id)
+                    .await
+                    .unwrap_or_default();
+                let stored_messages: Vec<crate::agent::types::ChatMessage> = records
+                    .into_iter()
+                    .filter_map(|r| {
+                        let role = if r.role == "user" {
+                            crate::agent::types::ChatRole::User
+                        } else {
+                            crate::agent::types::ChatRole::Assistant
+                        };
+                        let content: Vec<crate::agent::types::MessageContent> =
+                            serde_json::from_str(&r.content_json).ok()?;
+                        let timestamp = chrono::DateTime::parse_from_rfc3339(&r.created_at)
+                            .map(|t| t.with_timezone(&chrono::Utc))
+                            .unwrap_or_else(|_| chrono::Utc::now());
+                        Some(crate::agent::types::ChatMessage {
+                            role,
+                            content,
+                            timestamp,
+                            hidden: false,
+                        })
+                    })
+                    .collect();
+
+                let active_provider = chat_state.read().active_provider_id.clone();
+                let is_same_provider =
+                    !existing.provider_id.is_empty() && existing.provider_id == active_provider;
+
+                chat_state.with_mut(|s| {
+                    s.messages = stored_messages;
+                    s.current_session_id = Some(existing.session_id.clone());
                 });
+
+                if is_same_provider {
+                    chat_state.with_mut(|s| s.status = AgentStatus::Connecting);
+                    agent_channel.send(ChatRequest::LoadSession {
+                        session_id: existing.session_id,
+                        cwd: String::new(),
+                    });
+                }
             }
             // Nothing to resume: the next message starts this subject's
             // conversation, and `pending_subject` already says what it is about.


### PR DESCRIPTION
## Summary

Switching the in-app agent (or starting a new session) currently drops the transcript. This stores the conversation against the subject it is about, so it comes back on the next session — including a different provider.

- Persist chat messages per subject in a local-only table
- Restore the transcript when resuming or switching providers
- Prime the new agent with a compact conversation-history block
- Rebased onto #35; tool-call chips stay serializable so stored transcripts keep their type-aware UI

## Test plan

- [x] `just test` (427 passed) and `just lint` after rebase onto master
- [ ] Chat about a paper, switch provider, confirm the transcript is still there
- [ ] Close and reopen the paper, confirm the conversation resumes
- [ ] Tool-call chips in a restored transcript still render